### PR TITLE
chore: v2.0.0-beta.1 release

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"d0ee1248-8e14-4dd7-bab2-3ae29cfc3ded","pid":50881,"procStart":"Wed Apr 29 11:38:53 2026","acquiredAt":1777466160538}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"d0ee1248-8e14-4dd7-bab2-3ae29cfc3ded","pid":50881,"procStart":"Wed Apr 29 11:38:53 2026","acquiredAt":1777466160538}

--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,6 @@ typings/
 
 # dotenv environment variables file
 .env
+
+# Claude Code runtime state (locks). Versioned settings stay tracked.
+.claude/scheduled_tasks.lock

--- a/bun.lock
+++ b/bun.lock
@@ -186,7 +186,7 @@
     },
     "packages/attrs": {
       "name": "@vitus-labs/attrs",
-      "version": "2.0.0-beta.0",
+      "version": "2.0.0-beta.1",
       "devDependencies": {
         "@vitus-labs/core": "workspace:*",
         "@vitus-labs/elements": "workspace:*",
@@ -195,13 +195,13 @@
         "@vitus-labs/tools-typescript": "2.1.0",
       },
       "peerDependencies": {
-        "@vitus-labs/core": "2.0.0-beta.0",
+        "@vitus-labs/core": "2.0.0-beta.1",
         "react": ">= 19",
       },
     },
     "packages/connector-emotion": {
       "name": "@vitus-labs/connector-emotion",
-      "version": "2.0.0-beta.0",
+      "version": "2.0.0-beta.1",
       "devDependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
@@ -216,7 +216,7 @@
     },
     "packages/connector-native": {
       "name": "@vitus-labs/connector-native",
-      "version": "2.0.0-beta.0",
+      "version": "2.0.0-beta.1",
       "devDependencies": {
         "@vitus-labs/tools-rolldown": "2.2.0",
         "@vitus-labs/tools-typescript": "2.1.0",
@@ -228,7 +228,7 @@
     },
     "packages/connector-styled-components": {
       "name": "@vitus-labs/connector-styled-components",
-      "version": "2.0.0-beta.0",
+      "version": "2.0.0-beta.1",
       "devDependencies": {
         "@vitus-labs/tools-rolldown": "2.2.0",
         "@vitus-labs/tools-typescript": "2.1.0",
@@ -241,20 +241,20 @@
     },
     "packages/connector-styler": {
       "name": "@vitus-labs/connector-styler",
-      "version": "2.0.0-beta.0",
+      "version": "2.0.0-beta.1",
       "devDependencies": {
         "@vitus-labs/styler": "workspace:*",
         "@vitus-labs/tools-rolldown": "2.2.0",
         "@vitus-labs/tools-typescript": "2.1.0",
       },
       "peerDependencies": {
-        "@vitus-labs/styler": "2.0.0-beta.0",
+        "@vitus-labs/styler": "2.0.0-beta.1",
         "react": ">= 19",
       },
     },
     "packages/coolgrid": {
       "name": "@vitus-labs/coolgrid",
-      "version": "2.0.0-beta.0",
+      "version": "2.0.0-beta.1",
       "devDependencies": {
         "@vitus-labs/core": "workspace:*",
         "@vitus-labs/tools-rolldown": "2.2.0",
@@ -264,8 +264,8 @@
         "react-native": ">=0.84.1",
       },
       "peerDependencies": {
-        "@vitus-labs/core": "2.0.0-beta.0",
-        "@vitus-labs/unistyle": "2.0.0-beta.0",
+        "@vitus-labs/core": "2.0.0-beta.1",
+        "@vitus-labs/unistyle": "2.0.0-beta.1",
         "react": ">= 19",
         "react-native": ">= 0.76",
       },
@@ -275,7 +275,7 @@
     },
     "packages/core": {
       "name": "@vitus-labs/core",
-      "version": "2.0.0-beta.0",
+      "version": "2.0.0-beta.1",
       "dependencies": {
         "react-is": "^19.2.4",
       },
@@ -289,7 +289,7 @@
     },
     "packages/elements": {
       "name": "@vitus-labs/elements",
-      "version": "2.0.0-beta.0",
+      "version": "2.0.0-beta.1",
       "dependencies": {
         "react-is": "^19.2.4",
       },
@@ -302,8 +302,8 @@
         "@vitus-labs/unistyle": "workspace:*",
       },
       "peerDependencies": {
-        "@vitus-labs/core": "2.0.0-beta.0",
-        "@vitus-labs/unistyle": "2.0.0-beta.0",
+        "@vitus-labs/core": "2.0.0-beta.1",
+        "@vitus-labs/unistyle": "2.0.0-beta.1",
         "react": ">= 19",
         "react-dom": ">= 19",
         "react-native": ">= 0.76",
@@ -315,7 +315,7 @@
     },
     "packages/hooks": {
       "name": "@vitus-labs/hooks",
-      "version": "2.0.0-beta.0",
+      "version": "2.0.0-beta.1",
       "devDependencies": {
         "@vitus-labs/core": "workspace:*",
         "@vitus-labs/tools-rolldown": "2.2.0",
@@ -324,7 +324,7 @@
         "react-native": ">=0.84.1",
       },
       "peerDependencies": {
-        "@vitus-labs/core": "2.0.0-beta.0",
+        "@vitus-labs/core": "2.0.0-beta.1",
         "react": ">= 19",
         "react-native": ">= 0.76",
       },
@@ -334,7 +334,7 @@
     },
     "packages/kinetic": {
       "name": "@vitus-labs/kinetic",
-      "version": "2.0.0-beta.0",
+      "version": "2.0.0-beta.1",
       "devDependencies": {
         "@vitus-labs/hooks": "workspace:*",
         "@vitus-labs/tools-rolldown": "2.2.0",
@@ -342,7 +342,7 @@
         "react-native": ">=0.84.1",
       },
       "peerDependencies": {
-        "@vitus-labs/hooks": "2.0.0-beta.0",
+        "@vitus-labs/hooks": "2.0.0-beta.1",
         "react": ">= 19",
         "react-native": ">= 0.76",
       },
@@ -352,7 +352,7 @@
     },
     "packages/kinetic-presets": {
       "name": "@vitus-labs/kinetic-presets",
-      "version": "2.0.0-beta.0",
+      "version": "2.0.0-beta.1",
       "devDependencies": {
         "@vitus-labs/tools-rolldown": "2.2.0",
         "@vitus-labs/tools-typescript": "2.1.0",
@@ -363,7 +363,7 @@
     },
     "packages/rocketstories": {
       "name": "@vitus-labs/rocketstories",
-      "version": "2.0.0-beta.0",
+      "version": "2.0.0-beta.1",
       "dependencies": {
         "@vitus-labs/elements": "workspace:*",
       },
@@ -377,15 +377,15 @@
       },
       "peerDependencies": {
         "@storybook/react": "10.2.8",
-        "@vitus-labs/core": "2.0.0-beta.0",
-        "@vitus-labs/rocketstyle": "2.0.0-beta.0",
-        "@vitus-labs/unistyle": "2.0.0-beta.0",
+        "@vitus-labs/core": "2.0.0-beta.1",
+        "@vitus-labs/rocketstyle": "2.0.0-beta.1",
+        "@vitus-labs/unistyle": "2.0.0-beta.1",
         "react": ">= 19",
       },
     },
     "packages/rocketstyle": {
       "name": "@vitus-labs/rocketstyle",
-      "version": "2.0.0-beta.0",
+      "version": "2.0.0-beta.1",
       "devDependencies": {
         "@vitus-labs/core": "workspace:*",
         "@vitus-labs/elements": "workspace:*",
@@ -395,13 +395,13 @@
         "@vitus-labs/unistyle": "workspace:*",
       },
       "peerDependencies": {
-        "@vitus-labs/core": "2.0.0-beta.0",
+        "@vitus-labs/core": "2.0.0-beta.1",
         "react": ">= 19",
       },
     },
     "packages/styler": {
       "name": "@vitus-labs/styler",
-      "version": "2.0.0-beta.0",
+      "version": "2.0.0-beta.1",
       "devDependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
@@ -416,14 +416,14 @@
     },
     "packages/unistyle": {
       "name": "@vitus-labs/unistyle",
-      "version": "2.0.0-beta.0",
+      "version": "2.0.0-beta.1",
       "devDependencies": {
         "@vitus-labs/core": "workspace:*",
         "@vitus-labs/tools-rolldown": "2.2.0",
         "@vitus-labs/tools-typescript": "2.1.0",
       },
       "peerDependencies": {
-        "@vitus-labs/core": "2.0.0-beta.0",
+        "@vitus-labs/core": "2.0.0-beta.1",
         "react": ">= 19",
         "react-native": ">= 0.76",
       },

--- a/packages/attrs/package.json
+++ b/packages/attrs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vitus-labs/attrs",
-  "version": "2.0.0-beta.0",
+  "version": "2.0.0-beta.1",
   "license": "MIT",
   "author": "Vit Bokisch <vit@bokisch.cz>",
   "maintainers": [
@@ -59,7 +59,7 @@
     "version": "node ../../scripts/sync-peer-deps.mjs"
   },
   "peerDependencies": {
-    "@vitus-labs/core": "2.0.0-beta.0",
+    "@vitus-labs/core": "2.0.0-beta.1",
     "react": ">= 19"
   },
   "devDependencies": {

--- a/packages/connector-emotion/package.json
+++ b/packages/connector-emotion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vitus-labs/connector-emotion",
-  "version": "2.0.0-beta.0",
+  "version": "2.0.0-beta.1",
   "license": "MIT",
   "author": "Vit Bokisch <vit@bokisch.cz>",
   "maintainers": [

--- a/packages/connector-native/package.json
+++ b/packages/connector-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vitus-labs/connector-native",
-  "version": "2.0.0-beta.0",
+  "version": "2.0.0-beta.1",
   "license": "MIT",
   "author": "Vit Bokisch <vit@bokisch.cz>",
   "maintainers": [

--- a/packages/connector-styled-components/package.json
+++ b/packages/connector-styled-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vitus-labs/connector-styled-components",
-  "version": "2.0.0-beta.0",
+  "version": "2.0.0-beta.1",
   "license": "MIT",
   "author": "Vit Bokisch <vit@bokisch.cz>",
   "maintainers": [

--- a/packages/connector-styler/package.json
+++ b/packages/connector-styler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vitus-labs/connector-styler",
-  "version": "2.0.0-beta.0",
+  "version": "2.0.0-beta.1",
   "license": "MIT",
   "author": "Vit Bokisch <vit@bokisch.cz>",
   "maintainers": [
@@ -51,7 +51,7 @@
     "version": "node ../../scripts/sync-peer-deps.mjs"
   },
   "peerDependencies": {
-    "@vitus-labs/styler": "2.0.0-beta.0",
+    "@vitus-labs/styler": "2.0.0-beta.1",
     "react": ">= 19"
   },
   "devDependencies": {

--- a/packages/coolgrid/package.json
+++ b/packages/coolgrid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vitus-labs/coolgrid",
-  "version": "2.0.0-beta.0",
+  "version": "2.0.0-beta.1",
   "license": "MIT",
   "author": "Vit Bokisch <vit@bokisch.cz>",
   "maintainers": [
@@ -62,8 +62,8 @@
     "version": "node ../../scripts/sync-peer-deps.mjs"
   },
   "peerDependencies": {
-    "@vitus-labs/core": "2.0.0-beta.0",
-    "@vitus-labs/unistyle": "2.0.0-beta.0",
+    "@vitus-labs/core": "2.0.0-beta.1",
+    "@vitus-labs/unistyle": "2.0.0-beta.1",
     "react": ">= 19",
     "react-native": ">= 0.76"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vitus-labs/core",
-  "version": "2.0.0-beta.0",
+  "version": "2.0.0-beta.1",
   "license": "MIT",
   "author": "Vit Bokisch <vit@bokisch.cz>",
   "maintainers": [

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vitus-labs/elements",
-  "version": "2.0.0-beta.0",
+  "version": "2.0.0-beta.1",
   "license": "MIT",
   "author": "Vit Bokisch <vit@bokisch.cz>",
   "maintainers": [
@@ -58,8 +58,8 @@
     "version": "node ../../scripts/sync-peer-deps.mjs"
   },
   "peerDependencies": {
-    "@vitus-labs/core": "2.0.0-beta.0",
-    "@vitus-labs/unistyle": "2.0.0-beta.0",
+    "@vitus-labs/core": "2.0.0-beta.1",
+    "@vitus-labs/unistyle": "2.0.0-beta.1",
     "react": ">= 19",
     "react-dom": ">= 19",
     "react-native": ">= 0.76"

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vitus-labs/hooks",
-  "version": "2.0.0-beta.0",
+  "version": "2.0.0-beta.1",
   "license": "MIT",
   "author": "Vit Bokisch <vit@bokisch.cz>",
   "maintainers": [
@@ -52,7 +52,7 @@
     "node": ">= 18"
   },
   "peerDependencies": {
-    "@vitus-labs/core": "2.0.0-beta.0",
+    "@vitus-labs/core": "2.0.0-beta.1",
     "react": ">= 19",
     "react-native": ">= 0.76"
   },

--- a/packages/kinetic-presets/package.json
+++ b/packages/kinetic-presets/package.json
@@ -4,6 +4,11 @@
   "description": "65+ animation presets, factories, and composition utilities for @vitus-labs/kinetic",
   "license": "MIT",
   "author": "Vit Bokisch <vit@bokisch.cz>",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vitus-labs/ui-system",
+    "directory": "packages/kinetic-presets"
+  },
   "type": "module",
   "sideEffects": false,
   "publishConfig": {

--- a/packages/kinetic-presets/package.json
+++ b/packages/kinetic-presets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vitus-labs/kinetic-presets",
-  "version": "2.0.0-beta.0",
+  "version": "2.0.0-beta.1",
   "description": "65+ animation presets, factories, and composition utilities for @vitus-labs/kinetic",
   "license": "MIT",
   "author": "Vit Bokisch <vit@bokisch.cz>",

--- a/packages/kinetic/package.json
+++ b/packages/kinetic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vitus-labs/kinetic",
-  "version": "2.0.0-beta.0",
+  "version": "2.0.0-beta.1",
   "license": "MIT",
   "author": "Vit Bokisch <vit@bokisch.cz>",
   "maintainers": [
@@ -58,7 +58,7 @@
     "node": ">= 18"
   },
   "peerDependencies": {
-    "@vitus-labs/hooks": "2.0.0-beta.0",
+    "@vitus-labs/hooks": "2.0.0-beta.1",
     "react": ">= 19",
     "react-native": ">= 0.76"
   },

--- a/packages/rocketstories/package.json
+++ b/packages/rocketstories/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vitus-labs/rocketstories",
-  "version": "2.0.0-beta.0",
+  "version": "2.0.0-beta.1",
   "license": "MIT",
   "author": "Vit Bokisch <vit@bokisch.cz>",
   "maintainers": [
@@ -66,9 +66,9 @@
   },
   "peerDependencies": {
     "@storybook/react": "10.2.8",
-    "@vitus-labs/core": "2.0.0-beta.0",
-    "@vitus-labs/rocketstyle": "2.0.0-beta.0",
-    "@vitus-labs/unistyle": "2.0.0-beta.0",
+    "@vitus-labs/core": "2.0.0-beta.1",
+    "@vitus-labs/rocketstyle": "2.0.0-beta.1",
+    "@vitus-labs/unistyle": "2.0.0-beta.1",
     "react": ">= 19"
   },
   "dependencies": {

--- a/packages/rocketstyle/package.json
+++ b/packages/rocketstyle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vitus-labs/rocketstyle",
-  "version": "2.0.0-beta.0",
+  "version": "2.0.0-beta.1",
   "license": "MIT",
   "author": "Vit Bokisch <vit@bokisch.cz>",
   "maintainers": [
@@ -65,7 +65,7 @@
     "version": "node ../../scripts/sync-peer-deps.mjs"
   },
   "peerDependencies": {
-    "@vitus-labs/core": "2.0.0-beta.0",
+    "@vitus-labs/core": "2.0.0-beta.1",
     "react": ">= 19"
   },
   "devDependencies": {

--- a/packages/styler/package.json
+++ b/packages/styler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vitus-labs/styler",
-  "version": "2.0.0-beta.0",
+  "version": "2.0.0-beta.1",
   "license": "MIT",
   "author": "Vit Bokisch <vit@bokisch.cz>",
   "maintainers": [

--- a/packages/unistyle/package.json
+++ b/packages/unistyle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vitus-labs/unistyle",
-  "version": "2.0.0-beta.0",
+  "version": "2.0.0-beta.1",
   "license": "MIT",
   "author": "Vit Bokisch <vit@bokisch.cz>",
   "maintainers": [
@@ -51,7 +51,7 @@
     "node": ">= 18"
   },
   "peerDependencies": {
-    "@vitus-labs/core": "2.0.0-beta.0",
+    "@vitus-labs/core": "2.0.0-beta.1",
     "react": ">= 19",
     "react-native": ">= 0.76"
   },


### PR DESCRIPTION
Bumps all 15 packages from \`2.0.0-beta.0\` to **\`2.0.0-beta.1\`**.

\`beta.0\` was the previous beta cut on npm; this rolls forward with all the perf, quality, refactor, and dep work that landed since.

## What's in this beta vs beta.0
| PR | Topic |
|---|---|
| #166 | Performance audit fixes (regex hoist, ResizeObserver, single rAF resize listener, …) |
| #167 | Iterator → single \`ItemSpec\` pipeline |
| #168 | Overlay \`useOverlay\` split into focused modules |
| #169 | \`rocketstyle/init.ts\` \`@ts-nocheck\` removed |
| #170 | Chain method parameter types tightened |
| #171 | Shared utils, kinetic test fixtures, \`size-limit\` CI gate |
| #172 | Zero lint warnings, coverage gate, justified suppressions |
| #173, #177 | Deps to latest (tools-\* 2.2.0 / 2.1.0 for tools-typescript, jsdom 29.1.0) |
| #174 | expo-native security bumps |
| #176 | expo-native upgraded to SDK 55 |

Same content as \`2.0.0-alpha.29\` (already published to \`@next\`), promoted to a beta tier to signal "production-quality candidate".

## What happens on push
Branch matches \`release/**\` → CI's prerelease job publishes all 15 packages to npm with \`next\` tag.

## How to test
\`\`\`bash
npm install @vitus-labs/styler@2.0.0-beta.1
# or
npm install @vitus-labs/styler@next
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)