### PR TITLE
refactor: split Overlay's useOverlay into focused modules

### DIFF
--- a/packages/elements/src/Overlay/positionMath.ts
+++ b/packages/elements/src/Overlay/positionMath.ts
@@ -1,0 +1,301 @@
+/**
+ * Pure positioning math for the Overlay component. No React, no DOM mutations.
+ * Given the current trigger and content rects (plus alignment options), computes
+ * the final viewport-relative position and the alignment that was actually used
+ * (which may differ from the requested alignment when an edge would be clipped).
+ */
+import { IS_DEVELOPMENT } from '~/utils'
+
+export type OverlayPosition = Partial<{
+  top: number | string
+  bottom: number | string
+  left: number | string
+  right: number | string
+}>
+
+export type Align = 'bottom' | 'top' | 'left' | 'right'
+export type AlignX = 'left' | 'center' | 'right'
+export type AlignY = 'bottom' | 'top' | 'center'
+
+export type OverlayType =
+  | 'dropdown'
+  | 'tooltip'
+  | 'popover'
+  | 'modal'
+  | 'custom'
+
+export type PositionResult = {
+  pos: OverlayPosition
+  resolvedAlignX: AlignX
+  resolvedAlignY: AlignY
+}
+
+export type ComputeResult = {
+  pos: OverlayPosition
+  resolvedAlignX?: AlignX
+  resolvedAlignY?: AlignY
+}
+
+const sel = <T>(cond: boolean, a: T, b: T): T => (cond ? a : b)
+
+const devWarn = (msg: string) => {
+  if (!IS_DEVELOPMENT) return
+  // biome-ignore lint/suspicious/noConsole: dev-mode warning
+  console.warn(msg)
+}
+
+const calcDropdownVertical = (
+  c: DOMRect,
+  t: DOMRect,
+  align: 'top' | 'bottom',
+  alignX: AlignX,
+  offsetX: number,
+  offsetY: number,
+): PositionResult => {
+  const pos: OverlayPosition = {}
+
+  const topPos = t.top - offsetY - c.height
+  const bottomPos = t.bottom + offsetY
+  const leftPos = t.left + offsetX
+  const rightPos = t.right - offsetX - c.width
+
+  const fitsTop = topPos >= 0
+  const fitsBottom = bottomPos + c.height <= window.innerHeight
+  const fitsLeft = leftPos + c.width <= window.innerWidth
+  const fitsRight = rightPos >= 0
+
+  const useTop = sel(align === 'top', fitsTop, !fitsBottom)
+  pos.top = sel(useTop, topPos, bottomPos)
+  const resolvedAlignY: AlignY = sel(useTop, 'top', 'bottom')
+
+  let resolvedAlignX: AlignX = alignX
+  if (alignX === 'left') {
+    pos.left = sel(fitsLeft, leftPos, rightPos)
+    resolvedAlignX = sel(fitsLeft, 'left', 'right')
+  } else if (alignX === 'right') {
+    pos.left = sel(fitsRight, rightPos, leftPos)
+    resolvedAlignX = sel(fitsRight, 'right', 'left')
+  } else {
+    const center = t.left + (t.right - t.left) / 2 - c.width / 2
+    const fitsCL = center >= 0
+    const fitsCR = center + c.width <= window.innerWidth
+
+    if (fitsCL && fitsCR) {
+      resolvedAlignX = 'center'
+      pos.left = center
+    } else if (fitsCL) {
+      resolvedAlignX = 'left'
+      pos.left = leftPos
+    } else if (fitsCR) {
+      resolvedAlignX = 'right'
+      pos.left = rightPos
+    }
+  }
+
+  return { pos, resolvedAlignX, resolvedAlignY }
+}
+
+const calcDropdownHorizontal = (
+  c: DOMRect,
+  t: DOMRect,
+  align: 'left' | 'right',
+  alignY: AlignY,
+  offsetX: number,
+  offsetY: number,
+): PositionResult => {
+  const pos: OverlayPosition = {}
+
+  const leftPos = t.left - offsetX - c.width
+  const rightPos = t.right + offsetX
+  const topPos = t.top + offsetY
+  const bottomPos = t.bottom - offsetY - c.height
+
+  const fitsLeft = leftPos >= 0
+  const fitsRight = rightPos + c.width <= window.innerWidth
+  const fitsTop = topPos + c.height <= window.innerHeight
+  const fitsBottom = bottomPos >= 0
+
+  const useLeft = sel(align === 'left', fitsLeft, !fitsRight)
+  pos.left = sel(useLeft, leftPos, rightPos)
+  const resolvedAlignX: AlignX = sel(useLeft, 'left', 'right')
+
+  let resolvedAlignY: AlignY = alignY
+  if (alignY === 'top') {
+    pos.top = sel(fitsTop, topPos, bottomPos)
+    resolvedAlignY = sel(fitsTop, 'top', 'bottom')
+  } else if (alignY === 'bottom') {
+    pos.top = sel(fitsBottom, bottomPos, topPos)
+    resolvedAlignY = sel(fitsBottom, 'bottom', 'top')
+  } else {
+    const center = t.top + (t.bottom - t.top) / 2 - c.height / 2
+    const fitsCT = center >= 0
+    const fitsCB = center + c.height <= window.innerHeight
+
+    if (fitsCT && fitsCB) {
+      resolvedAlignY = 'center'
+      pos.top = center
+    } else if (fitsCT) {
+      resolvedAlignY = 'top'
+      pos.top = topPos
+    } else if (fitsCB) {
+      resolvedAlignY = 'bottom'
+      pos.top = bottomPos
+    }
+  }
+
+  return { pos, resolvedAlignX, resolvedAlignY }
+}
+
+const calcModalPos = (
+  c: DOMRect,
+  alignX: AlignX,
+  alignY: AlignY,
+  offsetX: number,
+  offsetY: number,
+): OverlayPosition => {
+  const pos: OverlayPosition = {}
+
+  switch (alignX) {
+    case 'right':
+      pos.right = offsetX
+      break
+    case 'left':
+      pos.left = offsetX
+      break
+    case 'center':
+      pos.left = window.innerWidth / 2 - c.width / 2
+      break
+    default:
+      pos.right = offsetX
+  }
+
+  switch (alignY) {
+    case 'top':
+      pos.top = offsetY
+      break
+    case 'center':
+      pos.top = window.innerHeight / 2 - c.height / 2
+      break
+    case 'bottom':
+      pos.bottom = offsetY
+      break
+    default:
+      pos.top = offsetY
+  }
+
+  return pos
+}
+
+const adjustForAncestor = (
+  pos: OverlayPosition,
+  ancestor: { top: number; left: number },
+): OverlayPosition => {
+  if (ancestor.top === 0 && ancestor.left === 0) return pos
+
+  const result = { ...pos }
+  if (typeof result.top === 'number') result.top -= ancestor.top
+  if (typeof result.bottom === 'number') result.bottom += ancestor.top
+  if (typeof result.left === 'number') result.left -= ancestor.left
+  if (typeof result.right === 'number') result.right += ancestor.left
+
+  return result
+}
+
+export const computePosition = (
+  type: OverlayType,
+  align: Align,
+  alignX: AlignX,
+  alignY: AlignY,
+  offsetX: number,
+  offsetY: number,
+  triggerEl: HTMLElement | null,
+  contentEl: HTMLElement | null,
+  ancestorOffset: { top: number; left: number },
+): ComputeResult => {
+  const isDropdown = ['dropdown', 'tooltip', 'popover'].includes(type)
+
+  if (isDropdown && (!triggerEl || !contentEl)) {
+    devWarn(
+      `[@vitus-labs/elements] Overlay (${type}): ` +
+        `${triggerEl ? 'contentRef' : 'triggerRef'} is not attached. ` +
+        'Position cannot be calculated without both refs.',
+    )
+    return { pos: {} }
+  }
+
+  if (isDropdown && triggerEl && contentEl) {
+    const c = contentEl.getBoundingClientRect()
+    const t = triggerEl.getBoundingClientRect()
+    const result =
+      align === 'top' || align === 'bottom'
+        ? calcDropdownVertical(c, t, align, alignX, offsetX, offsetY)
+        : calcDropdownHorizontal(
+            c,
+            t,
+            align as 'left' | 'right',
+            alignY,
+            offsetX,
+            offsetY,
+          )
+
+    return {
+      pos: adjustForAncestor(result.pos, ancestorOffset),
+      resolvedAlignX: result.resolvedAlignX,
+      resolvedAlignY: result.resolvedAlignY,
+    }
+  }
+
+  if (type === 'modal') {
+    if (!contentEl) {
+      devWarn(
+        '[@vitus-labs/elements] Overlay (modal): contentRef is not attached. ' +
+          'Modal position cannot be calculated without a content element.',
+      )
+      return { pos: {} }
+    }
+    const c = contentEl.getBoundingClientRect()
+    return {
+      pos: adjustForAncestor(
+        calcModalPos(c, alignX, alignY, offsetX, offsetY),
+        ancestorOffset,
+      ),
+    }
+  }
+
+  return { pos: {} }
+}
+
+export const processVisibilityEvent = (
+  e: Event,
+  active: boolean,
+  openOn: string,
+  closeOn: string,
+  isTrigger: (e: Event) => boolean,
+  isContent: (e: Event) => boolean,
+  showContent: () => void,
+  hideContent: () => void,
+) => {
+  // Open on click (hover is handled by dedicated mouseenter/mouseleave)
+  if (!active && openOn === 'click' && e.type === 'click' && isTrigger(e)) {
+    showContent()
+    return
+  }
+
+  if (!active) return
+
+  // Close handlers
+  if (closeOn === 'hover' && e.type === 'scroll') {
+    hideContent()
+    return
+  }
+
+  if (e.type !== 'click') return
+
+  if (closeOn === 'click') {
+    hideContent()
+  } else if (closeOn === 'clickOnTrigger' && isTrigger(e)) {
+    hideContent()
+  } else if (closeOn === 'clickOutsideContent' && !isContent(e)) {
+    hideContent()
+  }
+}

--- a/packages/elements/src/Overlay/useEscapeKey.ts
+++ b/packages/elements/src/Overlay/useEscapeKey.ts
@@ -1,0 +1,22 @@
+import { useEffect } from 'react'
+
+/** Closes the overlay on Escape keypress when `enabled` and `active`. */
+const useEscapeKey = (
+  enabled: boolean,
+  active: boolean,
+  blocked: boolean,
+  hide: () => void,
+) => {
+  useEffect(() => {
+    if (!enabled || !active || blocked) return undefined
+
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') hide()
+    }
+
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [enabled, active, blocked, hide])
+}
+
+export default useEscapeKey

--- a/packages/elements/src/Overlay/useHoverListeners.ts
+++ b/packages/elements/src/Overlay/useHoverListeners.ts
@@ -1,0 +1,109 @@
+import { useEffect, useRef } from 'react'
+
+type HoverConfig = {
+  triggerRef: { current: HTMLElement | null }
+  contentRef: { current: HTMLElement | null }
+  /** Re-runs the effect when content mounts/unmounts so listeners attach to the live element. */
+  isContentLoaded: boolean
+  active: boolean
+  blocked: boolean
+  disabled: boolean | undefined
+  openOn: string
+  closeOn: string
+  hoverDelay: number
+  showContent: () => void
+  hideContent: () => void
+}
+
+/**
+ * Hover-based open/close. Uses mouseenter/mouseleave on trigger + content
+ * (instead of window-level mousemove) and a configurable delay to bridge
+ * the gap between trigger and content elements without flicker.
+ */
+const useHoverListeners = ({
+  triggerRef,
+  contentRef,
+  isContentLoaded,
+  active,
+  blocked,
+  disabled,
+  openOn,
+  closeOn,
+  hoverDelay,
+  showContent,
+  hideContent,
+}: HoverConfig) => {
+  const hoverTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: isContentLoaded signals contentRef.current is available so the effect re-runs to attach listeners
+  useEffect(() => {
+    const enabledHover = openOn === 'hover' || closeOn === 'hover'
+    if (blocked || disabled || !enabledHover) return undefined
+
+    const trigger = triggerRef.current
+    const content = contentRef.current
+
+    const clearHoverTimeout = () => {
+      if (hoverTimeoutRef.current != null) {
+        clearTimeout(hoverTimeoutRef.current)
+        hoverTimeoutRef.current = null
+      }
+    }
+
+    const scheduleHide = () => {
+      clearHoverTimeout()
+      hoverTimeoutRef.current = setTimeout(hideContent, hoverDelay)
+    }
+
+    const onTriggerEnter = () => {
+      clearHoverTimeout()
+      if (openOn === 'hover' && !active) showContent()
+    }
+
+    const onTriggerLeave = () => {
+      if (closeOn === 'hover' && active) scheduleHide()
+    }
+
+    const onContentEnter = () => {
+      clearHoverTimeout()
+    }
+
+    const onContentLeave = () => {
+      if (closeOn === 'hover' && active) scheduleHide()
+    }
+
+    if (trigger) {
+      trigger.addEventListener('mouseenter', onTriggerEnter)
+      trigger.addEventListener('mouseleave', onTriggerLeave)
+    }
+
+    if (content) {
+      content.addEventListener('mouseenter', onContentEnter)
+      content.addEventListener('mouseleave', onContentLeave)
+    }
+
+    return () => {
+      clearHoverTimeout()
+      if (trigger) {
+        trigger.removeEventListener('mouseenter', onTriggerEnter)
+        trigger.removeEventListener('mouseleave', onTriggerLeave)
+      }
+      if (content) {
+        content.removeEventListener('mouseenter', onContentEnter)
+        content.removeEventListener('mouseleave', onContentLeave)
+      }
+    }
+  }, [
+    active,
+    isContentLoaded,
+    blocked,
+    disabled,
+    openOn,
+    closeOn,
+    hoverDelay,
+    showContent,
+    hideContent,
+  ])
+}
+
+export default useHoverListeners

--- a/packages/elements/src/Overlay/useOverlay.tsx
+++ b/packages/elements/src/Overlay/useOverlay.tsx
@@ -3,8 +3,10 @@
  * event listeners (click, hover, scroll, resize, ESC key), and dynamic
  * positioning of overlay content relative to its trigger. Supports dropdown,
  * tooltip, popover, and modal types with automatic edge-of-viewport flipping.
- * Event handlers are throttled for performance, and nested overlay blocking
- * is coordinated through the overlay context.
+ *
+ * Pure positioning math lives in `./positionMath`. Event-listener concerns
+ * live in dedicated hooks: `./useEscapeKey`, `./useHoverListeners`,
+ * `./useScrollReposition`.
  */
 import { context, throttle } from '@vitus-labs/core'
 import { value } from '@vitus-labs/unistyle'
@@ -16,19 +18,19 @@ import {
   useRef,
   useState,
 } from 'react'
-import { IS_DEVELOPMENT } from '~/utils'
 import Provider, { useOverlayContext } from './context'
-
-type OverlayPosition = Partial<{
-  top: number | string
-  bottom: number | string
-  left: number | string
-  right: number | string
-}>
-
-type Align = 'bottom' | 'top' | 'left' | 'right'
-type AlignX = 'left' | 'center' | 'right'
-type AlignY = 'bottom' | 'top' | 'center'
+import {
+  type Align,
+  type AlignX,
+  type AlignY,
+  computePosition,
+  type OverlayPosition,
+  type OverlayType,
+  processVisibilityEvent,
+} from './positionMath'
+import useEscapeKey from './useEscapeKey'
+import useHoverListeners from './useHoverListeners'
+import useScrollReposition from './useScrollReposition'
 
 export type UseOverlayProps = Partial<{
   /**
@@ -59,7 +61,7 @@ export type UseOverlayProps = Partial<{
    * has different positioning calculations than others.
    * @defaultValue `dropdown`
    */
-  type: 'dropdown' | 'tooltip' | 'popover' | 'modal' | 'custom'
+  type: OverlayType
   /**
    * Defines how `content` is treated regarding CSS positioning.
    * @defaultValue `fixed`
@@ -131,295 +133,15 @@ export type UseOverlayProps = Partial<{
   onClose: () => void
 }>
 
-type PositionResult = {
-  pos: OverlayPosition
-  resolvedAlignX: AlignX
-  resolvedAlignY: AlignY
-}
-
-// Reference counter for nested modals sharing document.body overflow lock.
-// Only the first modal sets overflow:hidden; only the last restores it.
-let modalOverflowCount = 0
-
-const sel = <T,>(cond: boolean, a: T, b: T): T => (cond ? a : b)
-
-const devWarn = (msg: string) => {
-  if (!IS_DEVELOPMENT) return
-  // biome-ignore lint/suspicious/noConsole: dev-mode warning
-  console.warn(msg)
-}
-
-const calcDropdownVertical = (
-  c: DOMRect,
-  t: DOMRect,
-  align: 'top' | 'bottom',
-  alignX: AlignX,
-  offsetX: number,
-  offsetY: number,
-): PositionResult => {
-  const pos: OverlayPosition = {}
-
-  const topPos = t.top - offsetY - c.height
-  const bottomPos = t.bottom + offsetY
-  const leftPos = t.left + offsetX
-  const rightPos = t.right - offsetX - c.width
-
-  const fitsTop = topPos >= 0
-  const fitsBottom = bottomPos + c.height <= window.innerHeight
-  const fitsLeft = leftPos + c.width <= window.innerWidth
-  const fitsRight = rightPos >= 0
-
-  const useTop = sel(align === 'top', fitsTop, !fitsBottom)
-  pos.top = sel(useTop, topPos, bottomPos)
-  const resolvedAlignY: AlignY = sel(useTop, 'top', 'bottom')
-
-  let resolvedAlignX: AlignX = alignX
-  if (alignX === 'left') {
-    pos.left = sel(fitsLeft, leftPos, rightPos)
-    resolvedAlignX = sel(fitsLeft, 'left', 'right')
-  } else if (alignX === 'right') {
-    pos.left = sel(fitsRight, rightPos, leftPos)
-    resolvedAlignX = sel(fitsRight, 'right', 'left')
-  } else {
-    const center = t.left + (t.right - t.left) / 2 - c.width / 2
-    const fitsCL = center >= 0
-    const fitsCR = center + c.width <= window.innerWidth
-
-    if (fitsCL && fitsCR) {
-      resolvedAlignX = 'center'
-      pos.left = center
-    } else if (fitsCL) {
-      resolvedAlignX = 'left'
-      pos.left = leftPos
-    } else if (fitsCR) {
-      resolvedAlignX = 'right'
-      pos.left = rightPos
-    }
-  }
-
-  return { pos, resolvedAlignX, resolvedAlignY }
-}
-
-const calcDropdownHorizontal = (
-  c: DOMRect,
-  t: DOMRect,
-  align: 'left' | 'right',
-  alignY: AlignY,
-  offsetX: number,
-  offsetY: number,
-): PositionResult => {
-  const pos: OverlayPosition = {}
-
-  const leftPos = t.left - offsetX - c.width
-  const rightPos = t.right + offsetX
-  const topPos = t.top + offsetY
-  const bottomPos = t.bottom - offsetY - c.height
-
-  const fitsLeft = leftPos >= 0
-  const fitsRight = rightPos + c.width <= window.innerWidth
-  const fitsTop = topPos + c.height <= window.innerHeight
-  const fitsBottom = bottomPos >= 0
-
-  const useLeft = sel(align === 'left', fitsLeft, !fitsRight)
-  pos.left = sel(useLeft, leftPos, rightPos)
-  const resolvedAlignX: AlignX = sel(useLeft, 'left', 'right')
-
-  let resolvedAlignY: AlignY = alignY
-  if (alignY === 'top') {
-    pos.top = sel(fitsTop, topPos, bottomPos)
-    resolvedAlignY = sel(fitsTop, 'top', 'bottom')
-  } else if (alignY === 'bottom') {
-    pos.top = sel(fitsBottom, bottomPos, topPos)
-    resolvedAlignY = sel(fitsBottom, 'bottom', 'top')
-  } else {
-    const center = t.top + (t.bottom - t.top) / 2 - c.height / 2
-    const fitsCT = center >= 0
-    const fitsCB = center + c.height <= window.innerHeight
-
-    if (fitsCT && fitsCB) {
-      resolvedAlignY = 'center'
-      pos.top = center
-    } else if (fitsCT) {
-      resolvedAlignY = 'top'
-      pos.top = topPos
-    } else if (fitsCB) {
-      resolvedAlignY = 'bottom'
-      pos.top = bottomPos
-    }
-  }
-
-  return { pos, resolvedAlignX, resolvedAlignY }
-}
-
-const calcModalPos = (
-  c: DOMRect,
-  alignX: AlignX,
-  alignY: AlignY,
-  offsetX: number,
-  offsetY: number,
-): OverlayPosition => {
-  const pos: OverlayPosition = {}
-
-  switch (alignX) {
-    case 'right':
-      pos.right = offsetX
-      break
-    case 'left':
-      pos.left = offsetX
-      break
-    case 'center':
-      pos.left = window.innerWidth / 2 - c.width / 2
-      break
-    default:
-      pos.right = offsetX
-  }
-
-  switch (alignY) {
-    case 'top':
-      pos.top = offsetY
-      break
-    case 'center':
-      pos.top = window.innerHeight / 2 - c.height / 2
-      break
-    case 'bottom':
-      pos.bottom = offsetY
-      break
-    default:
-      pos.top = offsetY
-  }
-
-  return pos
-}
-
-const adjustForAncestor = (
-  pos: OverlayPosition,
-  ancestor: { top: number; left: number },
-): OverlayPosition => {
-  if (ancestor.top === 0 && ancestor.left === 0) return pos
-
-  const result = { ...pos }
-  if (typeof result.top === 'number') result.top -= ancestor.top
-  if (typeof result.bottom === 'number') result.bottom += ancestor.top
-  if (typeof result.left === 'number') result.left -= ancestor.left
-  if (typeof result.right === 'number') result.right += ancestor.left
-
-  return result
-}
-
-type ComputeResult = {
-  pos: OverlayPosition
-  resolvedAlignX?: AlignX
-  resolvedAlignY?: AlignY
-}
-
-const computePosition = (
-  type: string,
-  align: Align,
-  alignX: AlignX,
-  alignY: AlignY,
-  offsetX: number,
-  offsetY: number,
-  triggerEl: HTMLElement | null,
-  contentEl: HTMLElement | null,
-  ancestorOffset: { top: number; left: number },
-): ComputeResult => {
-  const isDropdown = ['dropdown', 'tooltip', 'popover'].includes(type)
-
-  if (isDropdown && (!triggerEl || !contentEl)) {
-    devWarn(
-      `[@vitus-labs/elements] Overlay (${type}): ` +
-        `${triggerEl ? 'contentRef' : 'triggerRef'} is not attached. ` +
-        'Position cannot be calculated without both refs.',
-    )
-    return { pos: {} }
-  }
-
-  if (isDropdown && triggerEl && contentEl) {
-    const c = contentEl.getBoundingClientRect()
-    const t = triggerEl.getBoundingClientRect()
-    const result =
-      align === 'top' || align === 'bottom'
-        ? calcDropdownVertical(c, t, align, alignX, offsetX, offsetY)
-        : calcDropdownHorizontal(
-            c,
-            t,
-            align as 'left' | 'right',
-            alignY,
-            offsetX,
-            offsetY,
-          )
-
-    return {
-      pos: adjustForAncestor(result.pos, ancestorOffset),
-      resolvedAlignX: result.resolvedAlignX,
-      resolvedAlignY: result.resolvedAlignY,
-    }
-  }
-
-  if (type === 'modal') {
-    if (!contentEl) {
-      devWarn(
-        '[@vitus-labs/elements] Overlay (modal): contentRef is not attached. ' +
-          'Modal position cannot be calculated without a content element.',
-      )
-      return { pos: {} }
-    }
-    const c = contentEl.getBoundingClientRect()
-    return {
-      pos: adjustForAncestor(
-        calcModalPos(c, alignX, alignY, offsetX, offsetY),
-        ancestorOffset,
-      ),
-    }
-  }
-
-  return { pos: {} }
-}
-
-const processVisibilityEvent = (
-  e: Event,
-  active: boolean,
-  openOn: string,
-  closeOn: string,
-  isTrigger: (e: Event) => boolean,
-  isContent: (e: Event) => boolean,
-  showContent: () => void,
-  hideContent: () => void,
-) => {
-  // Open on click (hover is handled by dedicated mouseenter/mouseleave)
-  if (!active && openOn === 'click' && e.type === 'click' && isTrigger(e)) {
-    showContent()
-    return
-  }
-
-  if (!active) return
-
-  // Close handlers
-  if (closeOn === 'hover' && e.type === 'scroll') {
-    hideContent()
-    return
-  }
-
-  if (e.type !== 'click') return
-
-  if (closeOn === 'click') {
-    hideContent()
-  } else if (closeOn === 'clickOnTrigger' && isTrigger(e)) {
-    hideContent()
-  } else if (closeOn === 'clickOutsideContent' && !isContent(e)) {
-    hideContent()
-  }
-}
-
 const useOverlay = ({
   isOpen = false,
-  openOn = 'click', // click | hover
-  closeOn = 'click', // click | 'clickOnTrigger' | 'clickOutsideContent' | hover | manual
-  type = 'dropdown', // dropdown | tooltip | popover | modal
-  position = 'fixed', // absolute | fixed | relative | static
-  align = 'bottom', // main align prop top | left | bottom | right
-  alignX = 'left', // left | center | right
-  alignY = 'bottom', // top | center | bottom
+  openOn = 'click',
+  closeOn = 'click',
+  type = 'dropdown',
+  position = 'fixed',
+  align = 'bottom',
+  alignX = 'left',
+  alignY = 'bottom',
   offsetX = 0,
   offsetY = 0,
   throttleDelay = 200,
@@ -439,7 +161,7 @@ const useOverlay = ({
 
   const [blockedCount, setBlockedCount] = useState(0)
   const blocked = blockedCount > 0
-  const [active, handleActive] = useState(isOpen)
+  const [active, setActive] = useState(isOpen)
 
   const triggerRef = useRef<HTMLElement>(null)
   const contentRef = useRef<HTMLElement>(null)
@@ -451,13 +173,8 @@ const useOverlay = ({
     [],
   )
 
-  const showContent = useCallback(() => {
-    handleActive(true)
-  }, [])
-
-  const hideContent = useCallback(() => {
-    handleActive(false)
-  }, [])
+  const showContent = useCallback(() => setActive(true), [])
+  const hideContent = useCallback(() => setActive(false), [])
 
   // For position: absolute, getBoundingClientRect() returns viewport-relative
   // values but the element is positioned relative to its offsetParent.
@@ -529,8 +246,7 @@ const useOverlay = ({
   )
 
   const setContentPosition = useCallback(() => {
-    const currentPosition = calculateContentPosition()
-    assignContentPosition(currentPosition)
+    assignContentPosition(calculateContentPosition())
   }, [assignContentPosition, calculateContentPosition])
 
   const isNodeOrChild = useCallback(
@@ -540,7 +256,6 @@ const useOverlay = ({
           ref.current.contains(e.target as Element) || e.target === ref.current
         )
       }
-
       return false
     },
     [],
@@ -549,7 +264,6 @@ const useOverlay = ({
   const handleVisibilityByEventType = useCallback(
     (e: Event) => {
       if (blocked || disabled) return
-
       processVisibilityEvent(
         e,
         active,
@@ -599,16 +313,14 @@ const useOverlay = ({
     [throttleDelay],
   )
 
-  // --------------------------------------------------------------------------
-  // useEffects
-  // --------------------------------------------------------------------------
+  // ----------------------------------------------------------------------
+  // Effects: prop sync, initial positioning, lifecycle, focus management
+  // ----------------------------------------------------------------------
+
   useEffect(() => {
     setInnerAlignX(alignX)
     setInnerAlignY(alignY)
-
-    if (disabled) {
-      hideContent()
-    }
+    if (disabled) hideContent()
   }, [disabled, alignX, alignY, hideContent])
 
   useEffect(() => {
@@ -619,7 +331,6 @@ const useOverlay = ({
     // caused by the initial positioning (e.g. content becoming visible).
     setContentPosition()
     const rafId = requestAnimationFrame(() => setContentPosition())
-
     return () => cancelAnimationFrame(rafId)
   }, [active, isContentLoaded, setContentPosition])
 
@@ -669,77 +380,20 @@ const useOverlay = ({
     }
   }, [active, isContentLoaded, type])
 
-  // handle closing only when content is active
-  useEffect(() => {
-    if (!closeOnEsc || !active || blocked) return undefined
+  // ----------------------------------------------------------------------
+  // Composed listener hooks
+  // ----------------------------------------------------------------------
 
-    const handleEscKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        hideContent()
-      }
-    }
+  useEscapeKey(closeOnEsc, active, blocked, hideContent)
 
-    window.addEventListener('keydown', handleEscKey)
-
-    return () => {
-      window.removeEventListener('keydown', handleEscKey)
-    }
-  }, [active, blocked, closeOnEsc, hideContent])
-
-  // handles repositioning of content on document events
-  useEffect(() => {
-    if (!active) return undefined
-
-    const shouldSetOverflow = type === 'modal'
-
-    const onScroll = (e: Event) => {
-      handleContentPosition()
-      handleVisibility(e)
-    }
-
-    if (shouldSetOverflow) {
-      modalOverflowCount++
-      if (modalOverflowCount === 1) document.body.style.overflow = 'hidden'
-    }
-    window.addEventListener('resize', handleContentPosition)
-    window.addEventListener('scroll', onScroll, { passive: true })
-
-    return () => {
-      handleContentPosition.cancel()
-      handleVisibility.cancel()
-      if (shouldSetOverflow) {
-        modalOverflowCount--
-        if (modalOverflowCount === 0) document.body.style.overflow = ''
-      }
-      window.removeEventListener('resize', handleContentPosition)
-      window.removeEventListener('scroll', onScroll)
-    }
-  }, [active, type, handleVisibility, handleContentPosition])
-
-  // handles repositioning of content on a custom element if defined
-  useEffect(() => {
-    if (!active || !parentContainer) return undefined
-
-    if (closeOn !== 'hover') parentContainer.style.overflow = 'hidden'
-
-    const onScroll = (e: Event) => {
-      handleContentPosition()
-      handleVisibility(e)
-    }
-
-    parentContainer.addEventListener('scroll', onScroll, { passive: true })
-
-    return () => {
-      parentContainer.style.overflow = ''
-      parentContainer.removeEventListener('scroll', onScroll)
-    }
-  }, [
+  useScrollReposition({
     active,
+    type,
     parentContainer,
     closeOn,
     handleContentPosition,
     handleVisibility,
-  ])
+  })
 
   // Click-based open/close: attach to window
   useEffect(() => {
@@ -749,88 +403,24 @@ const useOverlay = ({
       openOn === 'click' ||
       ['click', 'clickOnTrigger', 'clickOutsideContent'].includes(closeOn)
 
-    if (enabledClick) {
-      window.addEventListener('click', handleClick)
-    }
+    if (enabledClick) window.addEventListener('click', handleClick)
 
-    return () => {
-      window.removeEventListener('click', handleClick)
-    }
+    return () => window.removeEventListener('click', handleClick)
   }, [openOn, closeOn, blocked, disabled, handleClick])
 
-  // Hover-based open/close: mouseenter/mouseleave on trigger + content
-  // instead of window-level mousemove (which fires on every pixel of movement).
-  // A short timeout bridges the gap between trigger and content elements.
-  const hoverTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-
-  // biome-ignore lint/correctness/useExhaustiveDependencies: isContentLoaded signals contentRef.current is available so the effect re-runs to attach listeners
-  useEffect(() => {
-    const enabledHover = openOn === 'hover' || closeOn === 'hover'
-    if (blocked || disabled || !enabledHover) return undefined
-
-    const trigger = triggerRef.current
-    const content = contentRef.current
-
-    const clearHoverTimeout = () => {
-      if (hoverTimeoutRef.current != null) {
-        clearTimeout(hoverTimeoutRef.current)
-        hoverTimeoutRef.current = null
-      }
-    }
-
-    const scheduleHide = () => {
-      clearHoverTimeout()
-      hoverTimeoutRef.current = setTimeout(hideContent, hoverDelay)
-    }
-
-    const onTriggerEnter = () => {
-      clearHoverTimeout()
-      if (openOn === 'hover' && !active) showContent()
-    }
-
-    const onTriggerLeave = () => {
-      if (closeOn === 'hover' && active) scheduleHide()
-    }
-
-    const onContentEnter = () => {
-      clearHoverTimeout()
-    }
-
-    const onContentLeave = () => {
-      if (closeOn === 'hover' && active) scheduleHide()
-    }
-
-    if (trigger) {
-      trigger.addEventListener('mouseenter', onTriggerEnter)
-      trigger.addEventListener('mouseleave', onTriggerLeave)
-    }
-
-    if (content) {
-      content.addEventListener('mouseenter', onContentEnter)
-      content.addEventListener('mouseleave', onContentLeave)
-    }
-
-    return () => {
-      clearHoverTimeout()
-      if (trigger) {
-        trigger.removeEventListener('mouseenter', onTriggerEnter)
-        trigger.removeEventListener('mouseleave', onTriggerLeave)
-      }
-      if (content) {
-        content.removeEventListener('mouseenter', onContentEnter)
-        content.removeEventListener('mouseleave', onContentLeave)
-      }
-    }
-  }, [
-    active,
+  useHoverListeners({
+    triggerRef,
+    contentRef,
     isContentLoaded,
+    active,
     blocked,
     disabled,
     openOn,
     closeOn,
+    hoverDelay,
     showContent,
     hideContent,
-  ])
+  })
 
   // hack-ish way to load content correctly on the first load
   // as `contentRef` is loaded dynamically

--- a/packages/elements/src/Overlay/useScrollReposition.ts
+++ b/packages/elements/src/Overlay/useScrollReposition.ts
@@ -1,0 +1,118 @@
+import { useEffect } from 'react'
+
+type Cancellable<T extends (...args: any[]) => any> = T & { cancel: () => void }
+type ThrottledNoArg = Cancellable<() => void>
+type ThrottledEvt = Cancellable<(e: Event) => void>
+
+type Config = {
+  active: boolean
+  type: string
+  parentContainer: HTMLElement | null | undefined
+  closeOn: string
+  /** Reposition is called on every scroll/resize tick. */
+  handleContentPosition: ThrottledNoArg
+  /** Visibility is also re-evaluated on scroll. */
+  handleVisibility: ThrottledEvt
+}
+
+// Reference counter for nested modals sharing document.body overflow lock.
+// Only the first modal sets overflow:hidden; only the last restores it.
+let modalOverflowCount = 0
+
+/**
+ * Window-level scroll/resize listeners that reposition active overlays and
+ * re-evaluate close-on-scroll behavior. Also manages the body overflow lock
+ * for modal overlays (refcounted across nested modals).
+ */
+const useWindowReposition = (
+  active: boolean,
+  type: string,
+  handleContentPosition: ThrottledNoArg,
+  handleVisibility: ThrottledEvt,
+) => {
+  useEffect(() => {
+    if (!active) return undefined
+
+    const shouldSetOverflow = type === 'modal'
+
+    const onScroll = (e: Event) => {
+      handleContentPosition()
+      handleVisibility(e)
+    }
+
+    if (shouldSetOverflow) {
+      modalOverflowCount++
+      if (modalOverflowCount === 1) document.body.style.overflow = 'hidden'
+    }
+    window.addEventListener('resize', handleContentPosition)
+    window.addEventListener('scroll', onScroll, { passive: true })
+
+    return () => {
+      handleContentPosition.cancel()
+      handleVisibility.cancel()
+      if (shouldSetOverflow) {
+        modalOverflowCount--
+        if (modalOverflowCount === 0) document.body.style.overflow = ''
+      }
+      window.removeEventListener('resize', handleContentPosition)
+      window.removeEventListener('scroll', onScroll)
+    }
+  }, [active, type, handleContentPosition, handleVisibility])
+}
+
+/**
+ * Same as `useWindowReposition` but for a custom scrollable ancestor.
+ * Locks the parent's overflow while the overlay is active (unless hover-driven,
+ * which expects the parent to keep scrolling).
+ */
+const useParentContainerReposition = (
+  active: boolean,
+  parentContainer: HTMLElement | null | undefined,
+  closeOn: string,
+  handleContentPosition: ThrottledNoArg,
+  handleVisibility: ThrottledEvt,
+) => {
+  useEffect(() => {
+    if (!active || !parentContainer) return undefined
+
+    if (closeOn !== 'hover') parentContainer.style.overflow = 'hidden'
+
+    const onScroll = (e: Event) => {
+      handleContentPosition()
+      handleVisibility(e)
+    }
+
+    parentContainer.addEventListener('scroll', onScroll, { passive: true })
+
+    return () => {
+      parentContainer.style.overflow = ''
+      parentContainer.removeEventListener('scroll', onScroll)
+    }
+  }, [
+    active,
+    parentContainer,
+    closeOn,
+    handleContentPosition,
+    handleVisibility,
+  ])
+}
+
+const useScrollReposition = ({
+  active,
+  type,
+  parentContainer,
+  closeOn,
+  handleContentPosition,
+  handleVisibility,
+}: Config) => {
+  useWindowReposition(active, type, handleContentPosition, handleVisibility)
+  useParentContainerReposition(
+    active,
+    parentContainer,
+    closeOn,
+    handleContentPosition,
+    handleVisibility,
+  )
+}
+
+export default useScrollReposition


### PR DESCRIPTION
## Summary
`useOverlay.tsx` had grown to 858 lines mixing pure positioning math with React state, focus management, and 5+ event-listener effects. Split into focused modules so each concern is independently readable and testable.

| Module | LOC | Concern |
|---|---|---|
| `positionMath.ts` | 301 | Pure math — `calcDropdown{Vertical,Horizontal}`, `calcModalPos`, `adjustForAncestor`, `computePosition`, `processVisibilityEvent`. No React, no DOM. |
| `useEscapeKey.ts` | 22 | ESC key handler |
| `useHoverListeners.ts` | 109 | Trigger/content `mouseenter`/`mouseleave` with `hoverDelay` flicker bridge |
| `useScrollReposition.ts` | 118 | Window + parent-container scroll/resize listeners + refcounted modal body-overflow lock |
| `useOverlay.tsx` | **448 (was 858)** | State, positioning callbacks, focus management, lifecycle — then composes the extracted hooks |

Public API unchanged — `useOverlay({...})` returns the same shape, `Overlay` component unchanged.

## Test plan
- [x] 74 Overlay tests pass
- [x] 268 elements tests pass
- [x] 2599 total tests pass
- [x] 0 type errors
- [x] 0 lint errors
- [x] All 15 packages build

🤖 Generated with [Claude Code](https://claude.com/claude-code)