### PR TITLE
perf: apply audit fixes across hot-path packages

### DIFF
--- a/packages/attrs/src/hoc/attrsHoc.tsx
+++ b/packages/attrs/src/hoc/attrsHoc.tsx
@@ -25,6 +25,10 @@ const createAttrsHOC: AttrsStyleHOC = ({ attrs, priorityAttrs }) => {
   // Pre-build the chain reducers once (not per render).
   const calculateAttrs = calculateChainOptions(attrs)
   const calculatePriorityAttrs = calculateChainOptions(priorityAttrs)
+  // Most components never call .attrs() — short-circuit the merge work below.
+  const hasAttrs = (attrs?.length ?? 0) > 0
+  const hasPriorityAttrs = (priorityAttrs?.length ?? 0) > 0
+  const hasAnyChain = hasAttrs || hasPriorityAttrs
 
   const attrsHoc = (WrappedComponent: ComponentType<any>) => {
     const HOC = (allProps: any) => {
@@ -38,15 +42,22 @@ const createAttrsHOC: AttrsStyleHOC = ({ attrs, priorityAttrs }) => {
       )
 
       const finalProps = useMemo(() => {
+        // Fast path: no attrs configured — skip the 3 spread allocations.
+        if (!hasAnyChain) {
+          return { $attrsRef: ref, ...filteredProps }
+        }
         // 1. Resolve priority attrs (lowest precedence defaults).
-        const prioritizedAttrs = calculatePriorityAttrs([filteredProps])
+        const prioritizedAttrs = hasPriorityAttrs
+          ? calculatePriorityAttrs([filteredProps])
+          : null
         // 2. Resolve normal attrs — these see priority + explicit props as input.
-        const finalAttrs = calculateAttrs([
-          {
-            ...prioritizedAttrs,
-            ...filteredProps,
-          },
-        ])
+        const finalAttrs = hasAttrs
+          ? calculateAttrs([
+              prioritizedAttrs
+                ? { ...prioritizedAttrs, ...filteredProps }
+                : filteredProps,
+            ])
+          : null
 
         // 3. Merge: priority < normal attrs < explicit props (last wins).
         return {

--- a/packages/coolgrid/src/useContext.tsx
+++ b/packages/coolgrid/src/useContext.tsx
@@ -1,6 +1,6 @@
 import { get, pick } from '@vitus-labs/core'
 import { context } from '@vitus-labs/unistyle'
-import { useContext } from 'react'
+import { useContext, useMemo } from 'react'
 import { CONTEXT_KEYS } from '~/constants'
 import type { Context, Obj, ValueType } from '~/types'
 
@@ -46,10 +46,14 @@ export const getGridContext: GetGridContext = (props = {}, theme = {}) => ({
 type UseGridContext = (props: Obj) => Context
 const useGridContext: UseGridContext = (props) => {
   const { theme } = useContext(context)
-  const ctxProps = pickThemeProps(props, CONTEXT_KEYS)
-  const gridContext = getGridContext(ctxProps, theme as Record<string, unknown>)
-
-  return { ...gridContext, ...ctxProps }
+  return useMemo(() => {
+    const ctxProps = pickThemeProps(props, CONTEXT_KEYS)
+    const gridContext = getGridContext(
+      ctxProps,
+      theme as Record<string, unknown>,
+    )
+    return { ...gridContext, ...ctxProps }
+  }, [props, theme])
 }
 
 export default useGridContext

--- a/packages/elements/src/Element/component.tsx
+++ b/packages/elements/src/Element/component.tsx
@@ -139,7 +139,17 @@ const Component: VLElement = ({
   useLayoutEffect(() => {
     if (!__WEB__) return
     if (!equalBeforeAfter || !beforeContent || !afterContent) return
-    if (equalizeRef.current) equalize(equalizeRef.current, direction)
+    const node = equalizeRef.current
+    if (!node) return
+
+    // Run once for the current props, then keep slot widths balanced when the
+    // element resizes (instead of forcing a layout flush on every re-render).
+    equalize(node, direction)
+
+    if (typeof ResizeObserver === 'undefined') return
+    const observer = new ResizeObserver(() => equalize(node, direction))
+    observer.observe(node)
+    return () => observer.disconnect()
   }, [equalBeforeAfter, beforeContent, afterContent, direction])
 
   // --------------------------------------------------------

--- a/packages/hooks/src/__tests__/useBreakpoint.test.ts
+++ b/packages/hooks/src/__tests__/useBreakpoint.test.ts
@@ -4,40 +4,43 @@ import type { ReactNode } from 'react'
 import { createElement } from 'react'
 import useBreakpoint from '../useBreakpoint'
 
-// ── matchMedia mock ──────────────────────────────────────────────────
-// Each call to window.matchMedia registers a listener set keyed by query.
-// We can later trigger change events by invoking handlers in the set.
-const listeners: Map<string, Set<() => void>> = new Map()
-const removedListeners: Map<string, Set<() => void>> = new Map()
+// ── window resize listener mock ──────────────────────────────────────
+// Each render of the hook attaches a single rAF-throttled `resize` listener
+// to `window`. We track those handlers so tests can dispatch a resize.
+const resizeHandlers: Set<EventListener> = new Set()
+const removedResizeHandlers: Set<EventListener> = new Set()
+const originalAdd = window.addEventListener.bind(window)
+const originalRemove = window.removeEventListener.bind(window)
 
 const installMatchMedia = () => {
-  Object.defineProperty(window, 'matchMedia', {
-    writable: true,
-    configurable: true,
-    value: vi.fn((query: string) => {
-      const set = new Set<() => void>()
-      listeners.set(query, set)
+  resizeHandlers.clear()
+  removedResizeHandlers.clear()
 
-      const removed = new Set<() => void>()
-      removedListeners.set(query, removed)
-
-      return {
-        matches: false,
-        media: query,
-        addEventListener: vi.fn((_event: string, handler: () => void) => {
-          set.add(handler)
-        }),
-        removeEventListener: vi.fn((_event: string, handler: () => void) => {
-          set.delete(handler)
-          removed.add(handler)
-        }),
-        onchange: null,
-        addListener: vi.fn(),
-        removeListener: vi.fn(),
-        dispatchEvent: vi.fn(),
+  window.addEventListener = vi.fn(
+    (type: string, listener: EventListenerOrEventListenerObject, opts?) => {
+      if (type === 'resize' && typeof listener === 'function') {
+        resizeHandlers.add(listener as EventListener)
       }
-    }),
-  })
+      return originalAdd(type as any, listener as any, opts as any)
+    },
+  ) as typeof window.addEventListener
+
+  window.removeEventListener = vi.fn(
+    (type: string, listener: EventListenerOrEventListenerObject, opts?) => {
+      if (type === 'resize' && typeof listener === 'function') {
+        resizeHandlers.delete(listener as EventListener)
+        removedResizeHandlers.add(listener as EventListener)
+      }
+      return originalRemove(type as any, listener as any, opts as any)
+    },
+  ) as typeof window.removeEventListener
+
+  // Make rAF synchronous in tests so resize updates flush immediately
+  ;(window as any).requestAnimationFrame = (cb: FrameRequestCallback) => {
+    cb(0)
+    return 1
+  }
+  ;(window as any).cancelAnimationFrame = () => undefined
 }
 
 // ── window.innerWidth helper ─────────────────────────────────────────
@@ -60,8 +63,6 @@ const createWrapper =
 
 // ── Test suite ───────────────────────────────────────────────────────
 beforeEach(() => {
-  listeners.clear()
-  removedListeners.clear()
   installMatchMedia()
   // Reset to a sane default width
   setWindowWidth(1024)
@@ -136,78 +137,42 @@ describe('useBreakpoint', () => {
     expect(result.current).toBe('xl')
   })
 
-  // 6. Sets up matchMedia listeners
-  it('sets up matchMedia listeners when breakpoints are provided', () => {
+  // 6. Sets up a single resize listener
+  it('sets up a single resize listener when breakpoints are provided', () => {
     setWindowWidth(800)
     const wrapper = createWrapper({ breakpoints })
     renderHook(() => useBreakpoint(), { wrapper })
 
-    // Should create one matchMedia listener per breakpoint
-    const breakpointCount = Object.keys(breakpoints).length
-    expect(listeners.size).toBe(breakpointCount)
-
-    // Each listener set should have exactly one handler
-    for (const [, set] of listeners) {
-      expect(set.size).toBe(1)
-    }
+    expect(resizeHandlers.size).toBe(1)
   })
 
-  it('creates matchMedia queries with correct min-width values', () => {
-    setWindowWidth(800)
-    const wrapper = createWrapper({ breakpoints })
-    renderHook(() => useBreakpoint(), { wrapper })
-
-    const queries = Array.from(listeners.keys())
-    for (const value of Object.values(breakpoints)) {
-      expect(queries).toContain(`(min-width: ${value}px)`)
-    }
-  })
-
-  // 7. Cleans up listeners on unmount
-  it('cleans up all matchMedia listeners on unmount', () => {
+  // 7. Cleans up resize listener on unmount
+  it('cleans up the resize listener on unmount', () => {
     setWindowWidth(800)
     const wrapper = createWrapper({ breakpoints })
     const { unmount } = renderHook(() => useBreakpoint(), { wrapper })
 
-    // Verify listeners are registered before unmount
-    for (const [, set] of listeners) {
-      expect(set.size).toBe(1)
-    }
+    expect(resizeHandlers.size).toBe(1)
 
     unmount()
 
-    // After unmount, all listener sets should be empty (handlers removed)
-    for (const [, set] of listeners) {
-      expect(set.size).toBe(0)
-    }
-
-    // All handlers should have been passed to removeEventListener
-    for (const [, removed] of removedListeners) {
-      expect(removed.size).toBe(1)
-    }
+    expect(resizeHandlers.size).toBe(0)
+    expect(removedResizeHandlers.size).toBe(1)
   })
 
-  // 8. Updates when matchMedia fires change event
-  it('updates the breakpoint when matchMedia fires a change event', () => {
+  // 8. Updates when window resizes
+  const fireResize = () => {
+    for (const handler of resizeHandlers) handler(new Event('resize'))
+  }
+
+  it('updates the breakpoint when window resizes upward', () => {
     setWindowWidth(800)
     const wrapper = createWrapper({ breakpoints })
     const { result } = renderHook(() => useBreakpoint(), { wrapper })
     expect(result.current).toBe('md')
 
-    // Simulate a viewport resize to 1300px by changing innerWidth
-    // and triggering one of the matchMedia handlers
     setWindowWidth(1300)
-    act(() => {
-      // Trigger any one handler — the update() function reads window.innerWidth
-      const firstSet = listeners.values().next().value as
-        | Set<() => void>
-        | undefined
-      if (firstSet) {
-        for (const handler of firstSet) {
-          handler()
-        }
-      }
-    })
+    act(fireResize)
 
     expect(result.current).toBe('xl')
   })
@@ -219,16 +184,7 @@ describe('useBreakpoint', () => {
     expect(result.current).toBe('xl')
 
     setWindowWidth(400)
-    act(() => {
-      const firstSet = listeners.values().next().value as
-        | Set<() => void>
-        | undefined
-      if (firstSet) {
-        for (const handler of firstSet) {
-          handler()
-        }
-      }
-    })
+    act(fireResize)
 
     expect(result.current).toBe('xs')
   })
@@ -241,10 +197,10 @@ describe('useBreakpoint', () => {
     expect(result.current).toBeUndefined()
   })
 
-  it('does not set up matchMedia listeners when breakpoints are empty', () => {
+  it('does not set up a resize listener when breakpoints are empty', () => {
     const wrapper = createWrapper({ breakpoints: {} })
     renderHook(() => useBreakpoint(), { wrapper })
-    expect(listeners.size).toBe(0)
+    expect(resizeHandlers.size).toBe(0)
   })
 
   // Edge case: single breakpoint

--- a/packages/hooks/src/useBreakpoint.ts
+++ b/packages/hooks/src/useBreakpoint.ts
@@ -39,12 +39,9 @@ const useBreakpoint: UseBreakpoint = () => {
   useEffect(() => {
     if (sorted.length === 0) return undefined
 
-    const mqls: {
-      mql: MediaQueryList
-      handler: (e: MediaQueryListEvent) => void
-    }[] = []
-
+    let raf = 0
     const update = () => {
+      raf = 0
       const width = window.innerWidth
       let match = sorted[0]?.[0]
       for (const [name, min] of sorted) {
@@ -53,17 +50,17 @@ const useBreakpoint: UseBreakpoint = () => {
       setCurrent(match)
     }
 
-    for (const [, min] of sorted) {
-      const mql = window.matchMedia(`(min-width: ${min}px)`)
-      const handler = () => update()
-      mql.addEventListener('change', handler)
-      mqls.push({ mql, handler })
+    // Single rAF-throttled resize listener instead of one matchMedia listener
+    // per breakpoint. With 5-8 breakpoints this saves 4-7 listener registrations
+    // per hook instance.
+    const onResize = () => {
+      if (raf === 0) raf = requestAnimationFrame(update)
     }
 
+    window.addEventListener('resize', onResize, { passive: true })
     return () => {
-      for (const { mql, handler } of mqls) {
-        mql.removeEventListener('change', handler)
-      }
+      if (raf !== 0) cancelAnimationFrame(raf)
+      window.removeEventListener('resize', onResize)
     }
   }, [sorted])
 

--- a/packages/hooks/src/useFocusTrap.ts
+++ b/packages/hooks/src/useFocusTrap.ts
@@ -18,16 +18,29 @@ const wrapFocus = (e: KeyboardEvent, target: HTMLElement | undefined) => {
  * Traps keyboard focus within the referenced container.
  * Tab and Shift+Tab cycle through focusable elements inside.
  * Useful for modals, dialogs, and dropdown menus.
+ *
+ * Focusable elements are cached and only re-queried when DOM mutations
+ * inside the container add/remove nodes — not on every Tab keypress.
  */
 const useFocusTrap: UseFocusTrap = (ref, enabled = true) => {
   useEffect(() => {
     if (!enabled) return undefined
+    const container = ref.current
+    if (!container) return undefined
+
+    let focusable: NodeListOf<HTMLElement> | null = null
+    const refresh = () => {
+      focusable = container.querySelectorAll<HTMLElement>(FOCUSABLE)
+    }
+    refresh()
+
+    // Re-query only when the container's DOM tree changes (rare),
+    // not on every Tab keypress.
+    const observer = new MutationObserver(refresh)
+    observer.observe(container, { childList: true, subtree: true })
 
     const handler = (e: KeyboardEvent) => {
-      if (e.key !== 'Tab' || !ref.current) return
-
-      const focusable = ref.current.querySelectorAll<HTMLElement>(FOCUSABLE)
-      if (focusable.length === 0) return
+      if (e.key !== 'Tab' || !focusable || focusable.length === 0) return
 
       const first = focusable[0]
       const last = focusable[focusable.length - 1]
@@ -41,7 +54,10 @@ const useFocusTrap: UseFocusTrap = (ref, enabled = true) => {
     }
 
     document.addEventListener('keydown', handler)
-    return () => document.removeEventListener('keydown', handler)
+    return () => {
+      observer.disconnect()
+      document.removeEventListener('keydown', handler)
+    }
   }, [ref, enabled])
 }
 

--- a/packages/kinetic/src/TransitionGroup.tsx
+++ b/packages/kinetic/src/TransitionGroup.tsx
@@ -37,6 +37,11 @@ const TransitionGroup = ({
   const prevRef = useRef<Map<string | number, ReactElement<any>>>(new Map())
   const leavingRef = useRef<Map<string | number, ReactElement<any>>>(new Map())
   const initialKeysRef = useRef<Set<string | number> | null>(null)
+  const callbackCache = useRef<Map<string | number, () => void>>(new Map())
+  // Capture latest user-provided onAfterLeave so cached per-key callbacks
+  // can call the freshest version without being recreated.
+  const onAfterLeaveRef = useRef(onAfterLeave)
+  onAfterLeaveRef.current = onAfterLeave
   const [, forceUpdate] = useState(0)
 
   // Build current keyed children map
@@ -65,10 +70,21 @@ const TransitionGroup = ({
 
   prevRef.current = currentMap
 
-  const handleAfterLeave = (key: string | number) => {
-    leavingRef.current.delete(key)
-    onAfterLeave?.()
-    forceUpdate((c) => c + 1)
+  // Cache one stable callback per key. Without this, every render produces
+  // fresh `onAfterLeave={() => handleAfterLeave(key)}` props which forces
+  // every child <Transition> to re-render when a single leaf finishes leaving.
+  const getOnAfterLeave = (key: string | number) => {
+    let cb = callbackCache.current.get(key)
+    if (!cb) {
+      cb = () => {
+        leavingRef.current.delete(key)
+        callbackCache.current.delete(key)
+        onAfterLeaveRef.current?.()
+        forceUpdate((c) => c + 1)
+      }
+      callbackCache.current.set(key, cb)
+    }
+    return cb
   }
 
   // Merge current + leaving, preserving insertion order
@@ -91,7 +107,7 @@ const TransitionGroup = ({
             appear={isInitial ? appear : true}
             timeout={timeout}
             {...transitionProps}
-            onAfterLeave={() => handleAfterLeave(key)}
+            onAfterLeave={getOnAfterLeave(key)}
           >
             {element}
           </Transition>

--- a/packages/rocketstyle/src/rocketstyle.tsx
+++ b/packages/rocketstyle/src/rocketstyle.tsx
@@ -6,7 +6,7 @@ import {
   pick,
   render,
 } from '@vitus-labs/core'
-import { useMemo } from 'react'
+import { useMemo, useRef as useReactRef } from 'react'
 import { LocalThemeManager } from '~/cache'
 import {
   CONFIG_KEYS,
@@ -58,6 +58,32 @@ import {
  * chainable static methods (`.attrs()`, `.theme()`, `.styles()`, `.config()`, etc.).
  * @module rocketstyle
  */
+
+const arraysEqual = (a: unknown[], b: unknown[]): boolean => {
+  if (a.length !== b.length) return false
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false
+  }
+  return true
+}
+
+const isShallowEqualRocketstate = (
+  a: Record<string, unknown> | null | undefined,
+  b: Record<string, unknown> | null | undefined,
+): boolean => {
+  if (a === b) return true
+  if (!a || !b) return false
+  const aKeys = Object.keys(a)
+  if (aKeys.length !== Object.keys(b).length) return false
+  for (const k of aKeys) {
+    const av = a[k]
+    const bv = b[k]
+    if (av === bv) continue
+    if (Array.isArray(av) && Array.isArray(bv) && arraysEqual(av, bv)) continue
+    return false
+  }
+  return true
+}
 
 // --------------------------------------------------------
 // cloneAndEnhance
@@ -302,26 +328,26 @@ const rocketComponent: RocketComponent = (options) => {
     // to our styled component
     // passed as $rocketstyle prop
     // --------------------------------------------------
-    // Content-based memoization: rocketstate is a fresh object each render,
-    // so serialize its values as a string key for useMemo comparison.
-    let rsKey = ''
-    for (const k in rocketstate) {
-      const v = rocketstate[k]
-      rsKey += `${k}=`
-      rsKey += `${Array.isArray(v) ? v.join(',') : v}|`
+    // Content-based memoization: rocketstate is a fresh object each render
+    // but its values are usually stable. Use a ref to keep the prior identity
+    // when the values are shallow-equal, so useMemo can skip recomputation.
+    const rocketstateRef = useReactRef(rocketstate)
+    if (!isShallowEqualRocketstate(rocketstateRef.current, rocketstate)) {
+      rocketstateRef.current = rocketstate
     }
+    const stableRocketstate = rocketstateRef.current
 
-    // biome-ignore lint/correctness/useExhaustiveDependencies: rsKey is a content-based serialization of rocketstate — replaces object reference in deps
+    // biome-ignore lint/correctness/useExhaustiveDependencies: options.transformKeys is captured from the factory closure and stable for the lifetime of the component
     const rocketstyle = useMemo(
       () =>
         getTheme({
-          rocketstate,
+          rocketstate: stableRocketstate,
           themes: currentModeThemes,
           baseTheme: currentModeBaseTheme,
           transformKeys: options.transformKeys,
           appTheme: theme,
         }),
-      [rsKey, currentModeThemes, currentModeBaseTheme, theme],
+      [stableRocketstate, currentModeThemes, currentModeBaseTheme, theme],
     )
 
     // --------------------------------------------------

--- a/packages/rocketstyle/src/utils/theme.ts
+++ b/packages/rocketstyle/src/utils/theme.ts
@@ -125,7 +125,11 @@ export const getTheme: GetTheme = ({
   transformKeys,
   appTheme,
 }) => {
-  let finalTheme = { ...baseTheme }
+  // Top-level shallow clone is safe — `merge()` does copy-on-write for nested
+  // plain objects (see core/utils.ts), so mutating `finalTheme` directly will
+  // never mutate `baseTheme`'s nested values. Avoiding `merge({}, finalTheme, val)`
+  // skips an empty-object alloc + a full deep clone of `finalTheme` per iteration.
+  const finalTheme = { ...baseTheme }
   const deferredTransforms: Array<
     (
       theme: Record<string, any>,
@@ -142,10 +146,11 @@ export const getTheme: GetTheme = ({
 
       const mergeValue = (item: string) => {
         const val = keyTheme[item]
+        if (val == null) return
         if (isTransform && typeof val === 'function') {
           deferredTransforms.push(val)
         } else {
-          finalTheme = merge({}, finalTheme, val)
+          merge(finalTheme, val)
         }
       }
 
@@ -159,8 +164,7 @@ export const getTheme: GetTheme = ({
 
   // Apply transform dimension values last with the fully accumulated theme
   for (const transform of deferredTransforms) {
-    finalTheme = merge(
-      {},
+    merge(
       finalTheme,
       transform(finalTheme, appTheme ?? {}, themeModeCallback, config.css),
     )

--- a/packages/styler/src/sheet.ts
+++ b/packages/styler/src/sheet.ts
@@ -25,6 +25,7 @@ export interface StyleSheetOptions {
 export class StyleSheet {
   private cache = new Map<string, string>()
   private insertCache = new Map<string, string>()
+  private prepareCache = new Map<string, { className: string; rules: string }>()
   private sheet: CSSStyleSheet | null = null
   private ssrBuffer: string[] = []
   private isSSR: boolean
@@ -359,12 +360,14 @@ export class StyleSheet {
     this.ssrBuffer = []
     this.cache.clear()
     this.insertCache.clear()
+    this.prepareCache.clear()
   }
 
   /** Clear the dedup cache. Useful for HMR / dev-time reloads. */
   clearCache(): void {
     this.cache.clear()
     this.insertCache.clear()
+    this.prepareCache.clear()
     clearNormCache()
   }
 
@@ -391,11 +394,17 @@ export class StyleSheet {
   /**
    * Compute className and full CSS rule text without injecting.
    * Used with React 19's `<style precedence>` for component-level injection.
+   * Result is cached so repeated calls (per render until cssText changes) skip
+   * the hash + splitAtRules + join work.
    */
   prepare(
     cssText: string,
     boost = false,
   ): { className: string; rules: string } {
+    const prepKey = boost ? `${cssText}\0` : cssText
+    const cached = this.prepareCache.get(prepKey)
+    if (cached) return cached
+
     const h = hash(cssText)
     const className = `${PREFIX}-${h}`
     const selector = boost ? `.${className}.${className}` : `.${className}`
@@ -409,7 +418,9 @@ export class StyleSheet {
       ? allRules.map((r) => `@layer ${this.layer}{${r}}`)
       : allRules
 
-    return { className, rules: finalRules.join('') }
+    const result = { className, rules: finalRules.join('') }
+    this.prepareCache.set(prepKey, result)
+    return result
   }
 
   /** Check if a className is already in the cache. O(1) Map lookup. */

--- a/packages/styler/src/styled.ts
+++ b/packages/styler/src/styled.ts
@@ -165,8 +165,15 @@ const createStyledComponent = (
   // useRef cache avoids recomputing when CSS text hasn't changed between renders.
   const DynamicStyled = ({ ref, ...rawProps }: Record<string, any>) => {
     const theme = useTheme()
-    const allProps = { ...rawProps, theme }
-    const cssText = normalizeCSS(resolve(strings, values, allProps))
+    // Mutate rawProps to inject theme for resolve(), restore afterwards.
+    // rawProps is freshly created by the destructure spread above — no caller
+    // holds its reference yet, so mutation is safe. Avoids a second n-key spread.
+    const hadTheme = 'theme' in rawProps
+    const prevTheme = rawProps.theme
+    rawProps.theme = theme
+    const cssText = normalizeCSS(resolve(strings, values, rawProps))
+    if (hadTheme) rawProps.theme = prevTheme
+    else delete rawProps.theme
 
     const cacheRef = useRef<{
       css: string

--- a/packages/unistyle/src/units/stripUnit.ts
+++ b/packages/unistyle/src/units/stripUnit.ts
@@ -6,6 +6,8 @@ export type StripUnit = <V extends string | number, UR extends boolean = false>(
   unitReturn?: UR,
 ) => UR extends true ? [Value<V>, Unit<V>] : Value<V>
 
+const CSS_UNIT_REGEX = /^([+-]?(?:\d+|\d*\.\d+))([a-z]*|%)$/
+
 /**
  * Strips the CSS unit suffix from a value.
  * With `unitReturn=true`, returns a `[number, unit]` tuple.
@@ -13,11 +15,9 @@ export type StripUnit = <V extends string | number, UR extends boolean = false>(
  * Non-string inputs are passed through unchanged.
  */
 const stripUnit: StripUnit = (value, unitReturn) => {
-  const cssRegex = /^([+-]?(?:\d+|\d*\.\d+))([a-z]*|%)$/
-
   if (typeof value !== 'string') return unitReturn ? [value, undefined] : value
 
-  const matchedValue = value.match(cssRegex)
+  const matchedValue = value.match(CSS_UNIT_REGEX)
 
   if (unitReturn) {
     if (matchedValue) return [parseFloat(value), matchedValue[2]]


### PR DESCRIPTION
Performance audit follow-ups, ordered by impact-to-effort ratio. All 2599 tests pass, 0 type errors, all 15 packages build.

## Tier 1 — hot path on every styled-component render

| # | Package | Fix |
|---|---|---|
| **1** | `unistyle` | Hoist `CSS_UNIT_REGEX` to module scope (was compiled per `stripUnit` call) |
| **2** | `rocketstyle` | Replace per-render `rsKey` string serialization with a shallow-equal ref pattern |
| **3** | `rocketstyle` | Mutate `finalTheme` directly in `getTheme()` loop — `merge()` is COW for nested plain objects, no `merge({}, finalTheme, val)` extra alloc |
| **4** | `coolgrid` | `useMemo` `useGridContext` result so Container → Row → Col chain stops cascading on every render |
| **5** | `styler` | Inject theme by mutating freshly-spread `rawProps` then restoring, instead of a second n-key spread per dynamic render |

## Tier 2 — frequent but bounded

| # | Package | Fix |
|---|---|---|
| **6** | `attrs` | Fast path in `attrsHoc` when no `.attrs()` / `.priorityAttrs()` configured — skips 3 spread allocations |
| **7** | `hooks` | `useFocusTrap` caches focusable NodeList via `MutationObserver` instead of `querySelectorAll` per Tab keypress |
| **9** | `hooks` | `useBreakpoint` uses single rAF-throttled `resize` listener instead of N `matchMedia` listeners (one per breakpoint) |
| **10** | `elements` | Element `equalize()` now observes via `ResizeObserver` instead of running layout in `useLayoutEffect` on every prop change |
| **11** | `kinetic` | `TransitionGroup` caches per-key `onAfterLeave` callbacks so one child finishing leaving doesn't churn fresh props for siblings |
| **12** | `styler` | Cache `prepare()` output by cssText so SSR/`<style precedence>` renders reuse hash + `splitAtRules` results |

## Skipped

- **#8 `useClickOutside`** — audit flagged stale handler closure, but the existing implementation already uses the `handlerRef` pattern. False positive.

## Test plan
- [x] `bun run test` — 2599 passed
- [x] `bun run typecheck` — 0 errors
- [x] `bun run lint` — 0 errors
- [x] `bun run pkgs:build` — all 15 packages built

🤖 Generated with [Claude Code](https://claude.com/claude-code)