### PR TITLE
v2.0.0-alpha.28 — perf + quality overhaul (alpha release)

### DIFF
--- a/.changeset/perf-quality-overhaul.md
+++ b/.changeset/perf-quality-overhaul.md
@@ -1,0 +1,50 @@
+---
+'@vitus-labs/attrs': minor
+'@vitus-labs/connector-emotion': minor
+'@vitus-labs/connector-native': minor
+'@vitus-labs/connector-styled-components': minor
+'@vitus-labs/connector-styler': minor
+'@vitus-labs/coolgrid': minor
+'@vitus-labs/core': minor
+'@vitus-labs/elements': minor
+'@vitus-labs/hooks': minor
+'@vitus-labs/kinetic': minor
+'@vitus-labs/kinetic-presets': minor
+'@vitus-labs/rocketstories': minor
+'@vitus-labs/rocketstyle': minor
+'@vitus-labs/styler': minor
+'@vitus-labs/unistyle': minor
+---
+
+Performance, quality, and maintenance overhaul. No public API changes — every change is internal: type tightening, perf optimizations, and code quality improvements.
+
+**Performance (PR #166)**
+- `unistyle/stripUnit`: regex hoisted to module scope (was compiled per call across 170+ properties × breakpoints)
+- `rocketstyle`: shallow-equal ref pattern replaces per-render string serialization for `useMemo` deps; `getTheme()` mutates `finalTheme` directly (copy-on-write protects `baseTheme`)
+- `coolgrid`: `useGridContext` result memoized
+- `styler`: theme injected via mutate-then-restore (avoids second n-key spread per dynamic render); `prepare()` results cached for SSR `<style precedence>` reuse
+- `attrs/hoc`: fast path when no `.attrs()`/`.priorityAttrs()` configured (skips 3 spread allocations)
+- `hooks/useFocusTrap`: focusable NodeList cached, refreshed via `MutationObserver`
+- `hooks/useBreakpoint`: single rAF-throttled resize listener (was N matchMedia listeners, one per breakpoint)
+- `elements/Element.equalize`: switched to `ResizeObserver` (no more synchronous layout in `useLayoutEffect`)
+- `kinetic/TransitionGroup`: per-key `onAfterLeave` callbacks cached so one child finishing leaving doesn't churn fresh callback props for siblings
+
+**Refactors (PRs #167, #168, #169, #170)**
+- `elements/Iterator`: three render paths unified into a single `ItemSpec` pipeline (240 → 204 lines)
+- `elements/Overlay`: `useOverlay` (858 lines) split into `positionMath`, `useEscapeKey`, `useHoverListeners`, `useScrollReposition` modules
+- `rocketstyle/init`: `@ts-nocheck` removed and replaced with one localized boundary cast; impl made generic so `D`/`UB` propagate
+- `rocketstyle` + `attrs`: 9 internal `any` parameters in chain methods replaced with proper interface types
+
+**Quality (PRs #171, #172)**
+- Lint warnings: 126 → 0 (biome overrides for tests + justified `biome-ignore` comments in source citing every invariant)
+- Coverage gate added at exact baseline — any drop fails CI (statements 98.42% / branches 94.1% / functions 98.45% / lines 99.1%)
+- Bundle size budgets enforced via `size-limit` (CI step + per-package budgets, ~78 KB gzipped total across 15 packages)
+- All 8 source-level `@ts-expect-error` comments now have one-line justifications
+- `@vitus-labs/tools-*` 1.x → 2.x bumped across the monorepo
+
+**Other**
+- Shared `evictMapByPercent` util extracted (`styler/sheet.ts` + `resolve.ts`)
+- Kinetic test fixtures extracted (~300 duplicated lines removed)
+- CLAUDE.md refreshed with audit/refactor learnings
+- All CI action SHAs pinned to latest (harden-runner v2.19.0, setup-node v6.4.0, setup-bun v2.2.0, cache v5.0.5, codeql-action v4.35.2)
+- expo-native security vulns fixed (0 high/critical, was many)

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"d0ee1248-8e14-4dd7-bab2-3ae29cfc3ded","pid":2861,"procStart":"Sat Apr 25 20:20:52 2026","acquiredAt":1777319362152}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"d0ee1248-8e14-4dd7-bab2-3ae29cfc3ded","pid":2861,"procStart":"Sat Apr 25 20:20:52 2026","acquiredAt":1777319362152}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,7 +106,8 @@ jobs:
       - name: Build all packages
         run: bun run pkgs:build
 
-      - name: Publish snapshot
-        run: |
-          bunx changeset version --snapshot alpha
-          bunx changeset publish --tag next
+      - name: Publish prerelease
+        # Versions in `package.json` are bumped manually in the branch (e.g.
+        # 2.0.0-alpha.28). Skip `changeset version` so we don't auto-bump or
+        # rewrite versions; just publish whatever the branch already declares.
+        run: bunx changeset publish --tag next

--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,6 @@ typings/
 
 # dotenv environment variables file
 .env
+
+# Claude Code runtime state (locks). Versioned settings stay tracked.
+.claude/scheduled_tasks.lock

--- a/bun.lock
+++ b/bun.lock
@@ -185,7 +185,7 @@
     },
     "packages/attrs": {
       "name": "@vitus-labs/attrs",
-      "version": "2.0.0-beta.0",
+      "version": "2.0.0-alpha.28",
       "devDependencies": {
         "@vitus-labs/core": "workspace:*",
         "@vitus-labs/elements": "workspace:*",
@@ -194,13 +194,13 @@
         "@vitus-labs/tools-typescript": "2.0.0",
       },
       "peerDependencies": {
-        "@vitus-labs/core": "2.0.0-beta.0",
+        "@vitus-labs/core": "2.0.0-alpha.28",
         "react": ">= 19",
       },
     },
     "packages/connector-emotion": {
       "name": "@vitus-labs/connector-emotion",
-      "version": "2.0.0-beta.0",
+      "version": "2.0.0-alpha.28",
       "devDependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
@@ -215,7 +215,7 @@
     },
     "packages/connector-native": {
       "name": "@vitus-labs/connector-native",
-      "version": "2.0.0-beta.0",
+      "version": "2.0.0-alpha.28",
       "devDependencies": {
         "@vitus-labs/tools-rolldown": "2.0.0",
         "@vitus-labs/tools-typescript": "2.0.0",
@@ -227,7 +227,7 @@
     },
     "packages/connector-styled-components": {
       "name": "@vitus-labs/connector-styled-components",
-      "version": "2.0.0-beta.0",
+      "version": "2.0.0-alpha.28",
       "devDependencies": {
         "@vitus-labs/tools-rolldown": "2.0.0",
         "@vitus-labs/tools-typescript": "2.0.0",
@@ -240,20 +240,20 @@
     },
     "packages/connector-styler": {
       "name": "@vitus-labs/connector-styler",
-      "version": "2.0.0-beta.0",
+      "version": "2.0.0-alpha.28",
       "devDependencies": {
         "@vitus-labs/styler": "workspace:*",
         "@vitus-labs/tools-rolldown": "2.0.0",
         "@vitus-labs/tools-typescript": "2.0.0",
       },
       "peerDependencies": {
-        "@vitus-labs/styler": "2.0.0-beta.0",
+        "@vitus-labs/styler": "2.0.0-alpha.28",
         "react": ">= 19",
       },
     },
     "packages/coolgrid": {
       "name": "@vitus-labs/coolgrid",
-      "version": "2.0.0-beta.0",
+      "version": "2.0.0-alpha.28",
       "devDependencies": {
         "@vitus-labs/core": "workspace:*",
         "@vitus-labs/tools-rolldown": "2.0.0",
@@ -263,8 +263,8 @@
         "react-native": ">=0.84.1",
       },
       "peerDependencies": {
-        "@vitus-labs/core": "2.0.0-beta.0",
-        "@vitus-labs/unistyle": "2.0.0-beta.0",
+        "@vitus-labs/core": "2.0.0-alpha.28",
+        "@vitus-labs/unistyle": "2.0.0-alpha.28",
         "react": ">= 19",
         "react-native": ">= 0.76",
       },
@@ -274,7 +274,7 @@
     },
     "packages/core": {
       "name": "@vitus-labs/core",
-      "version": "2.0.0-beta.0",
+      "version": "2.0.0-alpha.28",
       "dependencies": {
         "react-is": "^19.2.4",
       },
@@ -288,7 +288,7 @@
     },
     "packages/elements": {
       "name": "@vitus-labs/elements",
-      "version": "2.0.0-beta.0",
+      "version": "2.0.0-alpha.28",
       "dependencies": {
         "react-is": "^19.2.4",
       },
@@ -301,8 +301,8 @@
         "@vitus-labs/unistyle": "workspace:*",
       },
       "peerDependencies": {
-        "@vitus-labs/core": "2.0.0-beta.0",
-        "@vitus-labs/unistyle": "2.0.0-beta.0",
+        "@vitus-labs/core": "2.0.0-alpha.28",
+        "@vitus-labs/unistyle": "2.0.0-alpha.28",
         "react": ">= 19",
         "react-dom": ">= 19",
         "react-native": ">= 0.76",
@@ -314,7 +314,7 @@
     },
     "packages/hooks": {
       "name": "@vitus-labs/hooks",
-      "version": "2.0.0-beta.0",
+      "version": "2.0.0-alpha.28",
       "devDependencies": {
         "@vitus-labs/core": "workspace:*",
         "@vitus-labs/tools-rolldown": "2.0.0",
@@ -323,7 +323,7 @@
         "react-native": ">=0.84.1",
       },
       "peerDependencies": {
-        "@vitus-labs/core": "2.0.0-beta.0",
+        "@vitus-labs/core": "2.0.0-alpha.28",
         "react": ">= 19",
         "react-native": ">= 0.76",
       },
@@ -333,7 +333,7 @@
     },
     "packages/kinetic": {
       "name": "@vitus-labs/kinetic",
-      "version": "2.0.0-beta.0",
+      "version": "2.0.0-alpha.28",
       "devDependencies": {
         "@vitus-labs/hooks": "workspace:*",
         "@vitus-labs/tools-rolldown": "2.0.0",
@@ -341,7 +341,7 @@
         "react-native": ">=0.84.1",
       },
       "peerDependencies": {
-        "@vitus-labs/hooks": "2.0.0-beta.0",
+        "@vitus-labs/hooks": "2.0.0-alpha.28",
         "react": ">= 19",
         "react-native": ">= 0.76",
       },
@@ -351,7 +351,7 @@
     },
     "packages/kinetic-presets": {
       "name": "@vitus-labs/kinetic-presets",
-      "version": "2.0.0-beta.0",
+      "version": "2.0.0-alpha.28",
       "devDependencies": {
         "@vitus-labs/tools-rolldown": "2.0.0",
         "@vitus-labs/tools-typescript": "2.0.0",
@@ -362,7 +362,7 @@
     },
     "packages/rocketstories": {
       "name": "@vitus-labs/rocketstories",
-      "version": "2.0.0-beta.0",
+      "version": "2.0.0-alpha.28",
       "dependencies": {
         "@vitus-labs/elements": "workspace:*",
       },
@@ -376,15 +376,15 @@
       },
       "peerDependencies": {
         "@storybook/react": "10.2.8",
-        "@vitus-labs/core": "2.0.0-beta.0",
-        "@vitus-labs/rocketstyle": "2.0.0-beta.0",
-        "@vitus-labs/unistyle": "2.0.0-beta.0",
+        "@vitus-labs/core": "2.0.0-alpha.28",
+        "@vitus-labs/rocketstyle": "2.0.0-alpha.28",
+        "@vitus-labs/unistyle": "2.0.0-alpha.28",
         "react": ">= 19",
       },
     },
     "packages/rocketstyle": {
       "name": "@vitus-labs/rocketstyle",
-      "version": "2.0.0-beta.0",
+      "version": "2.0.0-alpha.28",
       "devDependencies": {
         "@vitus-labs/core": "workspace:*",
         "@vitus-labs/elements": "workspace:*",
@@ -394,13 +394,13 @@
         "@vitus-labs/unistyle": "workspace:*",
       },
       "peerDependencies": {
-        "@vitus-labs/core": "2.0.0-beta.0",
+        "@vitus-labs/core": "2.0.0-alpha.28",
         "react": ">= 19",
       },
     },
     "packages/styler": {
       "name": "@vitus-labs/styler",
-      "version": "2.0.0-beta.0",
+      "version": "2.0.0-alpha.28",
       "devDependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
@@ -415,14 +415,14 @@
     },
     "packages/unistyle": {
       "name": "@vitus-labs/unistyle",
-      "version": "2.0.0-beta.0",
+      "version": "2.0.0-alpha.28",
       "devDependencies": {
         "@vitus-labs/core": "workspace:*",
         "@vitus-labs/tools-rolldown": "2.0.0",
         "@vitus-labs/tools-typescript": "2.0.0",
       },
       "peerDependencies": {
-        "@vitus-labs/core": "2.0.0-beta.0",
+        "@vitus-labs/core": "2.0.0-alpha.28",
         "react": ">= 19",
         "react-native": ">= 0.76",
       },

--- a/bun.lock
+++ b/bun.lock
@@ -185,7 +185,7 @@
     },
     "packages/attrs": {
       "name": "@vitus-labs/attrs",
-      "version": "2.0.0-alpha.28",
+      "version": "2.0.0-alpha.29",
       "devDependencies": {
         "@vitus-labs/core": "workspace:*",
         "@vitus-labs/elements": "workspace:*",
@@ -194,13 +194,13 @@
         "@vitus-labs/tools-typescript": "2.0.0",
       },
       "peerDependencies": {
-        "@vitus-labs/core": "2.0.0-alpha.28",
+        "@vitus-labs/core": "2.0.0-alpha.29",
         "react": ">= 19",
       },
     },
     "packages/connector-emotion": {
       "name": "@vitus-labs/connector-emotion",
-      "version": "2.0.0-alpha.28",
+      "version": "2.0.0-alpha.29",
       "devDependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
@@ -215,7 +215,7 @@
     },
     "packages/connector-native": {
       "name": "@vitus-labs/connector-native",
-      "version": "2.0.0-alpha.28",
+      "version": "2.0.0-alpha.29",
       "devDependencies": {
         "@vitus-labs/tools-rolldown": "2.0.0",
         "@vitus-labs/tools-typescript": "2.0.0",
@@ -227,7 +227,7 @@
     },
     "packages/connector-styled-components": {
       "name": "@vitus-labs/connector-styled-components",
-      "version": "2.0.0-alpha.28",
+      "version": "2.0.0-alpha.29",
       "devDependencies": {
         "@vitus-labs/tools-rolldown": "2.0.0",
         "@vitus-labs/tools-typescript": "2.0.0",
@@ -240,20 +240,20 @@
     },
     "packages/connector-styler": {
       "name": "@vitus-labs/connector-styler",
-      "version": "2.0.0-alpha.28",
+      "version": "2.0.0-alpha.29",
       "devDependencies": {
         "@vitus-labs/styler": "workspace:*",
         "@vitus-labs/tools-rolldown": "2.0.0",
         "@vitus-labs/tools-typescript": "2.0.0",
       },
       "peerDependencies": {
-        "@vitus-labs/styler": "2.0.0-alpha.28",
+        "@vitus-labs/styler": "2.0.0-alpha.29",
         "react": ">= 19",
       },
     },
     "packages/coolgrid": {
       "name": "@vitus-labs/coolgrid",
-      "version": "2.0.0-alpha.28",
+      "version": "2.0.0-alpha.29",
       "devDependencies": {
         "@vitus-labs/core": "workspace:*",
         "@vitus-labs/tools-rolldown": "2.0.0",
@@ -263,8 +263,8 @@
         "react-native": ">=0.84.1",
       },
       "peerDependencies": {
-        "@vitus-labs/core": "2.0.0-alpha.28",
-        "@vitus-labs/unistyle": "2.0.0-alpha.28",
+        "@vitus-labs/core": "2.0.0-alpha.29",
+        "@vitus-labs/unistyle": "2.0.0-alpha.29",
         "react": ">= 19",
         "react-native": ">= 0.76",
       },
@@ -274,7 +274,7 @@
     },
     "packages/core": {
       "name": "@vitus-labs/core",
-      "version": "2.0.0-alpha.28",
+      "version": "2.0.0-alpha.29",
       "dependencies": {
         "react-is": "^19.2.4",
       },
@@ -288,7 +288,7 @@
     },
     "packages/elements": {
       "name": "@vitus-labs/elements",
-      "version": "2.0.0-alpha.28",
+      "version": "2.0.0-alpha.29",
       "dependencies": {
         "react-is": "^19.2.4",
       },
@@ -301,8 +301,8 @@
         "@vitus-labs/unistyle": "workspace:*",
       },
       "peerDependencies": {
-        "@vitus-labs/core": "2.0.0-alpha.28",
-        "@vitus-labs/unistyle": "2.0.0-alpha.28",
+        "@vitus-labs/core": "2.0.0-alpha.29",
+        "@vitus-labs/unistyle": "2.0.0-alpha.29",
         "react": ">= 19",
         "react-dom": ">= 19",
         "react-native": ">= 0.76",
@@ -314,7 +314,7 @@
     },
     "packages/hooks": {
       "name": "@vitus-labs/hooks",
-      "version": "2.0.0-alpha.28",
+      "version": "2.0.0-alpha.29",
       "devDependencies": {
         "@vitus-labs/core": "workspace:*",
         "@vitus-labs/tools-rolldown": "2.0.0",
@@ -323,7 +323,7 @@
         "react-native": ">=0.84.1",
       },
       "peerDependencies": {
-        "@vitus-labs/core": "2.0.0-alpha.28",
+        "@vitus-labs/core": "2.0.0-alpha.29",
         "react": ">= 19",
         "react-native": ">= 0.76",
       },
@@ -333,7 +333,7 @@
     },
     "packages/kinetic": {
       "name": "@vitus-labs/kinetic",
-      "version": "2.0.0-alpha.28",
+      "version": "2.0.0-alpha.29",
       "devDependencies": {
         "@vitus-labs/hooks": "workspace:*",
         "@vitus-labs/tools-rolldown": "2.0.0",
@@ -341,7 +341,7 @@
         "react-native": ">=0.84.1",
       },
       "peerDependencies": {
-        "@vitus-labs/hooks": "2.0.0-alpha.28",
+        "@vitus-labs/hooks": "2.0.0-alpha.29",
         "react": ">= 19",
         "react-native": ">= 0.76",
       },
@@ -351,7 +351,7 @@
     },
     "packages/kinetic-presets": {
       "name": "@vitus-labs/kinetic-presets",
-      "version": "2.0.0-alpha.28",
+      "version": "2.0.0-alpha.29",
       "devDependencies": {
         "@vitus-labs/tools-rolldown": "2.0.0",
         "@vitus-labs/tools-typescript": "2.0.0",
@@ -362,7 +362,7 @@
     },
     "packages/rocketstories": {
       "name": "@vitus-labs/rocketstories",
-      "version": "2.0.0-alpha.28",
+      "version": "2.0.0-alpha.29",
       "dependencies": {
         "@vitus-labs/elements": "workspace:*",
       },
@@ -376,15 +376,15 @@
       },
       "peerDependencies": {
         "@storybook/react": "10.2.8",
-        "@vitus-labs/core": "2.0.0-alpha.28",
-        "@vitus-labs/rocketstyle": "2.0.0-alpha.28",
-        "@vitus-labs/unistyle": "2.0.0-alpha.28",
+        "@vitus-labs/core": "2.0.0-alpha.29",
+        "@vitus-labs/rocketstyle": "2.0.0-alpha.29",
+        "@vitus-labs/unistyle": "2.0.0-alpha.29",
         "react": ">= 19",
       },
     },
     "packages/rocketstyle": {
       "name": "@vitus-labs/rocketstyle",
-      "version": "2.0.0-alpha.28",
+      "version": "2.0.0-alpha.29",
       "devDependencies": {
         "@vitus-labs/core": "workspace:*",
         "@vitus-labs/elements": "workspace:*",
@@ -394,13 +394,13 @@
         "@vitus-labs/unistyle": "workspace:*",
       },
       "peerDependencies": {
-        "@vitus-labs/core": "2.0.0-alpha.28",
+        "@vitus-labs/core": "2.0.0-alpha.29",
         "react": ">= 19",
       },
     },
     "packages/styler": {
       "name": "@vitus-labs/styler",
-      "version": "2.0.0-alpha.28",
+      "version": "2.0.0-alpha.29",
       "devDependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
@@ -415,14 +415,14 @@
     },
     "packages/unistyle": {
       "name": "@vitus-labs/unistyle",
-      "version": "2.0.0-alpha.28",
+      "version": "2.0.0-alpha.29",
       "devDependencies": {
         "@vitus-labs/core": "workspace:*",
         "@vitus-labs/tools-rolldown": "2.0.0",
         "@vitus-labs/tools-typescript": "2.0.0",
       },
       "peerDependencies": {
-        "@vitus-labs/core": "2.0.0-alpha.28",
+        "@vitus-labs/core": "2.0.0-alpha.29",
         "react": ">= 19",
         "react-native": ">= 0.76",
       },

--- a/examples/expo-native/package-lock.json
+++ b/examples/expo-native/package-lock.json
@@ -28,35 +28,35 @@
       },
       "devDependencies": {
         "@types/react": "^19.2.14",
-        "typescript": "~5.9.3"
+        "typescript": "~6.0.3"
       }
     },
     "../../packages/attrs": {
       "name": "@vitus-labs/attrs",
-      "version": "2.0.0-alpha.27",
+      "version": "2.0.0-beta.0",
       "license": "MIT",
       "devDependencies": {
         "@vitus-labs/core": "workspace:*",
         "@vitus-labs/elements": "workspace:*",
-        "@vitus-labs/tools-rolldown": "1.9.1-alpha.19",
-        "@vitus-labs/tools-storybook": "1.9.1-alpha.19",
-        "@vitus-labs/tools-typescript": "1.9.1-alpha.19"
+        "@vitus-labs/tools-rolldown": "2.0.0",
+        "@vitus-labs/tools-storybook": "2.0.0",
+        "@vitus-labs/tools-typescript": "2.0.0"
       },
       "engines": {
         "node": ">= 18"
       },
       "peerDependencies": {
-        "@vitus-labs/core": "2.0.0-alpha.27",
+        "@vitus-labs/core": "2.0.0-beta.0",
         "react": ">= 19"
       }
     },
     "../../packages/connector-native": {
       "name": "@vitus-labs/connector-native",
-      "version": "2.0.0-alpha.27",
+      "version": "2.0.0-beta.0",
       "license": "MIT",
       "devDependencies": {
-        "@vitus-labs/tools-rolldown": "1.9.1-alpha.19",
-        "@vitus-labs/tools-typescript": "1.9.1-alpha.19"
+        "@vitus-labs/tools-rolldown": "2.0.0",
+        "@vitus-labs/tools-typescript": "2.0.0"
       },
       "engines": {
         "node": ">= 18"
@@ -68,22 +68,22 @@
     },
     "../../packages/coolgrid": {
       "name": "@vitus-labs/coolgrid",
-      "version": "2.0.0-alpha.27",
+      "version": "2.0.0-beta.0",
       "license": "MIT",
       "devDependencies": {
         "@vitus-labs/core": "workspace:*",
-        "@vitus-labs/tools-rolldown": "1.9.1-alpha.19",
-        "@vitus-labs/tools-storybook": "1.9.1-alpha.19",
-        "@vitus-labs/tools-typescript": "1.9.1-alpha.19",
+        "@vitus-labs/tools-rolldown": "2.0.0",
+        "@vitus-labs/tools-storybook": "2.0.0",
+        "@vitus-labs/tools-typescript": "2.0.0",
         "@vitus-labs/unistyle": "workspace:*",
-        "react-native": ">=0.76.0"
+        "react-native": ">=0.84.1"
       },
       "engines": {
         "node": ">= 18"
       },
       "peerDependencies": {
-        "@vitus-labs/core": "2.0.0-alpha.27",
-        "@vitus-labs/unistyle": "2.0.0-alpha.27",
+        "@vitus-labs/core": "2.0.0-beta.0",
+        "@vitus-labs/unistyle": "2.0.0-beta.0",
         "react": ">= 19",
         "react-native": ">= 0.76"
       },
@@ -95,14 +95,14 @@
     },
     "../../packages/core": {
       "name": "@vitus-labs/core",
-      "version": "2.0.0-alpha.27",
+      "version": "2.0.0-beta.0",
       "license": "MIT",
       "dependencies": {
         "react-is": "^19.2.4"
       },
       "devDependencies": {
-        "@vitus-labs/tools-rolldown": "1.9.1-alpha.19",
-        "@vitus-labs/tools-typescript": "1.9.1-alpha.19"
+        "@vitus-labs/tools-rolldown": "2.0.0",
+        "@vitus-labs/tools-typescript": "2.0.0"
       },
       "engines": {
         "node": ">= 18"
@@ -113,7 +113,7 @@
     },
     "../../packages/elements": {
       "name": "@vitus-labs/elements",
-      "version": "2.0.0-alpha.27",
+      "version": "2.0.0-beta.0",
       "license": "MIT",
       "dependencies": {
         "react-is": "^19.2.4"
@@ -121,17 +121,17 @@
       "devDependencies": {
         "@vitus-labs/core": "workspace:*",
         "@vitus-labs/rocketstyle": "workspace:*",
-        "@vitus-labs/tools-rolldown": "1.9.1-alpha.19",
-        "@vitus-labs/tools-storybook": "1.9.1-alpha.19",
-        "@vitus-labs/tools-typescript": "1.9.1-alpha.19",
+        "@vitus-labs/tools-rolldown": "2.0.0",
+        "@vitus-labs/tools-storybook": "2.0.0",
+        "@vitus-labs/tools-typescript": "2.0.0",
         "@vitus-labs/unistyle": "workspace:*"
       },
       "engines": {
         "node": ">= 18"
       },
       "peerDependencies": {
-        "@vitus-labs/core": "2.0.0-alpha.27",
-        "@vitus-labs/unistyle": "2.0.0-alpha.27",
+        "@vitus-labs/core": "2.0.0-beta.0",
+        "@vitus-labs/unistyle": "2.0.0-beta.0",
         "react": ">= 19",
         "react-dom": ">= 19",
         "react-native": ">= 0.76"
@@ -147,20 +147,20 @@
     },
     "../../packages/hooks": {
       "name": "@vitus-labs/hooks",
-      "version": "2.0.0-alpha.27",
+      "version": "2.0.0-beta.0",
       "license": "MIT",
       "devDependencies": {
         "@vitus-labs/core": "workspace:*",
-        "@vitus-labs/tools-rolldown": "1.9.1-alpha.19",
-        "@vitus-labs/tools-storybook": "1.9.1-alpha.19",
-        "@vitus-labs/tools-typescript": "1.9.1-alpha.19",
-        "react-native": ">=0.76.0"
+        "@vitus-labs/tools-rolldown": "2.0.0",
+        "@vitus-labs/tools-storybook": "2.0.0",
+        "@vitus-labs/tools-typescript": "2.0.0",
+        "react-native": ">=0.84.1"
       },
       "engines": {
         "node": ">= 18"
       },
       "peerDependencies": {
-        "@vitus-labs/core": "2.0.0-alpha.27",
+        "@vitus-labs/core": "2.0.0-beta.0",
         "react": ">= 19",
         "react-native": ">= 0.76"
       },
@@ -172,19 +172,19 @@
     },
     "../../packages/kinetic": {
       "name": "@vitus-labs/kinetic",
-      "version": "2.0.0-alpha.27",
+      "version": "2.0.0-beta.0",
       "license": "MIT",
       "devDependencies": {
         "@vitus-labs/hooks": "workspace:*",
-        "@vitus-labs/tools-rolldown": "1.9.1-alpha.19",
-        "@vitus-labs/tools-typescript": "1.9.1-alpha.19",
-        "react-native": ">=0.76.0"
+        "@vitus-labs/tools-rolldown": "2.0.0",
+        "@vitus-labs/tools-typescript": "2.0.0",
+        "react-native": ">=0.84.1"
       },
       "engines": {
         "node": ">= 18"
       },
       "peerDependencies": {
-        "@vitus-labs/hooks": "2.0.0-alpha.27",
+        "@vitus-labs/hooks": "2.0.0-beta.0",
         "react": ">= 19",
         "react-native": ">= 0.76"
       },
@@ -196,11 +196,11 @@
     },
     "../../packages/kinetic-presets": {
       "name": "@vitus-labs/kinetic-presets",
-      "version": "2.0.0-alpha.27",
+      "version": "2.0.0-beta.0",
       "license": "MIT",
       "devDependencies": {
-        "@vitus-labs/tools-rolldown": "1.9.1-alpha.19",
-        "@vitus-labs/tools-typescript": "1.9.1-alpha.19"
+        "@vitus-labs/tools-rolldown": "2.0.0",
+        "@vitus-labs/tools-typescript": "2.0.0"
       },
       "peerDependencies": {
         "react": ">= 19"
@@ -208,38 +208,38 @@
     },
     "../../packages/rocketstyle": {
       "name": "@vitus-labs/rocketstyle",
-      "version": "2.0.0-alpha.27",
+      "version": "2.0.0-beta.0",
       "license": "MIT",
       "devDependencies": {
         "@vitus-labs/core": "workspace:*",
         "@vitus-labs/elements": "workspace:*",
-        "@vitus-labs/tools-rolldown": "1.9.1-alpha.19",
-        "@vitus-labs/tools-storybook": "1.9.1-alpha.19",
-        "@vitus-labs/tools-typescript": "1.9.1-alpha.19",
+        "@vitus-labs/tools-rolldown": "2.0.0",
+        "@vitus-labs/tools-storybook": "2.0.0",
+        "@vitus-labs/tools-typescript": "2.0.0",
         "@vitus-labs/unistyle": "workspace:*"
       },
       "engines": {
         "node": ">= 18"
       },
       "peerDependencies": {
-        "@vitus-labs/core": "2.0.0-alpha.27",
+        "@vitus-labs/core": "2.0.0-beta.0",
         "react": ">= 19"
       }
     },
     "../../packages/unistyle": {
       "name": "@vitus-labs/unistyle",
-      "version": "2.0.0-alpha.27",
+      "version": "2.0.0-beta.0",
       "license": "MIT",
       "devDependencies": {
         "@vitus-labs/core": "workspace:*",
-        "@vitus-labs/tools-rolldown": "1.9.1-alpha.19",
-        "@vitus-labs/tools-typescript": "1.9.1-alpha.19"
+        "@vitus-labs/tools-rolldown": "2.0.0",
+        "@vitus-labs/tools-typescript": "2.0.0"
       },
       "engines": {
         "node": ">= 18"
       },
       "peerDependencies": {
-        "@vitus-labs/core": "2.0.0-alpha.27",
+        "@vitus-labs/core": "2.0.0-beta.0",
         "react": ">= 19",
         "react-native": ">= 0.76"
       },
@@ -2133,41 +2133,6 @@
         "xml2js": "0.6.0"
       }
     },
-    "node_modules/@expo/require-utils": {
-      "version": "55.0.2",
-      "resolved": "https://registry.npmjs.org/@expo/require-utils/-/require-utils-55.0.2.tgz",
-      "integrity": "sha512-dV5oCShQ1umKBKagMMT4B/N+SREsQe3lU4Zgmko5AO0rxKV0tynZT6xXs+e2JxuqT4Rz997atg7pki0BnZb4uw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.20.0",
-        "@babel/core": "^7.25.2",
-        "@babel/plugin-transform-modules-commonjs": "^7.24.8"
-      },
-      "peerDependencies": {
-        "typescript": "^5.0.0 || ^5.0.0-0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@expo/require-utils/node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "js-tokens": "^4.0.0",
-        "picocolors": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@expo/schema-utils": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/@expo/schema-utils/-/schema-utils-0.1.8.tgz",
@@ -2721,9 +2686,9 @@
       }
     },
     "node_modules/@react-native/codegen/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -3191,9 +3156,9 @@
       "link": true
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.11.tgz",
-      "integrity": "sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==",
+      "version": "0.8.13",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
+      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -3322,9 +3287,9 @@
       }
     },
     "node_modules/anymatch/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -3658,9 +3623,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -4523,83 +4488,18 @@
       }
     },
     "node_modules/expo-constants": {
-      "version": "55.0.7",
-      "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-55.0.7.tgz",
-      "integrity": "sha512-kdcO4TsQRRqt0USvjaY5vgQMO9H52K3kBZ/ejC7F6rz70mv08GoowrZ1CYOr5O4JpPDRlIpQfZJUucaS/c+KWQ==",
+      "version": "55.0.15",
+      "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-55.0.15.tgz",
+      "integrity": "sha512-w394fcZLJjeKN+9ZnJzL/HiarE1nwZFDa+3S9frevh6Ur+MAAs9QDrcXhDrV8T3xqRzzYaqsP6Z8TFZ4efWN1A==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@expo/config": "~55.0.8",
         "@expo/env": "~2.1.1"
       },
       "peerDependencies": {
         "expo": "*",
         "react-native": "*"
       }
-    },
-    "node_modules/expo-constants/node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "js-tokens": "^4.0.0",
-        "picocolors": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/expo-constants/node_modules/@expo/config": {
-      "version": "55.0.8",
-      "resolved": "https://registry.npmjs.org/@expo/config/-/config-55.0.8.tgz",
-      "integrity": "sha512-D7RYYHfErCgEllGxNwdYdkgzLna7zkzUECBV3snbUpf7RvIpB5l1LpCgzuVoc5KVew5h7N1Tn4LnT/tBSUZsQg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@expo/config-plugins": "~55.0.6",
-        "@expo/config-types": "^55.0.5",
-        "@expo/json-file": "^10.0.12",
-        "@expo/require-utils": "^55.0.2",
-        "deepmerge": "^4.3.1",
-        "getenv": "^2.0.0",
-        "glob": "^13.0.0",
-        "resolve-from": "^5.0.0",
-        "resolve-workspace-root": "^2.0.0",
-        "semver": "^7.6.0",
-        "slugify": "^1.3.4"
-      }
-    },
-    "node_modules/expo-constants/node_modules/@expo/config-plugins": {
-      "version": "55.0.6",
-      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-55.0.6.tgz",
-      "integrity": "sha512-cIox6FjZlFaaX40rbQ3DvP9e87S5X85H9uw+BAxJE5timkMhuByy3GAlOsj1h96EyzSiol7Q6YIGgY1Jiz4M+A==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@expo/config-types": "^55.0.5",
-        "@expo/json-file": "~10.0.12",
-        "@expo/plist": "^0.5.2",
-        "@expo/sdk-runtime-versions": "^1.0.0",
-        "chalk": "^4.1.2",
-        "debug": "^4.3.5",
-        "getenv": "^2.0.0",
-        "glob": "^13.0.0",
-        "resolve-from": "^5.0.0",
-        "semver": "^7.5.4",
-        "slugify": "^1.6.6",
-        "xcode": "^3.0.1",
-        "xml2js": "0.6.0"
-      }
-    },
-    "node_modules/expo-constants/node_modules/@expo/config-types": {
-      "version": "55.0.5",
-      "resolved": "https://registry.npmjs.org/@expo/config-types/-/config-types-55.0.5.tgz",
-      "integrity": "sha512-sCmSUZG4mZ/ySXvfyyBdhjivz8Q539X1NondwDdYG7s3SBsk+wsgPJzYsqgAG/P9+l0xWjUD2F+kQ1cAJ6NNLg==",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/expo-constants/node_modules/@expo/env": {
       "version": "2.1.1",
@@ -4614,113 +4514,6 @@
       },
       "engines": {
         "node": ">=20.12.0"
-      }
-    },
-    "node_modules/expo-constants/node_modules/@expo/json-file": {
-      "version": "10.0.12",
-      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-10.0.12.tgz",
-      "integrity": "sha512-inbDycp1rMAelAofg7h/mMzIe+Owx6F7pur3XdQ3EPTy00tme+4P6FWgHKUcjN8dBSrnbRNpSyh5/shzHyVCyQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.20.0",
-        "json5": "^2.2.3"
-      }
-    },
-    "node_modules/expo-constants/node_modules/@expo/plist": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.5.2.tgz",
-      "integrity": "sha512-o4xdVdBpe4aTl3sPMZ2u3fJH4iG1I768EIRk1xRZP+GaFI93MaR3JvoFibYqxeTmLQ1p1kNEVqylfUjezxx45g==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@xmldom/xmldom": "^0.8.8",
-        "base64-js": "^1.5.1",
-        "xmlbuilder": "^15.1.1"
-      }
-    },
-    "node_modules/expo-constants/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/expo-constants/node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/expo-constants/node_modules/glob": {
-      "version": "13.0.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
-      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
-      "license": "BlueOak-1.0.0",
-      "peer": true,
-      "dependencies": {
-        "minimatch": "^10.2.2",
-        "minipass": "^7.1.3",
-        "path-scurry": "^2.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/expo-constants/node_modules/lru-cache": {
-      "version": "11.2.6",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
-      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
-      "license": "BlueOak-1.0.0",
-      "peer": true,
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/expo-constants/node_modules/minimatch": {
-      "version": "10.2.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
-      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
-      "license": "BlueOak-1.0.0",
-      "peer": true,
-      "dependencies": {
-        "brace-expansion": "^5.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/expo-constants/node_modules/path-scurry": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
-      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
-      "license": "BlueOak-1.0.0",
-      "peer": true,
-      "dependencies": {
-        "lru-cache": "^11.0.0",
-        "minipass": "^7.1.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/expo-file-system": {
@@ -5578,9 +5371,9 @@
       }
     },
     "node_modules/jest-util/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -6506,9 +6299,9 @@
       }
     },
     "node_modules/micromatch/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -6676,9 +6469,9 @@
       "license": "MIT"
     },
     "node_modules/node-forge": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.3.tgz",
-      "integrity": "sha512-rLvcdSyRCyouf6jcOIPe/BgwG/d7hKjzMKOas33/pHEr6gbq18IK9zV7DiPvzsz0oBJPme6qr6H6kGZuI9/DZg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
       "license": "(BSD-3-Clause OR GPL-2.0)",
       "engines": {
         "node": ">= 6.13.0"
@@ -7055,9 +6848,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-3.0.1.tgz",
-      "integrity": "sha512-I3EurrIQMlRc9IaAZnqRR044Phh2DXY+55o7uJ0V+hYZAcQYSuFWsc9q5PvyDHUSCe1Qxn/iBz+78s86zWnGag==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-3.0.2.tgz",
+      "integrity": "sha512-cfDHL6LStTEKlNilboNtobT/kEa30PtAf2Q1OgszfrG/rpVl1xaFWT9ktfkS306GmHgmnad1Sw4wabhlvFtsTw==",
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -7470,9 +7263,9 @@
       }
     },
     "node_modules/react-native/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -7718,9 +7511,9 @@
       }
     },
     "node_modules/rimraf/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -8335,9 +8128,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.10",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.10.tgz",
-      "integrity": "sha512-8mOPs1//5q/rlkNSPcCegA6hiHJYDmSLEI8aMH/CdSQJNWztHC9WHNam5zdQlfpTwB9Xp7IBEsHfV5LKMJGVAw==",
+      "version": "7.5.13",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
+      "integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
@@ -8423,9 +8216,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -8544,10 +8337,10 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "devOptional": true,
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -8558,9 +8351,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.23.0.tgz",
-      "integrity": "sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==",
+      "version": "6.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
+      "integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"

--- a/packages/attrs/package.json
+++ b/packages/attrs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vitus-labs/attrs",
-  "version": "2.0.0-beta.0",
+  "version": "2.0.0-alpha.28",
   "license": "MIT",
   "author": "Vit Bokisch <vit@bokisch.cz>",
   "maintainers": [
@@ -59,7 +59,7 @@
     "version": "node ../../scripts/sync-peer-deps.mjs"
   },
   "peerDependencies": {
-    "@vitus-labs/core": "2.0.0-beta.0",
+    "@vitus-labs/core": "2.0.0-alpha.28",
     "react": ">= 19"
   },
   "devDependencies": {

--- a/packages/attrs/package.json
+++ b/packages/attrs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vitus-labs/attrs",
-  "version": "2.0.0-alpha.28",
+  "version": "2.0.0-alpha.29",
   "license": "MIT",
   "author": "Vit Bokisch <vit@bokisch.cz>",
   "maintainers": [
@@ -59,7 +59,7 @@
     "version": "node ../../scripts/sync-peer-deps.mjs"
   },
   "peerDependencies": {
-    "@vitus-labs/core": "2.0.0-alpha.28",
+    "@vitus-labs/core": "2.0.0-alpha.29",
     "react": ">= 19"
   },
   "devDependencies": {

--- a/packages/connector-emotion/package.json
+++ b/packages/connector-emotion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vitus-labs/connector-emotion",
-  "version": "2.0.0-alpha.28",
+  "version": "2.0.0-alpha.29",
   "license": "MIT",
   "author": "Vit Bokisch <vit@bokisch.cz>",
   "maintainers": [

--- a/packages/connector-emotion/package.json
+++ b/packages/connector-emotion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vitus-labs/connector-emotion",
-  "version": "2.0.0-beta.0",
+  "version": "2.0.0-alpha.28",
   "license": "MIT",
   "author": "Vit Bokisch <vit@bokisch.cz>",
   "maintainers": [

--- a/packages/connector-native/package.json
+++ b/packages/connector-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vitus-labs/connector-native",
-  "version": "2.0.0-alpha.28",
+  "version": "2.0.0-alpha.29",
   "license": "MIT",
   "author": "Vit Bokisch <vit@bokisch.cz>",
   "maintainers": [

--- a/packages/connector-native/package.json
+++ b/packages/connector-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vitus-labs/connector-native",
-  "version": "2.0.0-beta.0",
+  "version": "2.0.0-alpha.28",
   "license": "MIT",
   "author": "Vit Bokisch <vit@bokisch.cz>",
   "maintainers": [

--- a/packages/connector-styled-components/package.json
+++ b/packages/connector-styled-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vitus-labs/connector-styled-components",
-  "version": "2.0.0-beta.0",
+  "version": "2.0.0-alpha.28",
   "license": "MIT",
   "author": "Vit Bokisch <vit@bokisch.cz>",
   "maintainers": [

--- a/packages/connector-styled-components/package.json
+++ b/packages/connector-styled-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vitus-labs/connector-styled-components",
-  "version": "2.0.0-alpha.28",
+  "version": "2.0.0-alpha.29",
   "license": "MIT",
   "author": "Vit Bokisch <vit@bokisch.cz>",
   "maintainers": [

--- a/packages/connector-styler/package.json
+++ b/packages/connector-styler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vitus-labs/connector-styler",
-  "version": "2.0.0-alpha.28",
+  "version": "2.0.0-alpha.29",
   "license": "MIT",
   "author": "Vit Bokisch <vit@bokisch.cz>",
   "maintainers": [
@@ -51,7 +51,7 @@
     "version": "node ../../scripts/sync-peer-deps.mjs"
   },
   "peerDependencies": {
-    "@vitus-labs/styler": "2.0.0-alpha.28",
+    "@vitus-labs/styler": "2.0.0-alpha.29",
     "react": ">= 19"
   },
   "devDependencies": {

--- a/packages/connector-styler/package.json
+++ b/packages/connector-styler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vitus-labs/connector-styler",
-  "version": "2.0.0-beta.0",
+  "version": "2.0.0-alpha.28",
   "license": "MIT",
   "author": "Vit Bokisch <vit@bokisch.cz>",
   "maintainers": [
@@ -51,7 +51,7 @@
     "version": "node ../../scripts/sync-peer-deps.mjs"
   },
   "peerDependencies": {
-    "@vitus-labs/styler": "2.0.0-beta.0",
+    "@vitus-labs/styler": "2.0.0-alpha.28",
     "react": ">= 19"
   },
   "devDependencies": {

--- a/packages/coolgrid/package.json
+++ b/packages/coolgrid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vitus-labs/coolgrid",
-  "version": "2.0.0-beta.0",
+  "version": "2.0.0-alpha.28",
   "license": "MIT",
   "author": "Vit Bokisch <vit@bokisch.cz>",
   "maintainers": [
@@ -62,8 +62,8 @@
     "version": "node ../../scripts/sync-peer-deps.mjs"
   },
   "peerDependencies": {
-    "@vitus-labs/core": "2.0.0-beta.0",
-    "@vitus-labs/unistyle": "2.0.0-beta.0",
+    "@vitus-labs/core": "2.0.0-alpha.28",
+    "@vitus-labs/unistyle": "2.0.0-alpha.28",
     "react": ">= 19",
     "react-native": ">= 0.76"
   },

--- a/packages/coolgrid/package.json
+++ b/packages/coolgrid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vitus-labs/coolgrid",
-  "version": "2.0.0-alpha.28",
+  "version": "2.0.0-alpha.29",
   "license": "MIT",
   "author": "Vit Bokisch <vit@bokisch.cz>",
   "maintainers": [
@@ -62,8 +62,8 @@
     "version": "node ../../scripts/sync-peer-deps.mjs"
   },
   "peerDependencies": {
-    "@vitus-labs/core": "2.0.0-alpha.28",
-    "@vitus-labs/unistyle": "2.0.0-alpha.28",
+    "@vitus-labs/core": "2.0.0-alpha.29",
+    "@vitus-labs/unistyle": "2.0.0-alpha.29",
     "react": ">= 19",
     "react-native": ">= 0.76"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vitus-labs/core",
-  "version": "2.0.0-beta.0",
+  "version": "2.0.0-alpha.28",
   "license": "MIT",
   "author": "Vit Bokisch <vit@bokisch.cz>",
   "maintainers": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vitus-labs/core",
-  "version": "2.0.0-alpha.28",
+  "version": "2.0.0-alpha.29",
   "license": "MIT",
   "author": "Vit Bokisch <vit@bokisch.cz>",
   "maintainers": [

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vitus-labs/elements",
-  "version": "2.0.0-alpha.28",
+  "version": "2.0.0-alpha.29",
   "license": "MIT",
   "author": "Vit Bokisch <vit@bokisch.cz>",
   "maintainers": [
@@ -58,8 +58,8 @@
     "version": "node ../../scripts/sync-peer-deps.mjs"
   },
   "peerDependencies": {
-    "@vitus-labs/core": "2.0.0-alpha.28",
-    "@vitus-labs/unistyle": "2.0.0-alpha.28",
+    "@vitus-labs/core": "2.0.0-alpha.29",
+    "@vitus-labs/unistyle": "2.0.0-alpha.29",
     "react": ">= 19",
     "react-dom": ">= 19",
     "react-native": ">= 0.76"

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vitus-labs/elements",
-  "version": "2.0.0-beta.0",
+  "version": "2.0.0-alpha.28",
   "license": "MIT",
   "author": "Vit Bokisch <vit@bokisch.cz>",
   "maintainers": [
@@ -58,8 +58,8 @@
     "version": "node ../../scripts/sync-peer-deps.mjs"
   },
   "peerDependencies": {
-    "@vitus-labs/core": "2.0.0-beta.0",
-    "@vitus-labs/unistyle": "2.0.0-beta.0",
+    "@vitus-labs/core": "2.0.0-alpha.28",
+    "@vitus-labs/unistyle": "2.0.0-alpha.28",
     "react": ">= 19",
     "react-dom": ">= 19",
     "react-native": ">= 0.76"

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vitus-labs/hooks",
-  "version": "2.0.0-beta.0",
+  "version": "2.0.0-alpha.28",
   "license": "MIT",
   "author": "Vit Bokisch <vit@bokisch.cz>",
   "maintainers": [
@@ -52,7 +52,7 @@
     "node": ">= 18"
   },
   "peerDependencies": {
-    "@vitus-labs/core": "2.0.0-beta.0",
+    "@vitus-labs/core": "2.0.0-alpha.28",
     "react": ">= 19",
     "react-native": ">= 0.76"
   },

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vitus-labs/hooks",
-  "version": "2.0.0-alpha.28",
+  "version": "2.0.0-alpha.29",
   "license": "MIT",
   "author": "Vit Bokisch <vit@bokisch.cz>",
   "maintainers": [
@@ -52,7 +52,7 @@
     "node": ">= 18"
   },
   "peerDependencies": {
-    "@vitus-labs/core": "2.0.0-alpha.28",
+    "@vitus-labs/core": "2.0.0-alpha.29",
     "react": ">= 19",
     "react-native": ">= 0.76"
   },

--- a/packages/kinetic-presets/package.json
+++ b/packages/kinetic-presets/package.json
@@ -4,6 +4,11 @@
   "description": "65+ animation presets, factories, and composition utilities for @vitus-labs/kinetic",
   "license": "MIT",
   "author": "Vit Bokisch <vit@bokisch.cz>",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vitus-labs/ui-system",
+    "directory": "packages/kinetic-presets"
+  },
   "type": "module",
   "sideEffects": false,
   "publishConfig": {

--- a/packages/kinetic-presets/package.json
+++ b/packages/kinetic-presets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vitus-labs/kinetic-presets",
-  "version": "2.0.0-alpha.28",
+  "version": "2.0.0-alpha.29",
   "description": "65+ animation presets, factories, and composition utilities for @vitus-labs/kinetic",
   "license": "MIT",
   "author": "Vit Bokisch <vit@bokisch.cz>",

--- a/packages/kinetic-presets/package.json
+++ b/packages/kinetic-presets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vitus-labs/kinetic-presets",
-  "version": "2.0.0-beta.0",
+  "version": "2.0.0-alpha.28",
   "description": "65+ animation presets, factories, and composition utilities for @vitus-labs/kinetic",
   "license": "MIT",
   "author": "Vit Bokisch <vit@bokisch.cz>",

--- a/packages/kinetic/package.json
+++ b/packages/kinetic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vitus-labs/kinetic",
-  "version": "2.0.0-beta.0",
+  "version": "2.0.0-alpha.28",
   "license": "MIT",
   "author": "Vit Bokisch <vit@bokisch.cz>",
   "maintainers": [
@@ -58,7 +58,7 @@
     "node": ">= 18"
   },
   "peerDependencies": {
-    "@vitus-labs/hooks": "2.0.0-beta.0",
+    "@vitus-labs/hooks": "2.0.0-alpha.28",
     "react": ">= 19",
     "react-native": ">= 0.76"
   },

--- a/packages/kinetic/package.json
+++ b/packages/kinetic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vitus-labs/kinetic",
-  "version": "2.0.0-alpha.28",
+  "version": "2.0.0-alpha.29",
   "license": "MIT",
   "author": "Vit Bokisch <vit@bokisch.cz>",
   "maintainers": [
@@ -58,7 +58,7 @@
     "node": ">= 18"
   },
   "peerDependencies": {
-    "@vitus-labs/hooks": "2.0.0-alpha.28",
+    "@vitus-labs/hooks": "2.0.0-alpha.29",
     "react": ">= 19",
     "react-native": ">= 0.76"
   },

--- a/packages/rocketstories/package.json
+++ b/packages/rocketstories/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vitus-labs/rocketstories",
-  "version": "2.0.0-beta.0",
+  "version": "2.0.0-alpha.28",
   "license": "MIT",
   "author": "Vit Bokisch <vit@bokisch.cz>",
   "maintainers": [
@@ -66,9 +66,9 @@
   },
   "peerDependencies": {
     "@storybook/react": "10.2.8",
-    "@vitus-labs/core": "2.0.0-beta.0",
-    "@vitus-labs/rocketstyle": "2.0.0-beta.0",
-    "@vitus-labs/unistyle": "2.0.0-beta.0",
+    "@vitus-labs/core": "2.0.0-alpha.28",
+    "@vitus-labs/rocketstyle": "2.0.0-alpha.28",
+    "@vitus-labs/unistyle": "2.0.0-alpha.28",
     "react": ">= 19"
   },
   "dependencies": {

--- a/packages/rocketstories/package.json
+++ b/packages/rocketstories/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vitus-labs/rocketstories",
-  "version": "2.0.0-alpha.28",
+  "version": "2.0.0-alpha.29",
   "license": "MIT",
   "author": "Vit Bokisch <vit@bokisch.cz>",
   "maintainers": [
@@ -66,9 +66,9 @@
   },
   "peerDependencies": {
     "@storybook/react": "10.2.8",
-    "@vitus-labs/core": "2.0.0-alpha.28",
-    "@vitus-labs/rocketstyle": "2.0.0-alpha.28",
-    "@vitus-labs/unistyle": "2.0.0-alpha.28",
+    "@vitus-labs/core": "2.0.0-alpha.29",
+    "@vitus-labs/rocketstyle": "2.0.0-alpha.29",
+    "@vitus-labs/unistyle": "2.0.0-alpha.29",
     "react": ">= 19"
   },
   "dependencies": {

--- a/packages/rocketstyle/package.json
+++ b/packages/rocketstyle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vitus-labs/rocketstyle",
-  "version": "2.0.0-beta.0",
+  "version": "2.0.0-alpha.28",
   "license": "MIT",
   "author": "Vit Bokisch <vit@bokisch.cz>",
   "maintainers": [
@@ -65,7 +65,7 @@
     "version": "node ../../scripts/sync-peer-deps.mjs"
   },
   "peerDependencies": {
-    "@vitus-labs/core": "2.0.0-beta.0",
+    "@vitus-labs/core": "2.0.0-alpha.28",
     "react": ">= 19"
   },
   "devDependencies": {

--- a/packages/rocketstyle/package.json
+++ b/packages/rocketstyle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vitus-labs/rocketstyle",
-  "version": "2.0.0-alpha.28",
+  "version": "2.0.0-alpha.29",
   "license": "MIT",
   "author": "Vit Bokisch <vit@bokisch.cz>",
   "maintainers": [
@@ -65,7 +65,7 @@
     "version": "node ../../scripts/sync-peer-deps.mjs"
   },
   "peerDependencies": {
-    "@vitus-labs/core": "2.0.0-alpha.28",
+    "@vitus-labs/core": "2.0.0-alpha.29",
     "react": ">= 19"
   },
   "devDependencies": {

--- a/packages/styler/package.json
+++ b/packages/styler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vitus-labs/styler",
-  "version": "2.0.0-alpha.28",
+  "version": "2.0.0-alpha.29",
   "license": "MIT",
   "author": "Vit Bokisch <vit@bokisch.cz>",
   "maintainers": [

--- a/packages/styler/package.json
+++ b/packages/styler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vitus-labs/styler",
-  "version": "2.0.0-beta.0",
+  "version": "2.0.0-alpha.28",
   "license": "MIT",
   "author": "Vit Bokisch <vit@bokisch.cz>",
   "maintainers": [

--- a/packages/unistyle/package.json
+++ b/packages/unistyle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vitus-labs/unistyle",
-  "version": "2.0.0-alpha.28",
+  "version": "2.0.0-alpha.29",
   "license": "MIT",
   "author": "Vit Bokisch <vit@bokisch.cz>",
   "maintainers": [
@@ -51,7 +51,7 @@
     "node": ">= 18"
   },
   "peerDependencies": {
-    "@vitus-labs/core": "2.0.0-alpha.28",
+    "@vitus-labs/core": "2.0.0-alpha.29",
     "react": ">= 19",
     "react-native": ">= 0.76"
   },

--- a/packages/unistyle/package.json
+++ b/packages/unistyle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vitus-labs/unistyle",
-  "version": "2.0.0-beta.0",
+  "version": "2.0.0-alpha.28",
   "license": "MIT",
   "author": "Vit Bokisch <vit@bokisch.cz>",
   "maintainers": [
@@ -51,7 +51,7 @@
     "node": ">= 18"
   },
   "peerDependencies": {
-    "@vitus-labs/core": "2.0.0-beta.0",
+    "@vitus-labs/core": "2.0.0-alpha.28",
     "react": ">= 19",
     "react-native": ">= 0.76"
   },


### PR DESCRIPTION
## What this is
The next alpha release — `2.0.0-alpha.28`, continuing the alpha sequence that was interrupted by the changesets switch in #147.

## What it includes
All internal improvements landed in PRs #165–#174 (no public API changes):
- **Performance audit** (#166): regex hoisting, ResizeObserver migration, ref-shallow-equal memoization, single-listener resize, etc.
- **Refactors** (#167–#170): Iterator simplification, Overlay split into focused modules, rocketstyle init type cleanup, chain method type tightening
- **Quality** (#171, #172): zero lint warnings, coverage gate at exact baseline, bundle size budgets, justified suppressions
- **Deps** (#173, #174): tools-* → 2.0.0, expo-native security bumps

## Workflow change
The prerelease job no longer runs `changeset version --snapshot alpha`. It just runs `changeset publish --tag next` and respects whatever versions are in `package.json`. This restores the historical "manual version bump in branch, CI publishes" pattern that produced `alpha.21–27` previously.

## Versions
- All 15 `@vitus-labs/*` packages: `2.0.0-beta.0` → `2.0.0-alpha.28`
- Internal `workspace:*` references updated to match
- npm tag: `next`

## Status
- [x] All 2599 tests pass
- [x] 0 type errors
- [x] 0 lint warnings
- [x] All 15 packages build
- [x] Bundle size budgets pass
- [x] CI prerelease job triggered on push — publishing to npm now

## Install
After CI publishes:
```bash
npm install @vitus-labs/styler@next  # 2.0.0-alpha.28
```

## Note about merging
The PR is for **visibility/discussion only** — the alpha is already published by CI on push, not on merge. When this branch eventually merges to main, the included `.changeset/perf-quality-overhaul.md` will trigger a stable Release PR (minor bump → 2.1.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)