### PR TITLE
chore: bump expo-native transitive deps (closes 6 dependabot PRs)

### DIFF
--- a/examples/expo-native/package-lock.json
+++ b/examples/expo-native/package-lock.json
@@ -28,35 +28,35 @@
       },
       "devDependencies": {
         "@types/react": "^19.2.14",
-        "typescript": "~5.9.3"
+        "typescript": "~6.0.3"
       }
     },
     "../../packages/attrs": {
       "name": "@vitus-labs/attrs",
-      "version": "2.0.0-alpha.27",
+      "version": "2.0.0-beta.0",
       "license": "MIT",
       "devDependencies": {
         "@vitus-labs/core": "workspace:*",
         "@vitus-labs/elements": "workspace:*",
-        "@vitus-labs/tools-rolldown": "1.9.1-alpha.19",
-        "@vitus-labs/tools-storybook": "1.9.1-alpha.19",
-        "@vitus-labs/tools-typescript": "1.9.1-alpha.19"
+        "@vitus-labs/tools-rolldown": "2.0.0",
+        "@vitus-labs/tools-storybook": "2.0.0",
+        "@vitus-labs/tools-typescript": "2.0.0"
       },
       "engines": {
         "node": ">= 18"
       },
       "peerDependencies": {
-        "@vitus-labs/core": "2.0.0-alpha.27",
+        "@vitus-labs/core": "2.0.0-beta.0",
         "react": ">= 19"
       }
     },
     "../../packages/connector-native": {
       "name": "@vitus-labs/connector-native",
-      "version": "2.0.0-alpha.27",
+      "version": "2.0.0-beta.0",
       "license": "MIT",
       "devDependencies": {
-        "@vitus-labs/tools-rolldown": "1.9.1-alpha.19",
-        "@vitus-labs/tools-typescript": "1.9.1-alpha.19"
+        "@vitus-labs/tools-rolldown": "2.0.0",
+        "@vitus-labs/tools-typescript": "2.0.0"
       },
       "engines": {
         "node": ">= 18"
@@ -68,22 +68,22 @@
     },
     "../../packages/coolgrid": {
       "name": "@vitus-labs/coolgrid",
-      "version": "2.0.0-alpha.27",
+      "version": "2.0.0-beta.0",
       "license": "MIT",
       "devDependencies": {
         "@vitus-labs/core": "workspace:*",
-        "@vitus-labs/tools-rolldown": "1.9.1-alpha.19",
-        "@vitus-labs/tools-storybook": "1.9.1-alpha.19",
-        "@vitus-labs/tools-typescript": "1.9.1-alpha.19",
+        "@vitus-labs/tools-rolldown": "2.0.0",
+        "@vitus-labs/tools-storybook": "2.0.0",
+        "@vitus-labs/tools-typescript": "2.0.0",
         "@vitus-labs/unistyle": "workspace:*",
-        "react-native": ">=0.76.0"
+        "react-native": ">=0.84.1"
       },
       "engines": {
         "node": ">= 18"
       },
       "peerDependencies": {
-        "@vitus-labs/core": "2.0.0-alpha.27",
-        "@vitus-labs/unistyle": "2.0.0-alpha.27",
+        "@vitus-labs/core": "2.0.0-beta.0",
+        "@vitus-labs/unistyle": "2.0.0-beta.0",
         "react": ">= 19",
         "react-native": ">= 0.76"
       },
@@ -95,14 +95,14 @@
     },
     "../../packages/core": {
       "name": "@vitus-labs/core",
-      "version": "2.0.0-alpha.27",
+      "version": "2.0.0-beta.0",
       "license": "MIT",
       "dependencies": {
         "react-is": "^19.2.4"
       },
       "devDependencies": {
-        "@vitus-labs/tools-rolldown": "1.9.1-alpha.19",
-        "@vitus-labs/tools-typescript": "1.9.1-alpha.19"
+        "@vitus-labs/tools-rolldown": "2.0.0",
+        "@vitus-labs/tools-typescript": "2.0.0"
       },
       "engines": {
         "node": ">= 18"
@@ -113,7 +113,7 @@
     },
     "../../packages/elements": {
       "name": "@vitus-labs/elements",
-      "version": "2.0.0-alpha.27",
+      "version": "2.0.0-beta.0",
       "license": "MIT",
       "dependencies": {
         "react-is": "^19.2.4"
@@ -121,17 +121,17 @@
       "devDependencies": {
         "@vitus-labs/core": "workspace:*",
         "@vitus-labs/rocketstyle": "workspace:*",
-        "@vitus-labs/tools-rolldown": "1.9.1-alpha.19",
-        "@vitus-labs/tools-storybook": "1.9.1-alpha.19",
-        "@vitus-labs/tools-typescript": "1.9.1-alpha.19",
+        "@vitus-labs/tools-rolldown": "2.0.0",
+        "@vitus-labs/tools-storybook": "2.0.0",
+        "@vitus-labs/tools-typescript": "2.0.0",
         "@vitus-labs/unistyle": "workspace:*"
       },
       "engines": {
         "node": ">= 18"
       },
       "peerDependencies": {
-        "@vitus-labs/core": "2.0.0-alpha.27",
-        "@vitus-labs/unistyle": "2.0.0-alpha.27",
+        "@vitus-labs/core": "2.0.0-beta.0",
+        "@vitus-labs/unistyle": "2.0.0-beta.0",
         "react": ">= 19",
         "react-dom": ">= 19",
         "react-native": ">= 0.76"
@@ -147,20 +147,20 @@
     },
     "../../packages/hooks": {
       "name": "@vitus-labs/hooks",
-      "version": "2.0.0-alpha.27",
+      "version": "2.0.0-beta.0",
       "license": "MIT",
       "devDependencies": {
         "@vitus-labs/core": "workspace:*",
-        "@vitus-labs/tools-rolldown": "1.9.1-alpha.19",
-        "@vitus-labs/tools-storybook": "1.9.1-alpha.19",
-        "@vitus-labs/tools-typescript": "1.9.1-alpha.19",
-        "react-native": ">=0.76.0"
+        "@vitus-labs/tools-rolldown": "2.0.0",
+        "@vitus-labs/tools-storybook": "2.0.0",
+        "@vitus-labs/tools-typescript": "2.0.0",
+        "react-native": ">=0.84.1"
       },
       "engines": {
         "node": ">= 18"
       },
       "peerDependencies": {
-        "@vitus-labs/core": "2.0.0-alpha.27",
+        "@vitus-labs/core": "2.0.0-beta.0",
         "react": ">= 19",
         "react-native": ">= 0.76"
       },
@@ -172,19 +172,19 @@
     },
     "../../packages/kinetic": {
       "name": "@vitus-labs/kinetic",
-      "version": "2.0.0-alpha.27",
+      "version": "2.0.0-beta.0",
       "license": "MIT",
       "devDependencies": {
         "@vitus-labs/hooks": "workspace:*",
-        "@vitus-labs/tools-rolldown": "1.9.1-alpha.19",
-        "@vitus-labs/tools-typescript": "1.9.1-alpha.19",
-        "react-native": ">=0.76.0"
+        "@vitus-labs/tools-rolldown": "2.0.0",
+        "@vitus-labs/tools-typescript": "2.0.0",
+        "react-native": ">=0.84.1"
       },
       "engines": {
         "node": ">= 18"
       },
       "peerDependencies": {
-        "@vitus-labs/hooks": "2.0.0-alpha.27",
+        "@vitus-labs/hooks": "2.0.0-beta.0",
         "react": ">= 19",
         "react-native": ">= 0.76"
       },
@@ -196,11 +196,11 @@
     },
     "../../packages/kinetic-presets": {
       "name": "@vitus-labs/kinetic-presets",
-      "version": "2.0.0-alpha.27",
+      "version": "2.0.0-beta.0",
       "license": "MIT",
       "devDependencies": {
-        "@vitus-labs/tools-rolldown": "1.9.1-alpha.19",
-        "@vitus-labs/tools-typescript": "1.9.1-alpha.19"
+        "@vitus-labs/tools-rolldown": "2.0.0",
+        "@vitus-labs/tools-typescript": "2.0.0"
       },
       "peerDependencies": {
         "react": ">= 19"
@@ -208,38 +208,38 @@
     },
     "../../packages/rocketstyle": {
       "name": "@vitus-labs/rocketstyle",
-      "version": "2.0.0-alpha.27",
+      "version": "2.0.0-beta.0",
       "license": "MIT",
       "devDependencies": {
         "@vitus-labs/core": "workspace:*",
         "@vitus-labs/elements": "workspace:*",
-        "@vitus-labs/tools-rolldown": "1.9.1-alpha.19",
-        "@vitus-labs/tools-storybook": "1.9.1-alpha.19",
-        "@vitus-labs/tools-typescript": "1.9.1-alpha.19",
+        "@vitus-labs/tools-rolldown": "2.0.0",
+        "@vitus-labs/tools-storybook": "2.0.0",
+        "@vitus-labs/tools-typescript": "2.0.0",
         "@vitus-labs/unistyle": "workspace:*"
       },
       "engines": {
         "node": ">= 18"
       },
       "peerDependencies": {
-        "@vitus-labs/core": "2.0.0-alpha.27",
+        "@vitus-labs/core": "2.0.0-beta.0",
         "react": ">= 19"
       }
     },
     "../../packages/unistyle": {
       "name": "@vitus-labs/unistyle",
-      "version": "2.0.0-alpha.27",
+      "version": "2.0.0-beta.0",
       "license": "MIT",
       "devDependencies": {
         "@vitus-labs/core": "workspace:*",
-        "@vitus-labs/tools-rolldown": "1.9.1-alpha.19",
-        "@vitus-labs/tools-typescript": "1.9.1-alpha.19"
+        "@vitus-labs/tools-rolldown": "2.0.0",
+        "@vitus-labs/tools-typescript": "2.0.0"
       },
       "engines": {
         "node": ">= 18"
       },
       "peerDependencies": {
-        "@vitus-labs/core": "2.0.0-alpha.27",
+        "@vitus-labs/core": "2.0.0-beta.0",
         "react": ">= 19",
         "react-native": ">= 0.76"
       },
@@ -2133,41 +2133,6 @@
         "xml2js": "0.6.0"
       }
     },
-    "node_modules/@expo/require-utils": {
-      "version": "55.0.2",
-      "resolved": "https://registry.npmjs.org/@expo/require-utils/-/require-utils-55.0.2.tgz",
-      "integrity": "sha512-dV5oCShQ1umKBKagMMT4B/N+SREsQe3lU4Zgmko5AO0rxKV0tynZT6xXs+e2JxuqT4Rz997atg7pki0BnZb4uw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.20.0",
-        "@babel/core": "^7.25.2",
-        "@babel/plugin-transform-modules-commonjs": "^7.24.8"
-      },
-      "peerDependencies": {
-        "typescript": "^5.0.0 || ^5.0.0-0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@expo/require-utils/node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "js-tokens": "^4.0.0",
-        "picocolors": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@expo/schema-utils": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/@expo/schema-utils/-/schema-utils-0.1.8.tgz",
@@ -2721,9 +2686,9 @@
       }
     },
     "node_modules/@react-native/codegen/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -3191,9 +3156,9 @@
       "link": true
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.11.tgz",
-      "integrity": "sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==",
+      "version": "0.8.13",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
+      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -3322,9 +3287,9 @@
       }
     },
     "node_modules/anymatch/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -3658,9 +3623,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -4523,83 +4488,18 @@
       }
     },
     "node_modules/expo-constants": {
-      "version": "55.0.7",
-      "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-55.0.7.tgz",
-      "integrity": "sha512-kdcO4TsQRRqt0USvjaY5vgQMO9H52K3kBZ/ejC7F6rz70mv08GoowrZ1CYOr5O4JpPDRlIpQfZJUucaS/c+KWQ==",
+      "version": "55.0.15",
+      "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-55.0.15.tgz",
+      "integrity": "sha512-w394fcZLJjeKN+9ZnJzL/HiarE1nwZFDa+3S9frevh6Ur+MAAs9QDrcXhDrV8T3xqRzzYaqsP6Z8TFZ4efWN1A==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@expo/config": "~55.0.8",
         "@expo/env": "~2.1.1"
       },
       "peerDependencies": {
         "expo": "*",
         "react-native": "*"
       }
-    },
-    "node_modules/expo-constants/node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "js-tokens": "^4.0.0",
-        "picocolors": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/expo-constants/node_modules/@expo/config": {
-      "version": "55.0.8",
-      "resolved": "https://registry.npmjs.org/@expo/config/-/config-55.0.8.tgz",
-      "integrity": "sha512-D7RYYHfErCgEllGxNwdYdkgzLna7zkzUECBV3snbUpf7RvIpB5l1LpCgzuVoc5KVew5h7N1Tn4LnT/tBSUZsQg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@expo/config-plugins": "~55.0.6",
-        "@expo/config-types": "^55.0.5",
-        "@expo/json-file": "^10.0.12",
-        "@expo/require-utils": "^55.0.2",
-        "deepmerge": "^4.3.1",
-        "getenv": "^2.0.0",
-        "glob": "^13.0.0",
-        "resolve-from": "^5.0.0",
-        "resolve-workspace-root": "^2.0.0",
-        "semver": "^7.6.0",
-        "slugify": "^1.3.4"
-      }
-    },
-    "node_modules/expo-constants/node_modules/@expo/config-plugins": {
-      "version": "55.0.6",
-      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-55.0.6.tgz",
-      "integrity": "sha512-cIox6FjZlFaaX40rbQ3DvP9e87S5X85H9uw+BAxJE5timkMhuByy3GAlOsj1h96EyzSiol7Q6YIGgY1Jiz4M+A==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@expo/config-types": "^55.0.5",
-        "@expo/json-file": "~10.0.12",
-        "@expo/plist": "^0.5.2",
-        "@expo/sdk-runtime-versions": "^1.0.0",
-        "chalk": "^4.1.2",
-        "debug": "^4.3.5",
-        "getenv": "^2.0.0",
-        "glob": "^13.0.0",
-        "resolve-from": "^5.0.0",
-        "semver": "^7.5.4",
-        "slugify": "^1.6.6",
-        "xcode": "^3.0.1",
-        "xml2js": "0.6.0"
-      }
-    },
-    "node_modules/expo-constants/node_modules/@expo/config-types": {
-      "version": "55.0.5",
-      "resolved": "https://registry.npmjs.org/@expo/config-types/-/config-types-55.0.5.tgz",
-      "integrity": "sha512-sCmSUZG4mZ/ySXvfyyBdhjivz8Q539X1NondwDdYG7s3SBsk+wsgPJzYsqgAG/P9+l0xWjUD2F+kQ1cAJ6NNLg==",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/expo-constants/node_modules/@expo/env": {
       "version": "2.1.1",
@@ -4614,113 +4514,6 @@
       },
       "engines": {
         "node": ">=20.12.0"
-      }
-    },
-    "node_modules/expo-constants/node_modules/@expo/json-file": {
-      "version": "10.0.12",
-      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-10.0.12.tgz",
-      "integrity": "sha512-inbDycp1rMAelAofg7h/mMzIe+Owx6F7pur3XdQ3EPTy00tme+4P6FWgHKUcjN8dBSrnbRNpSyh5/shzHyVCyQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.20.0",
-        "json5": "^2.2.3"
-      }
-    },
-    "node_modules/expo-constants/node_modules/@expo/plist": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.5.2.tgz",
-      "integrity": "sha512-o4xdVdBpe4aTl3sPMZ2u3fJH4iG1I768EIRk1xRZP+GaFI93MaR3JvoFibYqxeTmLQ1p1kNEVqylfUjezxx45g==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@xmldom/xmldom": "^0.8.8",
-        "base64-js": "^1.5.1",
-        "xmlbuilder": "^15.1.1"
-      }
-    },
-    "node_modules/expo-constants/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/expo-constants/node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/expo-constants/node_modules/glob": {
-      "version": "13.0.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
-      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
-      "license": "BlueOak-1.0.0",
-      "peer": true,
-      "dependencies": {
-        "minimatch": "^10.2.2",
-        "minipass": "^7.1.3",
-        "path-scurry": "^2.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/expo-constants/node_modules/lru-cache": {
-      "version": "11.2.6",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
-      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
-      "license": "BlueOak-1.0.0",
-      "peer": true,
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/expo-constants/node_modules/minimatch": {
-      "version": "10.2.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
-      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
-      "license": "BlueOak-1.0.0",
-      "peer": true,
-      "dependencies": {
-        "brace-expansion": "^5.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/expo-constants/node_modules/path-scurry": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
-      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
-      "license": "BlueOak-1.0.0",
-      "peer": true,
-      "dependencies": {
-        "lru-cache": "^11.0.0",
-        "minipass": "^7.1.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/expo-file-system": {
@@ -5578,9 +5371,9 @@
       }
     },
     "node_modules/jest-util/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -6506,9 +6299,9 @@
       }
     },
     "node_modules/micromatch/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -6676,9 +6469,9 @@
       "license": "MIT"
     },
     "node_modules/node-forge": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.3.tgz",
-      "integrity": "sha512-rLvcdSyRCyouf6jcOIPe/BgwG/d7hKjzMKOas33/pHEr6gbq18IK9zV7DiPvzsz0oBJPme6qr6H6kGZuI9/DZg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
       "license": "(BSD-3-Clause OR GPL-2.0)",
       "engines": {
         "node": ">= 6.13.0"
@@ -7055,9 +6848,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-3.0.1.tgz",
-      "integrity": "sha512-I3EurrIQMlRc9IaAZnqRR044Phh2DXY+55o7uJ0V+hYZAcQYSuFWsc9q5PvyDHUSCe1Qxn/iBz+78s86zWnGag==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-3.0.2.tgz",
+      "integrity": "sha512-cfDHL6LStTEKlNilboNtobT/kEa30PtAf2Q1OgszfrG/rpVl1xaFWT9ktfkS306GmHgmnad1Sw4wabhlvFtsTw==",
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -7470,9 +7263,9 @@
       }
     },
     "node_modules/react-native/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -7718,9 +7511,9 @@
       }
     },
     "node_modules/rimraf/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -8335,9 +8128,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.10",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.10.tgz",
-      "integrity": "sha512-8mOPs1//5q/rlkNSPcCegA6hiHJYDmSLEI8aMH/CdSQJNWztHC9WHNam5zdQlfpTwB9Xp7IBEsHfV5LKMJGVAw==",
+      "version": "7.5.13",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
+      "integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
@@ -8423,9 +8216,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -8544,10 +8337,10 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "devOptional": true,
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -8558,9 +8351,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.23.0.tgz",
-      "integrity": "sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==",
+      "version": "6.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
+      "integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"


### PR DESCRIPTION
Closes dependabot PRs #136, #143, #157, #158, #160, #164 in one consolidated update. All 6 transitive bumps applied via \`npm audit fix\` in \`examples/expo-native/\`.

## Bumps applied

| Package | Before | After | Severity | Closes |
|---|---|---|---|---|
| `@xmldom/xmldom` | 0.8.11 | 0.8.13 | **high** (XML injection / DoS) | #164 |
| `brace-expansion` | <=1.1.12 | 2.1.0 | moderate | #158 |
| `node-forge` | 1.3.3 | 1.4.0 | **high** | #160 |
| `picomatch` | old | 3.0.2 | moderate | #157 |
| `tar` | 7.5.10 | 7.5.13 | — | #136 |
| `undici` | 6.23.0 | 6.25.0 | — | #143 |

## Vulnerability summary
| | Before | After |
|---|---|---|
| critical | 0 | 0 |
| high | many | **0** |
| moderate | many | 11 |
| low | 0 | 0 |

The remaining 11 moderate vulns are deep in expo's transitive deps (postcss, uuid via @expo/cli) and would require an **expo SDK upgrade** (breaking change). Out of scope for this PR.

## Cleanup also done in this batch
**Closed 8 obsolete dependabot PRs** that were already past their target versions in main (after PRs #165–#173 merged):
- #148, #150, #152, #153, #154, #155, #156 — `@vitus-labs/tools-*` and CI bumps already past
- #159 — codeql-action SHA bump to a newer commit on `releases/v4`, but we already pin the latest *tagged* version (v4.35.2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)