### PR TITLE
chore: audit follow-ups — CLAUDE.md, shared utils, test fixtures, size budgets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,9 @@ jobs:
       - name: Type Check
         run: bun run typecheck
 
+      - name: Bundle size budget
+        run: bun run size
+
       - name: Test with coverage
         run: bun run test -- --coverage
 

--- a/.size-limit.json
+++ b/.size-limit.json
@@ -1,0 +1,92 @@
+[
+  {
+    "name": "@vitus-labs/attrs",
+    "path": "packages/attrs/lib/index.js",
+    "limit": "3 KB",
+    "gzip": true
+  },
+  {
+    "name": "@vitus-labs/connector-emotion",
+    "path": "packages/connector-emotion/lib/index.js",
+    "limit": "1.4 KB",
+    "gzip": true
+  },
+  {
+    "name": "@vitus-labs/connector-native",
+    "path": "packages/connector-native/lib/index.js",
+    "limit": "3.5 KB",
+    "gzip": true
+  },
+  {
+    "name": "@vitus-labs/connector-styled-components",
+    "path": "packages/connector-styled-components/lib/index.js",
+    "limit": "300 B",
+    "gzip": true
+  },
+  {
+    "name": "@vitus-labs/connector-styler",
+    "path": "packages/connector-styler/lib/index.js",
+    "limit": "300 B",
+    "gzip": true
+  },
+  {
+    "name": "@vitus-labs/coolgrid",
+    "path": "packages/coolgrid/lib/index.js",
+    "limit": "4.5 KB",
+    "gzip": true
+  },
+  {
+    "name": "@vitus-labs/core",
+    "path": "packages/core/lib/index.js",
+    "limit": "6 KB",
+    "gzip": true
+  },
+  {
+    "name": "@vitus-labs/elements",
+    "path": "packages/elements/lib/index.js",
+    "limit": "15 KB",
+    "gzip": true
+  },
+  {
+    "name": "@vitus-labs/hooks",
+    "path": "packages/hooks/lib/index.js",
+    "limit": "6.5 KB",
+    "gzip": true
+  },
+  {
+    "name": "@vitus-labs/kinetic",
+    "path": "packages/kinetic/lib/index.js",
+    "limit": "6.5 KB",
+    "gzip": true
+  },
+  {
+    "name": "@vitus-labs/kinetic-presets",
+    "path": "packages/kinetic-presets/lib/index.js",
+    "limit": "8 KB",
+    "gzip": true
+  },
+  {
+    "name": "@vitus-labs/rocketstories",
+    "path": "packages/rocketstories/lib/index.js",
+    "limit": "10 KB",
+    "gzip": true
+  },
+  {
+    "name": "@vitus-labs/rocketstyle",
+    "path": "packages/rocketstyle/lib/index.js",
+    "limit": "9 KB",
+    "gzip": true
+  },
+  {
+    "name": "@vitus-labs/styler",
+    "path": "packages/styler/lib/index.js",
+    "limit": "12 KB",
+    "gzip": true
+  },
+  {
+    "name": "@vitus-labs/unistyle",
+    "path": "packages/unistyle/lib/index.js",
+    "limit": "12 KB",
+    "gzip": true
+  }
+]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,12 +4,12 @@ A modular React UI ecosystem: components, styling, layout, hooks, animations, an
 
 ## Project Structure
 
-Monorepo with 16 packages under `packages/`, managed with Bun workspaces and Lerna for publishing.
+Monorepo with 15 packages under `packages/`, managed with Bun workspaces. Publishing via Changesets (Lerna removed in #147).
 
 ```
 packages/
 ├── core/                  # CSS engine connector, init(), utilities (get, set, merge, compose, pick, omit)
-├── styler/                # CSS-in-JS engine (~3KB gzip): css, styled, keyframes, ThemeProvider
+├── styler/                # CSS-in-JS engine (~7.5KB gzip): css, styled, keyframes, ThemeProvider
 ├── connector-styler/      # Connects styler to core's engine interface
 ├── connector-emotion/     # Connects Emotion to core's engine interface
 ├── connector-styled-components/  # Connects styled-components to core's engine interface
@@ -22,8 +22,7 @@ packages/
 ├── coolgrid/              # Responsive 12-column grid: Container, Row, Col
 ├── hooks/                 # 27+ React hooks (DOM, state, accessibility, timing, theme)
 ├── kinetic/               # CSS-transition animations: Transition, TransitionGroup, Stagger, Collapse
-├── kinetic-presets/       # 65+ animation presets + factories + composition utilities
-└── native-primitives/     # React Native primitive components
+└── kinetic-presets/       # 65+ animation presets + factories + composition utilities
 ```
 
 ## Setup & Initialization
@@ -68,7 +67,10 @@ const Button = rocketstyle({
   .styles((css) => css`padding: 8px 16px;`)
   .attrs(({ size }) => ({ tag: 'button' }))
 ```
-Chain: `.theme()`, `.styles()`, `.attrs()`, `.config()`, `.statics()`, `.compose()`, plus dynamic dimension methods.
+Chain methods come from two places:
+- `.theme()`, `.styles()`, `.compose()` and dynamic dimension methods → attached by `createStaticsChainingEnhancers` (driven by `STATIC_KEYS`)
+- `.attrs()`, `.config()`, `.statics()`, `getStaticDimensions()`, `getDefaultAttrs()` → attached via `Object.assign` in `rocketstyle.tsx`
+Don't hardcode the dynamic ones in `Object.assign` — they'll shadow the dynamic version.
 
 ### Styler (CSS-in-JS)
 ```tsx
@@ -82,9 +84,12 @@ const Card = styled.div`
   &:hover { opacity: 0.8; }
 `
 ```
-- Static templates (no function interpolations) → computed once, cached
+- Static templates (no function interpolations) → computed once, cached via single-entry hot cache + WeakMap fallback
 - Dynamic templates → resolved per render, CSS string cache prevents recomputation
+- `prepare()` results are cached by cssText for SSR `<style precedence>` reuse
+- `splitAtRules` extracts nested @media/@supports/@container into separate top-level rules
 - SSR: React 19 `<style precedence>` for streaming
+- Both `cache` and `normalizeCSS` cache evict the oldest 10% when over threshold (shared `evictMapByPercent` util)
 
 ### Responsive Grid
 ```tsx
@@ -108,20 +113,23 @@ import { fadeUp } from '@vitus-labs/kinetic-presets'
   {items.map(item => <div key={item.id}>{item.name}</div>)}
 </Stagger>
 ```
+`TransitionGroup` caches per-key `onAfterLeave` callbacks via a ref Map so a single child finishing leaving doesn't churn fresh callback props for siblings.
 
 ## Development Commands
 
 ```bash
-bun install           # Install dependencies
-bun run test          # Run all tests (Vitest, ~2600 tests in ~10s)
-bun run lint          # Lint with Biome
-bun run lint -- --fix # Auto-fix lint issues
-bun run pkgs:build    # Build all packages (rolldown)
+bun install                 # Install dependencies
+bun run test                # Run all tests (Vitest, ~2599 tests in ~10s)
+bun run lint                # Lint with Biome
+bun run lint -- --fix       # Auto-fix lint issues
+bun run pkgs:build          # Build all packages (rolldown)
+bun run typecheck           # Typecheck all packages
+bun run size                # Check bundle sizes against budgets
 ```
 
-Single package:
+Single package (Lerna removed; use bun workspaces):
 ```bash
-npx lerna run build --scope=@vitus-labs/core --stream
+bun run --filter=@vitus-labs/core build
 ```
 
 ## Build System
@@ -129,6 +137,7 @@ npx lerna run build --scope=@vitus-labs/core --stream
 - Bundler: `@vitus-labs/tools-rolldown` (rolldown-based), config in `vl-tools.config.js`
 - Output: `lib/` with ESM bundle + DTS
 - Tests: Vitest with `resolve.conditions: ['source']` to resolve workspace packages to source
+- CI bundle-size budgets enforced via `size-limit` (config in `.size-limit.json`)
 
 ## Platform Support
 
@@ -144,3 +153,23 @@ npx lerna run build --scope=@vitus-labs/core --stream
 - `PlatformConfig`: component, textComponent, createMediaQueries
 - Inter-package deps use `workspace:*` protocol
 - Circular dep: elements ↔ rocketstyle (story-only, not structural)
+- Overlay's `useOverlay` is split into focused modules: `positionMath.ts` (pure math), `useEscapeKey.ts`, `useHoverListeners.ts`, `useScrollReposition.ts`. Follow the same pattern for new "fat hook" cases.
+- `Element.equalize` uses `ResizeObserver` instead of running layout in `useLayoutEffect` on every prop change.
+
+## Type System Notes
+
+- The `attrs` and `rocketstyle` chain machinery (`Object.assign(Component, { method... })` + recursive `cloneAndEnhance` factory call) hits a fundamental TS limitation: chain method **return** types can't be expressed at the impl level. The current code uses one boundary cast per package — don't try to fix it without redesigning the chain machinery (builder class / phantom-type tuple / HKT encoding).
+- Internal `any` parameters in chain method impls (`attrs.tsx`, `rocketstyle.tsx`) have been replaced with proper interface types (PR #170). The pattern: public interface declares the precise types; impl `Object.assign` bypasses return-type checks but *parameters* should be properly typed.
+- `useExhaustiveDependencies` for `useMemo` in rocketstyle: factory-closure-captured options (e.g. `options.transformKeys`) are stable for the component's lifetime — use `// biome-ignore lint/correctness/useExhaustiveDependencies` with a clear reason instead of adding to deps.
+- `rocketstateRef` in rocketstyle uses a shallow-equal pattern to keep useMemo's identity stable across renders when dimension values are unchanged. See `isShallowEqualRocketstate` in `rocketstyle.tsx`.
+
+## Performance Hot Paths
+
+These were optimized in PR #166 — don't regress:
+- `unistyle/units/stripUnit.ts`: regex hoisted to module scope
+- `rocketstyle/utils/theme.ts`: `getTheme()` mutates `finalTheme` directly (merge() does copy-on-write for nested plain objects, so baseTheme stays untouched)
+- `coolgrid/useContext.tsx`: `useGridContext` result memoized
+- `styler/styled.ts`: `theme` injected by mutating freshly-spread `rawProps`, then restored — avoids second n-key spread per dynamic render
+- `attrs/hoc/attrsHoc.tsx`: fast path when no `.attrs()`/`.priorityAttrs()` configured
+- `hooks/useFocusTrap.ts`: focusable NodeList cached, refreshed via MutationObserver
+- `hooks/useBreakpoint.ts`: single rAF-throttled resize listener (was N matchMedia listeners)

--- a/bun.lock
+++ b/bun.lock
@@ -8,6 +8,7 @@
         "@biomejs/biome": "^2.4.13",
         "@changesets/changelog-github": "^0.6.0",
         "@changesets/cli": "^2.31.0",
+        "@size-limit/file": "^12.1.0",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@types/node": "25.6.0",
@@ -25,6 +26,7 @@
         "react-docgen-typescript-webpack-plugin": "^1.1.0",
         "react-dom": "^19.2.5",
         "react-icons-kit": "^2.0.0",
+        "size-limit": "^12.1.0",
         "ts-patch": "^3.3.0",
         "typescript": "6.0.3",
         "typescript-transform-paths": "^3.5.6",
@@ -996,6 +998,8 @@
 
     "@sinclair/typebox": ["@sinclair/typebox@0.27.10", "", {}, "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA=="],
 
+    "@size-limit/file": ["@size-limit/file@12.1.0", "", { "peerDependencies": { "size-limit": "12.1.0" } }, "sha512-eGwDcIufnNnvJRzv3liDOn6MAOGgmOTUdpeGQ2KuRTlgIgO54AJH1ilvktlJc6PIjNfwpYY0dOGyap1QgM1swQ=="],
+
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
     "@storybook/addon-a11y": ["@storybook/addon-a11y@10.3.5", "", { "dependencies": { "@storybook/global": "^5.0.0", "axe-core": "^4.2.0" }, "peerDependencies": { "storybook": "^10.3.5" } }, "sha512-5k6lpgfIeLxvNhE8v3wEzdiu73ONKjF4gmH1AHvfqYd8kIVzQJai0KCDxgvqNncXHQhIWkaf1fg6+9hKaYJyaw=="],
@@ -1279,6 +1283,8 @@
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
 
     "bundle-name": ["bundle-name@4.1.0", "", { "dependencies": { "run-applescript": "^7.0.0" } }, "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q=="],
+
+    "bytes-iec": ["bytes-iec@3.1.1", "", {}, "sha512-fey6+4jDK7TFtFg/klGSvNKJctyU7n2aQdnM+CO0ruLPbqqMOM8Tio0Pc+deqUeVKX1tL5DQep1zQ7+37aTAsA=="],
 
     "cacache": ["cacache@17.1.4", "", { "dependencies": { "@npmcli/fs": "^3.1.0", "fs-minipass": "^3.0.0", "glob": "^10.2.2", "lru-cache": "^7.7.1", "minipass": "^7.0.3", "minipass-collect": "^1.0.2", "minipass-flush": "^1.0.5", "minipass-pipeline": "^1.2.4", "p-map": "^4.0.0", "ssri": "^10.0.0", "tar": "^6.1.11", "unique-filename": "^3.0.0" } }, "sha512-/aJwG2l3ZMJ1xNAnqbMpA40of9dj/pIH3QfiuQSqjfPJF747VR0J/bHn+/KdNnHKc6XQcWt/AfRSBft82W1d2A=="],
 
@@ -1694,6 +1700,8 @@
 
     "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
 
+    "lilconfig": ["lilconfig@3.1.3", "", {}, "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw=="],
+
     "lines-and-columns": ["lines-and-columns@1.2.4", "", {}, "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="],
 
     "locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
@@ -1807,6 +1815,8 @@
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
     "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
+
+    "nanospinner": ["nanospinner@1.2.2", "", { "dependencies": { "picocolors": "^1.1.1" } }, "sha512-Zt/AmG6qRU3e+WnzGGLuMCEAO/dAu45stNbHY223tUxldaDAeE+FxSPsd9Q+j+paejmm0ZbrNVs5Sraqy3dRxA=="],
 
     "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 
@@ -2061,6 +2071,8 @@
     "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
     "sigstore": ["sigstore@1.9.0", "", { "dependencies": { "@sigstore/bundle": "^1.1.0", "@sigstore/protobuf-specs": "^0.2.0", "@sigstore/sign": "^1.0.0", "@sigstore/tuf": "^1.0.3", "make-fetch-happen": "^11.0.1" }, "bin": { "sigstore": "bin/sigstore.js" } }, "sha512-0Zjz0oe37d08VeOtBIuB6cRriqXse2e8w+7yIy2XSXjshRKxbc2KkhXjL229jXSxEm7UbcjS76wcJDGQddVI9A=="],
+
+    "size-limit": ["size-limit@12.1.0", "", { "dependencies": { "bytes-iec": "^3.1.1", "lilconfig": "^3.1.3", "nanospinner": "^1.2.2", "picocolors": "^1.1.1", "tinyglobby": "^0.2.16" }, "peerDependencies": { "jiti": "^2.0.0" }, "optionalPeers": ["jiti"], "bin": { "size-limit": "bin.js" } }, "sha512-VnDS2fycANrJFVPQwjaD+h+hkISY7EB3LsPsYWje4lBCjQwwsZLxjwwRwVJKHrcj2ZqyG+DdXykWm9mbZklZrw=="],
 
     "slash": ["slash@3.0.0", "", {}, "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="],
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "pkgs:build": "bun run --filter './packages/*' build",
     "test": "vitest run",
     "typecheck": "bun run --filter './packages/*' typecheck",
+    "size": "size-limit",
     "format": "biome format --write .",
     "atlas": "vl_atlas"
   },
@@ -37,6 +38,7 @@
     "@biomejs/biome": "^2.4.13",
     "@changesets/changelog-github": "^0.6.0",
     "@changesets/cli": "^2.31.0",
+    "@size-limit/file": "^12.1.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@types/node": "25.6.0",
@@ -54,6 +56,7 @@
     "react-docgen-typescript-webpack-plugin": "^1.1.0",
     "react-dom": "^19.2.5",
     "react-icons-kit": "^2.0.0",
+    "size-limit": "^12.1.0",
     "ts-patch": "^3.3.0",
     "typescript": "6.0.3",
     "typescript-transform-paths": "^3.5.6",

--- a/packages/kinetic/src/__tests__/Collapse.test.tsx
+++ b/packages/kinetic/src/__tests__/Collapse.test.tsx
@@ -1,24 +1,9 @@
 import { act, render, screen } from '@testing-library/react'
 import Collapse from '../Collapse'
 import { kinetic } from '../index'
+import { fireTransitionEnd, setupMatchMedia } from './setupFixtures'
 
-// Mock matchMedia
-beforeAll(() => {
-  Object.defineProperty(window, 'matchMedia', {
-    writable: true,
-    configurable: true,
-    value: vi.fn((query: string) => ({
-      matches: false,
-      media: query,
-      addEventListener: vi.fn(),
-      removeEventListener: vi.fn(),
-      onchange: null,
-      addListener: vi.fn(),
-      removeListener: vi.fn(),
-      dispatchEvent: vi.fn(),
-    })),
-  })
-})
+setupMatchMedia()
 
 // Mock scrollHeight
 const mockScrollHeight = (value: number) => {
@@ -28,12 +13,6 @@ const mockScrollHeight = (value: number) => {
       return value
     },
   })
-}
-
-const fireTransitionEnd = (el: HTMLElement) => {
-  const event = new Event('transitionend', { bubbles: true })
-  Object.defineProperty(event, 'target', { value: el })
-  el.dispatchEvent(event)
 }
 
 describe('Collapse', () => {

--- a/packages/kinetic/src/__tests__/Stagger.test.tsx
+++ b/packages/kinetic/src/__tests__/Stagger.test.tsx
@@ -1,47 +1,9 @@
 import { act, render, screen } from '@testing-library/react'
 import Stagger from '../Stagger'
+import { setupMatchMedia, setupRaf } from './setupFixtures'
 
-// Mock matchMedia
-beforeAll(() => {
-  Object.defineProperty(window, 'matchMedia', {
-    writable: true,
-    configurable: true,
-    value: vi.fn((query: string) => ({
-      matches: false,
-      media: query,
-      addEventListener: vi.fn(),
-      removeEventListener: vi.fn(),
-      onchange: null,
-      addListener: vi.fn(),
-      removeListener: vi.fn(),
-      dispatchEvent: vi.fn(),
-    })),
-  })
-})
-
-let rafCallbacks: (() => void)[] = []
-const originalRaf = globalThis.requestAnimationFrame
-const originalCaf = globalThis.cancelAnimationFrame
-
-beforeEach(() => {
-  vi.useFakeTimers()
-  rafCallbacks = []
-
-  vi.stubGlobal(
-    'requestAnimationFrame',
-    vi.fn((cb: () => void) => {
-      rafCallbacks.push(cb)
-      return rafCallbacks.length
-    }),
-  )
-  vi.stubGlobal('cancelAnimationFrame', vi.fn())
-})
-
-afterEach(() => {
-  vi.useRealTimers()
-  vi.stubGlobal('requestAnimationFrame', originalRaf)
-  vi.stubGlobal('cancelAnimationFrame', originalCaf)
-})
+setupMatchMedia()
+setupRaf()
 
 describe('Stagger', () => {
   it('renders all children when show=true', () => {

--- a/packages/kinetic/src/__tests__/Transition.test.tsx
+++ b/packages/kinetic/src/__tests__/Transition.test.tsx
@@ -1,61 +1,9 @@
 import { act, render, screen } from '@testing-library/react'
 import Transition from '../Transition'
+import { fireTransitionEnd, setupMatchMedia, setupRaf } from './setupFixtures'
 
-// Mock matchMedia (needed by useReducedMotion → useMediaQuery)
-beforeAll(() => {
-  Object.defineProperty(window, 'matchMedia', {
-    writable: true,
-    configurable: true,
-    value: vi.fn((query: string) => ({
-      matches: false,
-      media: query,
-      addEventListener: vi.fn(),
-      removeEventListener: vi.fn(),
-      onchange: null,
-      addListener: vi.fn(),
-      removeListener: vi.fn(),
-      dispatchEvent: vi.fn(),
-    })),
-  })
-})
-
-// Mock requestAnimationFrame for deterministic double-rAF testing
-let rafCallbacks: (() => void)[] = []
-const originalRaf = globalThis.requestAnimationFrame
-const originalCaf = globalThis.cancelAnimationFrame
-
-beforeEach(() => {
-  vi.useFakeTimers()
-  rafCallbacks = []
-
-  vi.stubGlobal(
-    'requestAnimationFrame',
-    vi.fn((cb: () => void) => {
-      rafCallbacks.push(cb)
-      return rafCallbacks.length
-    }),
-  )
-
-  vi.stubGlobal('cancelAnimationFrame', vi.fn())
-})
-
-afterEach(() => {
-  vi.useRealTimers()
-  vi.stubGlobal('requestAnimationFrame', originalRaf)
-  vi.stubGlobal('cancelAnimationFrame', originalCaf)
-})
-
-const flushRaf = () => {
-  const cbs = [...rafCallbacks]
-  rafCallbacks = []
-  for (const cb of cbs) cb()
-}
-
-const fireTransitionEnd = (el: HTMLElement) => {
-  const event = new Event('transitionend', { bubbles: true })
-  Object.defineProperty(event, 'target', { value: el })
-  el.dispatchEvent(event)
-}
+setupMatchMedia()
+const { flushRaf } = setupRaf()
 
 describe('Transition', () => {
   it('renders children when show=true', () => {

--- a/packages/kinetic/src/__tests__/TransitionGroup.test.tsx
+++ b/packages/kinetic/src/__tests__/TransitionGroup.test.tsx
@@ -1,59 +1,9 @@
 import { act, render, screen } from '@testing-library/react'
 import TransitionGroup from '../TransitionGroup'
+import { fireTransitionEnd, setupMatchMedia, setupRaf } from './setupFixtures'
 
-// Mock matchMedia
-beforeAll(() => {
-  Object.defineProperty(window, 'matchMedia', {
-    writable: true,
-    configurable: true,
-    value: vi.fn((query: string) => ({
-      matches: false,
-      media: query,
-      addEventListener: vi.fn(),
-      removeEventListener: vi.fn(),
-      onchange: null,
-      addListener: vi.fn(),
-      removeListener: vi.fn(),
-      dispatchEvent: vi.fn(),
-    })),
-  })
-})
-
-let rafCallbacks: (() => void)[] = []
-const originalRaf = globalThis.requestAnimationFrame
-const originalCaf = globalThis.cancelAnimationFrame
-
-beforeEach(() => {
-  vi.useFakeTimers()
-  rafCallbacks = []
-
-  vi.stubGlobal(
-    'requestAnimationFrame',
-    vi.fn((cb: () => void) => {
-      rafCallbacks.push(cb)
-      return rafCallbacks.length
-    }),
-  )
-  vi.stubGlobal('cancelAnimationFrame', vi.fn())
-})
-
-afterEach(() => {
-  vi.useRealTimers()
-  vi.stubGlobal('requestAnimationFrame', originalRaf)
-  vi.stubGlobal('cancelAnimationFrame', originalCaf)
-})
-
-const flushRaf = () => {
-  const cbs = [...rafCallbacks]
-  rafCallbacks = []
-  for (const cb of cbs) cb()
-}
-
-const fireTransitionEnd = (el: HTMLElement) => {
-  const event = new Event('transitionend', { bubbles: true })
-  Object.defineProperty(event, 'target', { value: el })
-  el.dispatchEvent(event)
-}
+setupMatchMedia()
+const { flushRaf } = setupRaf()
 
 describe('TransitionGroup', () => {
   it('renders all children initially', () => {

--- a/packages/kinetic/src/__tests__/TransitionItem.test.tsx
+++ b/packages/kinetic/src/__tests__/TransitionItem.test.tsx
@@ -1,61 +1,9 @@
 import { act, render, screen } from '@testing-library/react'
 import TransitionItem from '../kinetic/TransitionItem'
+import { fireTransitionEnd, setupMatchMedia, setupRaf } from './setupFixtures'
 
-// Mock matchMedia (needed by useReducedMotion)
-beforeAll(() => {
-  Object.defineProperty(window, 'matchMedia', {
-    writable: true,
-    configurable: true,
-    value: vi.fn((query: string) => ({
-      matches: false,
-      media: query,
-      addEventListener: vi.fn(),
-      removeEventListener: vi.fn(),
-      onchange: null,
-      addListener: vi.fn(),
-      removeListener: vi.fn(),
-      dispatchEvent: vi.fn(),
-    })),
-  })
-})
-
-// Mock rAF for deterministic testing
-let rafCallbacks: (() => void)[] = []
-const originalRaf = globalThis.requestAnimationFrame
-const originalCaf = globalThis.cancelAnimationFrame
-
-beforeEach(() => {
-  vi.useFakeTimers()
-  rafCallbacks = []
-
-  vi.stubGlobal(
-    'requestAnimationFrame',
-    vi.fn((cb: () => void) => {
-      rafCallbacks.push(cb)
-      return rafCallbacks.length
-    }),
-  )
-
-  vi.stubGlobal('cancelAnimationFrame', vi.fn())
-})
-
-afterEach(() => {
-  vi.useRealTimers()
-  vi.stubGlobal('requestAnimationFrame', originalRaf)
-  vi.stubGlobal('cancelAnimationFrame', originalCaf)
-})
-
-const flushRaf = () => {
-  const cbs = [...rafCallbacks]
-  rafCallbacks = []
-  for (const cb of cbs) cb()
-}
-
-const fireTransitionEnd = (el: HTMLElement) => {
-  const event = new Event('transitionend', { bubbles: true })
-  Object.defineProperty(event, 'target', { value: el })
-  el.dispatchEvent(event)
-}
+setupMatchMedia()
+const { flushRaf } = setupRaf()
 
 // ─── Rendering ──────────────────────────────────────────────
 

--- a/packages/kinetic/src/__tests__/kinetic.test.tsx
+++ b/packages/kinetic/src/__tests__/kinetic.test.tsx
@@ -1,62 +1,10 @@
 import { act, render, screen } from '@testing-library/react'
 import { kinetic } from '../index'
 import { fade, slideUp } from '../presets'
+import { fireTransitionEnd, setupMatchMedia, setupRaf } from './setupFixtures'
 
-// Mock matchMedia (needed by useReducedMotion)
-beforeAll(() => {
-  Object.defineProperty(window, 'matchMedia', {
-    writable: true,
-    configurable: true,
-    value: vi.fn((query: string) => ({
-      matches: false,
-      media: query,
-      addEventListener: vi.fn(),
-      removeEventListener: vi.fn(),
-      onchange: null,
-      addListener: vi.fn(),
-      removeListener: vi.fn(),
-      dispatchEvent: vi.fn(),
-    })),
-  })
-})
-
-// Mock rAF for deterministic testing
-let rafCallbacks: (() => void)[] = []
-const originalRaf = globalThis.requestAnimationFrame
-const originalCaf = globalThis.cancelAnimationFrame
-
-beforeEach(() => {
-  vi.useFakeTimers()
-  rafCallbacks = []
-
-  vi.stubGlobal(
-    'requestAnimationFrame',
-    vi.fn((cb: () => void) => {
-      rafCallbacks.push(cb)
-      return rafCallbacks.length
-    }),
-  )
-
-  vi.stubGlobal('cancelAnimationFrame', vi.fn())
-})
-
-afterEach(() => {
-  vi.useRealTimers()
-  vi.stubGlobal('requestAnimationFrame', originalRaf)
-  vi.stubGlobal('cancelAnimationFrame', originalCaf)
-})
-
-const flushRaf = () => {
-  const cbs = [...rafCallbacks]
-  rafCallbacks = []
-  for (const cb of cbs) cb()
-}
-
-const fireTransitionEnd = (el: HTMLElement) => {
-  const event = new Event('transitionend', { bubbles: true })
-  Object.defineProperty(event, 'target', { value: el })
-  el.dispatchEvent(event)
-}
+setupMatchMedia()
+const { flushRaf } = setupRaf()
 
 // ─── Transition Mode (default) ────────────────────────────
 

--- a/packages/kinetic/src/__tests__/setupFixtures.ts
+++ b/packages/kinetic/src/__tests__/setupFixtures.ts
@@ -1,0 +1,93 @@
+/**
+ * Shared test fixtures for kinetic component tests.
+ *
+ * - `setupMatchMedia()` — install a window.matchMedia mock (always non-matching).
+ *   Required because `useReducedMotion` → `useMediaQuery` reads matchMedia at mount.
+ *
+ * - `setupRaf()` — replace requestAnimationFrame with a controllable queue + fake
+ *   timers. Returns `{ flushRaf }` to manually run queued callbacks. Restores the
+ *   originals automatically on the next `afterEach`.
+ *
+ * - `fireTransitionEnd(el)` — dispatch a `transitionend` event with the element
+ *   set as the event target (jsdom doesn't auto-set target on synthetic events).
+ *
+ * Usage:
+ *   ```ts
+ *   import { setupMatchMedia, setupRaf, fireTransitionEnd } from './setupFixtures'
+ *
+ *   setupMatchMedia()
+ *   const { flushRaf } = setupRaf()
+ *   ```
+ */
+
+/** Install a non-matching matchMedia mock. Call from a test file's top level. */
+export const setupMatchMedia = () => {
+  beforeAll(() => {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      configurable: true,
+      value: vi.fn((query: string) => ({
+        matches: false,
+        media: query,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    })
+  })
+}
+
+/**
+ * Install a controllable rAF queue + fake timers, restored after each test.
+ * Returns a `flushRaf()` helper that runs (and clears) all queued callbacks.
+ */
+export const setupRaf = () => {
+  let rafCallbacks: (() => void)[] = []
+  const originalRaf = globalThis.requestAnimationFrame
+  const originalCaf = globalThis.cancelAnimationFrame
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    rafCallbacks = []
+
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      vi.fn((cb: () => void) => {
+        rafCallbacks.push(cb)
+        return rafCallbacks.length
+      }),
+    )
+    vi.stubGlobal('cancelAnimationFrame', vi.fn())
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.stubGlobal('requestAnimationFrame', originalRaf)
+    vi.stubGlobal('cancelAnimationFrame', originalCaf)
+  })
+
+  const flushRaf = () => {
+    const cbs = [...rafCallbacks]
+    rafCallbacks = []
+    for (const cb of cbs) cb()
+  }
+
+  return { flushRaf }
+}
+
+/** Dispatch a `transitionend` event on `el` with `target` set (jsdom workaround). */
+export const fireTransitionEnd = (el: HTMLElement) => {
+  const event = new Event('transitionend', { bubbles: true })
+  Object.defineProperty(event, 'target', { value: el })
+  el.dispatchEvent(event)
+}
+
+/** Dispatch an `animationend` event on `el` with `target` set (jsdom workaround). */
+export const fireAnimationEnd = (el: HTMLElement) => {
+  const event = new Event('animationend', { bubbles: true })
+  Object.defineProperty(event, 'target', { value: el })
+  el.dispatchEvent(event)
+}

--- a/packages/styler/src/evict.ts
+++ b/packages/styler/src/evict.ts
@@ -1,0 +1,17 @@
+/**
+ * Evict the oldest `percent`% of a Map's entries (by insertion order). Used by
+ * the bounded caches in `sheet.ts` and `resolve.ts` so we degrade gracefully
+ * past the threshold instead of dropping a fixed amount and immediately re-
+ * filling. Map iteration order is insertion order in V8/JSC/SpiderMonkey, so
+ * iterating + deleting from the front evicts the oldest entries.
+ */
+export const evictMapByPercent = <K, V>(map: Map<K, V>, percent = 0.1) => {
+  const toDelete = Math.floor(map.size * percent)
+  if (toDelete <= 0) return
+  let count = 0
+  for (const key of map.keys()) {
+    if (count >= toDelete) break
+    map.delete(key)
+    count++
+  }
+}

--- a/packages/styler/src/resolve.ts
+++ b/packages/styler/src/resolve.ts
@@ -4,6 +4,7 @@
  * primitive values.
  */
 
+import { evictMapByPercent } from './evict'
 import type { DefaultTheme } from './ThemeProvider'
 
 export type Interpolation =
@@ -148,12 +149,7 @@ export const normalizeCSS = (css: string): string => {
 
   // Evict oldest ~10% to prevent memory leaks without cliff-edge drop
   if (normCache.size > 2000) {
-    let count = 0
-    for (const key of normCache.keys()) {
-      if (count >= 200) break
-      normCache.delete(key)
-      count++
-    }
+    evictMapByPercent(normCache, 0.1)
   }
   normCache.set(css, out)
 

--- a/packages/styler/src/sheet.ts
+++ b/packages/styler/src/sheet.ts
@@ -8,6 +8,7 @@
  * reliance on CSS Nesting for at-rules (which has CSSOM specification gaps
  * per W3C csswg-drafts#7850).
  */
+import { evictMapByPercent } from './evict'
 import { hash } from './hash'
 import { clearNormCache } from './resolve'
 
@@ -101,15 +102,7 @@ export class StyleSheet {
   /** Evict oldest entries when cache exceeds max size. */
   private evictIfNeeded() {
     if (this.cache.size <= this.maxCacheSize) return
-
-    // Map iteration order is insertion order — delete oldest 10%
-    const toDelete = Math.floor(this.maxCacheSize * 0.1)
-    let count = 0
-    for (const key of this.cache.keys()) {
-      if (count >= toDelete) break
-      this.cache.delete(key)
-      count++
-    }
+    evictMapByPercent(this.cache, 0.1)
   }
 
   /**


### PR DESCRIPTION
Bundles four small but useful internal cleanups identified in the post-audit review. **No public API or runtime behavior changes.**

## What's included

### 1. CLAUDE.md refresh
Updated with everything learned from audit + refactor PRs (#147, #166, #167, #168, #169, #170):
- Lerna → Changesets, updated single-package build cmd
- Package count corrected (15, was claiming 16)
- Documents where rocketstyle chain methods come from (`Object.assign` vs dynamic `createStaticsChainingEnhancers` driven by `STATIC_KEYS`) — prevents future accidental shadowing like the one we caught in PR #170
- Notes the Overlay `positionMath` split (PR #168) as the reference pattern for splitting fat hooks
- Type system notes on chain machinery TS limitation and the "internal `any` is OK if interface is properly typed" pattern (PR #170)
- New "Performance Hot Paths" section listing PR #166 wins so future edits don't regress them
- New `bun run size` command listed under dev commands

### 2. styler `evictMapByPercent` shared util
`sheet.ts` and `resolve.ts` had two independent copies of "evict oldest 10% by insertion order". Extracted to `packages/styler/src/evict.ts` (separate file to avoid the `shared.ts ↔ resolve.ts` circular dep).

### 3. kinetic shared test fixtures
Six test files (Transition, TransitionGroup, Stagger, Collapse, TransitionItem, kinetic) each reimplemented the same matchMedia mock + rAF stub + `fireTransitionEnd` helper — ~50 lines each, ~300 lines total. Extracted to `packages/kinetic/src/__tests__/setupFixtures.ts`:
- `setupMatchMedia()` — installs the matchMedia mock
- `setupRaf()` — controllable rAF queue + fake timers, returns `flushRaf`
- `fireTransitionEnd(el)` / `fireAnimationEnd(el)` — jsdom event helpers

Net: -300 lines from tests + 80 lines fixtures.

### 4. Bundle size budgets (CI)
New `.size-limit.json` config + `bun run size` script + CI step. Budgets set ~20% above current sizes to allow normal growth while catching real regressions.

| Package | Current (gzip) | Budget |
|---|---|---|
| `@vitus-labs/connector-styled-components` | 186 B | 300 B |
| `@vitus-labs/connector-styler` | 193 B | 300 B |
| `@vitus-labs/connector-emotion` | 1.10 KB | 1.4 KB |
| `@vitus-labs/attrs` | 2.52 KB | 3 KB |
| `@vitus-labs/connector-native` | 2.74 KB | 3.5 KB |
| `@vitus-labs/coolgrid` | 3.52 KB | 4.5 KB |
| `@vitus-labs/core` | 4.83 KB | 6 KB |
| `@vitus-labs/kinetic` | 5.09 KB | 6.5 KB |
| `@vitus-labs/hooks` | 5.25 KB | 6.5 KB |
| `@vitus-labs/kinetic-presets` | 6.32 KB | 8 KB |
| `@vitus-labs/rocketstyle` | 7.18 KB | 9 KB |
| `@vitus-labs/rocketstories` | 8.27 KB | 10 KB |
| `@vitus-labs/unistyle` | 9.27 KB | 12 KB |
| `@vitus-labs/styler` | 9.73 KB | 12 KB |
| `@vitus-labs/elements` | 11.82 KB | 15 KB |
| **Total** | **~78 KB** | — |

Uses `@size-limit/file` (just measures the built bundle — doesn't try to bundle peer deps like react-native, which would otherwise fail on Flow syntax).

## Skipped from audit candidates
- **`ReactElement<any>` → `ReactElement` tightening**: would propagate as `ReactElement<unknown>` in newer `@types/react` and break props access in Transition impl files. Cascade not worth a marginal idiom change.
- **styler `hotCache` + `staticComponentCache` consolidation**: code is dense but correct, refactoring risks breaking subtle ordering for marginal gain.

## Test plan
- [x] All 2599 tests pass
- [x] 0 type errors
- [x] 0 lint errors (126 pre-existing warnings unchanged)
- [x] All 15 packages build
- [x] All 15 size budgets pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)