### PR TITLE
fix(styler): drop SSR double-emit, hydrate cache from <style precedence>

### DIFF
--- a/packages/styler/src/__tests__/sheet-precedence-hydration.test.ts
+++ b/packages/styler/src/__tests__/sheet-precedence-hydration.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Tests for cache hydration from React 19 `<style data-precedence>` tags.
+ *
+ * The bug this guards against: when SSR emits CSS via `<style precedence>`
+ * (the default path), the client-side `mount()` previously only scanned
+ * `<style[data-vl]>` for hydration. The cache started empty, so the first
+ * `useInsertionEffect` cache-missed and re-injected every rule into a fresh
+ * `data-vl` sheet — leaving every rule duplicated in the DOM.
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { hash } from '../hash'
+import { createSheet } from '../sheet'
+
+const cleanHead = () => {
+  document
+    .querySelectorAll('style[data-vl], style[data-precedence]')
+    .forEach((el) => {
+      el.remove()
+    })
+}
+
+const addPrecedenceTag = (
+  href: string,
+  cssText: string,
+  precedence = 'medium',
+) => {
+  const el = document.createElement('style')
+  el.setAttribute('data-precedence', precedence)
+  el.setAttribute('data-href', href)
+  el.textContent = cssText
+  document.head.appendChild(el)
+  return el
+}
+
+describe('StyleSheet — hydration from <style data-precedence> tags', () => {
+  beforeEach(cleanHead)
+  afterEach(cleanHead)
+
+  it('populates cache from a `vl-` prefixed precedence tag', () => {
+    addPrecedenceTag('vl-abc123', '.vl-abc123{color:red}')
+    const s = createSheet()
+    expect(s.has('vl-abc123')).toBe(true)
+  })
+
+  it('populates cache from a `g-` prefixed precedence tag (createGlobalStyle)', () => {
+    addPrecedenceTag('g-xyz789', 'body{margin:0}', 'low')
+    const s = createSheet()
+    expect(s.has('g-xyz789')).toBe(true)
+  })
+
+  it('ignores precedence tags with unrelated prefixes', () => {
+    addPrecedenceTag('other-foo', '.other-foo{color:red}')
+    const s = createSheet()
+    expect(s.has('other-foo')).toBe(false)
+  })
+
+  it('ignores precedence tags missing a data-href', () => {
+    const el = document.createElement('style')
+    el.setAttribute('data-precedence', 'medium')
+    el.textContent = '.vl-noid{color:red}'
+    document.head.appendChild(el)
+    const s = createSheet()
+    expect(s.cacheSize).toBe(0)
+  })
+
+  it('hydrates multiple precedence tags in one mount', () => {
+    addPrecedenceTag('vl-a', '.vl-a{color:red}')
+    addPrecedenceTag('vl-b', '.vl-b{color:blue}')
+    addPrecedenceTag('g-c', 'html{font-size:16px}')
+    const s = createSheet()
+    expect(s.has('vl-a')).toBe(true)
+    expect(s.has('vl-b')).toBe(true)
+    expect(s.has('g-c')).toBe(true)
+  })
+})
+
+describe('StyleSheet — insert() after precedence hydration', () => {
+  beforeEach(cleanHead)
+  afterEach(cleanHead)
+
+  it('insert() of a hydrated rule does NOT inject a duplicate into the data-vl sheet', () => {
+    const cssText = 'color:red;'
+    const className = `vl-${hash(cssText)}`
+
+    addPrecedenceTag(className, `.${className}{${cssText}}`)
+    const s = createSheet()
+    expect(s.has(className)).toBe(true)
+
+    const returned = s.insert(cssText)
+    expect(returned).toBe(className)
+
+    // Look up the data-vl sheet — must not contain the rule
+    const dataVl = document.querySelector(
+      'style[data-vl]',
+    ) as HTMLStyleElement | null
+    const dataVlRules = dataVl?.sheet
+      ? Array.from(dataVl.sheet.cssRules).map((r) => r.cssText)
+      : []
+    expect(dataVlRules.some((r) => r.includes(`.${className}`))).toBe(false)
+  })
+
+  it('insertGlobal() of a hydrated rule does NOT inject a duplicate', () => {
+    const cssText = 'body{margin:0}'
+    const key = `g-${hash(cssText)}`
+
+    addPrecedenceTag(key, cssText, 'low')
+    const s = createSheet()
+    expect(s.has(key)).toBe(true)
+
+    s.insertGlobal(cssText)
+
+    const dataVl = document.querySelector(
+      'style[data-vl]',
+    ) as HTMLStyleElement | null
+    const dataVlRules = dataVl?.sheet
+      ? Array.from(dataVl.sheet.cssRules).map((r) => r.cssText)
+      : []
+    // The body rule should not have been re-inserted into our data-vl sheet
+    expect(
+      dataVlRules.some((r) => r.includes('margin') && r.includes('0')),
+    ).toBe(false)
+  })
+
+  it('insert() of an UN-hydrated rule still injects normally', () => {
+    addPrecedenceTag('vl-known', '.vl-known{color:red}')
+    const s = createSheet()
+
+    // A different CSS text — not in the cache from precedence hydration
+    const cls = s.insert('color:blue;')
+    expect(cls).not.toBe('vl-known')
+
+    const dataVl = document.querySelector(
+      'style[data-vl]',
+    ) as HTMLStyleElement | null
+    const dataVlRules = dataVl?.sheet
+      ? Array.from(dataVl.sheet.cssRules).map((r) => r.cssText)
+      : []
+    expect(dataVlRules.some((r) => r.includes(`.${cls}`))).toBe(true)
+  })
+})

--- a/packages/styler/src/__tests__/ssr-hydration-roundtrip.test.tsx
+++ b/packages/styler/src/__tests__/ssr-hydration-roundtrip.test.tsx
@@ -1,0 +1,226 @@
+/**
+ * End-to-end SSR ↔ hydration roundtrip:
+ *   1. Render a styled component to an HTML string with renderToString
+ *   2. Mount that HTML into the document head/body to simulate hydration state
+ *   3. Re-import sheet (so its constructor runs with the hydrated DOM in place)
+ *   4. Render the SAME component on the client
+ *   5. Assert: no rule appears twice across all `<style>` elements
+ *
+ * Before the precedence-hydration fix, step 5 failed: every rule was present
+ * once in the React-emitted `<style data-precedence>` tag *and* a second time
+ * in the freshly-mounted `<style data-vl>` sheet.
+ */
+import { render } from '@testing-library/react'
+import { createElement } from 'react'
+import { renderToString } from 'react-dom/server'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const cleanHead = () => {
+  document
+    .querySelectorAll('style[data-vl], style[data-precedence]')
+    .forEach((el) => {
+      el.remove()
+    })
+}
+
+/**
+ * Run `fn` with `globalThis.document` deleted so any imported module's
+ * `IS_SERVER` check evaluates true. Always restores document, even on throw —
+ * a leaked deletion would crash the next test's beforeEach/afterEach.
+ */
+const runAsSSR = async <T,>(fn: () => Promise<T>): Promise<T> => {
+  const original = globalThis.document
+  // @ts-expect-error - SSR simulation
+  delete globalThis.document
+  try {
+    return await fn()
+  } finally {
+    globalThis.document = original
+  }
+}
+
+/** Walk every `<style>` element in the document, return all CSS rule texts. */
+const collectAllRules = (): string[] => {
+  const rules: string[] = []
+  document.querySelectorAll('style').forEach((el) => {
+    if (!el.sheet) return
+    for (let i = 0; i < el.sheet.cssRules.length; i++) {
+      rules.push(el.sheet.cssRules[i]!.cssText)
+    }
+  })
+  return rules
+}
+
+const countRulesMatching = (predicate: (rule: string) => boolean): number =>
+  collectAllRules().filter(predicate).length
+
+describe('SSR → client hydration roundtrip — no duplicate rules', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    cleanHead()
+  })
+
+  afterEach(() => {
+    cleanHead()
+    vi.resetModules()
+  })
+
+  it('static styled component: rule appears exactly once after hydration', async () => {
+    // 1. SSR phase: import styled fresh with `document` deleted
+    const html = await runAsSSR(async () => {
+      const { styled: ssrStyled } = await import('../styled')
+      const SSRComp = ssrStyled('div')`color: red;`
+      // renderToString must be called inside the SSR window so
+      // useInsertionEffect resolves to its server no-op variant.
+      return renderToString(createElement(SSRComp, null, 'hi'))
+    })
+
+    // 2. Inject the SSR HTML into the document head as if React just hydrated
+    document.head.insertAdjacentHTML('beforeend', html)
+
+    // Sanity: a <style data-precedence> tag with our class is now in the head
+    const precedenceTags = document.head.querySelectorAll(
+      'style[data-precedence][data-href^="vl-"]',
+    )
+    expect(precedenceTags.length).toBe(1)
+    const ssrClassName = precedenceTags[0]!.getAttribute('data-href')!
+    expect(ssrClassName).toMatch(/^vl-/)
+
+    // 3. Fresh sheet import — its constructor mounts and hydrates from the
+    //    precedence tag we just inserted
+    vi.resetModules()
+    const { sheet } = await import('../sheet')
+    expect(sheet.has(ssrClassName)).toBe(true)
+
+    // 4. Client-render the same component (same template literal text, so
+    //    same className). useInsertionEffect runs and *would* re-insert the
+    //    rule if the cache hadn't been hydrated.
+    const { styled: clientStyled } = await import('../styled')
+    const ClientComp = clientStyled('div')`color: red;`
+    render(<ClientComp />)
+
+    // 5. The rule must appear exactly once across the whole document
+    const occurrences = countRulesMatching(
+      (r) => r.includes(`.${ssrClassName}`) && r.includes('color: red'),
+    )
+    expect(occurrences).toBe(1)
+  })
+
+  it('dynamic styled component: rule appears exactly once after hydration', async () => {
+    const html = await runAsSSR(async () => {
+      const { styled: ssrStyled } = await import('../styled')
+      const { ThemeProvider: SSRTP } = await import('../ThemeProvider')
+      const SSRComp = ssrStyled('div')`color: ${(p: any) => p.$c};`
+      return renderToString(
+        <SSRTP theme={{}}>
+          <SSRComp $c="red" />
+        </SSRTP>,
+      )
+    })
+
+    document.head.insertAdjacentHTML('beforeend', html)
+
+    const precedenceTags = document.head.querySelectorAll(
+      'style[data-precedence][data-href^="vl-"]',
+    )
+    expect(precedenceTags.length).toBe(1)
+    const ssrClassName = precedenceTags[0]!.getAttribute('data-href')!
+
+    vi.resetModules()
+    const { sheet } = await import('../sheet')
+    expect(sheet.has(ssrClassName)).toBe(true)
+
+    const { styled: clientStyled } = await import('../styled')
+    const { ThemeProvider } = await import('../ThemeProvider')
+    const ClientComp = clientStyled('div')`color: ${(p: any) => p.$c};`
+    render(
+      <ThemeProvider theme={{}}>
+        <ClientComp $c="red" />
+      </ThemeProvider>,
+    )
+
+    const occurrences = countRulesMatching(
+      (r) => r.includes(`.${ssrClassName}`) && r.includes('color: red'),
+    )
+    expect(occurrences).toBe(1)
+  })
+
+  it('createGlobalStyle: rule appears exactly once after hydration', async () => {
+    const html = await runAsSSR(async () => {
+      const { createGlobalStyle: ssrCreateGlobalStyle } = await import(
+        '../globalStyle'
+      )
+      const SSRGlobal = ssrCreateGlobalStyle`body { margin: 0; }`
+      return renderToString(createElement(SSRGlobal))
+    })
+
+    document.head.insertAdjacentHTML('beforeend', html)
+
+    const precedenceTags = document.head.querySelectorAll(
+      'style[data-precedence][data-href^="g-"]',
+    )
+    expect(precedenceTags.length).toBe(1)
+    const ssrHref = precedenceTags[0]!.getAttribute('data-href')!
+    expect(ssrHref).toMatch(/^g-/)
+
+    vi.resetModules()
+    const { sheet } = await import('../sheet')
+    expect(sheet.has(ssrHref)).toBe(true)
+
+    const { createGlobalStyle: clientCreateGlobalStyle } = await import(
+      '../globalStyle'
+    )
+    const ClientGlobal = clientCreateGlobalStyle`body { margin: 0; }`
+    render(<ClientGlobal />)
+
+    const occurrences = countRulesMatching(
+      (r) => r.includes('body') && r.includes('margin') && r.includes('0'),
+    )
+    expect(occurrences).toBe(1)
+  })
+
+  it('mixed scoped + global: each rule appears exactly once', async () => {
+    const { componentHtml, globalHtml } = await runAsSSR(async () => {
+      const { styled: ssrStyled } = await import('../styled')
+      const { createGlobalStyle: ssrCreateGlobalStyle } = await import(
+        '../globalStyle'
+      )
+      const SSRComp = ssrStyled('div')`color: red;`
+      const SSRGlobal = ssrCreateGlobalStyle`body { margin: 0; }`
+      return {
+        componentHtml: renderToString(createElement(SSRComp, null, 'hi')),
+        globalHtml: renderToString(createElement(SSRGlobal)),
+      }
+    })
+
+    document.head.insertAdjacentHTML('beforeend', componentHtml + globalHtml)
+
+    vi.resetModules()
+    await import('../sheet') // trigger mount + hydrate
+
+    const { styled: clientStyled } = await import('../styled')
+    const { createGlobalStyle: clientCreateGlobalStyle } = await import(
+      '../globalStyle'
+    )
+    const ClientComp = clientStyled('div')`color: red;`
+    const ClientGlobal = clientCreateGlobalStyle`body { margin: 0; }`
+
+    render(
+      <>
+        <ClientGlobal />
+        <ClientComp />
+      </>,
+    )
+
+    expect(
+      countRulesMatching(
+        (r) => r.includes('color: red') && r.match(/^\.vl-/) !== null,
+      ),
+    ).toBe(1)
+    expect(
+      countRulesMatching(
+        (r) => r.includes('body') && r.includes('margin') && r.includes('0'),
+      ),
+    ).toBe(1)
+  })
+})

--- a/packages/styler/src/globalStyle.ts
+++ b/packages/styler/src/globalStyle.ts
@@ -38,11 +38,14 @@ export const createGlobalStyle = (
     const cssText = normalizeCSS(resolve(strings, values, {}))
     const href = cssText.trim() ? `g-${hash(cssText)}` : ''
 
-    // Inject into sheet. Client: insertRule() into shared sheet. SSR: ssrBuffer.
-    if (cssText.trim()) sheet.insertGlobal(cssText)
+    // Client only: inject into shared sheet. On SSR we deliberately do NOT
+    // call sheet.insertGlobal() — that would push duplicates into ssrBuffer
+    // and the same rule would also re-insert via insertRule() on hydration
+    // (cache miss → DOM duplication). React 19 dedupes <style precedence>
+    // emissions automatically, so a single precedence tag is sufficient.
+    if (!IS_SERVER && cssText.trim()) sheet.insertGlobal(cssText)
 
     // SSR: pre-compute <style precedence> for FOUC-free delivery.
-    // Client: CSS already injected via sheet.insertGlobal() above.
     const cachedStyleEl =
       IS_SERVER && href
         ? createElement('style', { href, precedence: 'low' }, cssText)
@@ -69,9 +72,9 @@ export const createGlobalStyle = (
 
     if (!href) return null
 
-    // SSR: render <style precedence> for FOUC-free delivery
+    // SSR: render <style precedence> for FOUC-free delivery. We deliberately
+    // do NOT push to ssrBuffer here — see static-path comment above.
     if (IS_SERVER) {
-      sheet.insertGlobal(cssText)
       return createElement('style', { href, precedence: 'low' }, cssText)
     }
 

--- a/packages/styler/src/sheet.ts
+++ b/packages/styler/src/sheet.ts
@@ -56,6 +56,13 @@ export class StyleSheet {
       this.sheet = el.sheet ?? null
     }
 
+    // Hydrate from React 19 `<style precedence data-href="…">` tags emitted
+    // during SSR. The default SSR path is precedence-only, so without this
+    // step the cache would miss on first client render and `insert()` would
+    // duplicate every rule into the `data-vl` sheet — visible as doubled
+    // styles in the DOM.
+    this.hydrateFromPrecedenceTags()
+
     // Inject @layer declaration if configured
     if (this.layer && this.sheet) {
       try {
@@ -64,6 +71,25 @@ export class StyleSheet {
         // skip if @layer not supported
       }
     }
+  }
+
+  /**
+   * Populate the dedup cache from React 19's `<style data-precedence data-href>`
+   * tags. The `data-href` is the same shape we'd compute client-side
+   * (`vl-<hash>` for component styles, `g-<hash>` for globals), so a Map
+   * pre-population is sufficient — no need to re-parse the cssText.
+   */
+  private hydrateFromPrecedenceTags() {
+    const tags = document.querySelectorAll<HTMLStyleElement>(
+      'style[data-precedence][data-href]',
+    )
+    tags.forEach((el) => {
+      const href = el.getAttribute('data-href')
+      if (!href) return
+      if (href.startsWith(`${PREFIX}-`) || href.startsWith('g-')) {
+        this.cache.set(href, href)
+      }
+    })
   }
 
   /** Extract className from a selector like ".vl-abc" or ".vl-abc.vl-abc" → "vl-abc" */
@@ -311,7 +337,10 @@ export class StyleSheet {
   /** Insert global CSS rules (no wrapper selector). Deduplicates by hash. */
   insertGlobal(cssText: string): void {
     const h = hash(cssText)
-    const key = `global-${h}`
+    // Cache key matches the `data-href` shape emitted by createGlobalStyle's
+    // <style precedence> tag, so SSR hydration via `hydrateFromPrecedenceTags`
+    // can populate this same key and prevent duplicate insertion on the client.
+    const key = `g-${h}`
 
     if (this.cache.has(key)) return
 
@@ -343,13 +372,25 @@ export class StyleSheet {
     }
   }
 
-  /** Returns collected CSS for SSR as a complete `<style>` tag string. */
+  /**
+   * Returns collected CSS for SSR as a complete `<style>` tag string.
+   *
+   * NOTE: With the default React 19 `<style precedence>` SSR path, this
+   * buffer is **empty** — components emit their own precedence tags inline,
+   * which React collects and dedupes automatically. This API is retained as
+   * an opt-in "manual mode" for callers that explicitly push rules into the
+   * buffer (e.g. legacy SSR pipelines via direct `sheet.insert(cssText)`
+   * calls outside of render).
+   */
   getStyleTag(): string {
     const css = this.ssrBuffer.join('').replace(/<\/style/gi, '<\\/style')
     return `<style ${ATTR}="">${css}</style>`
   }
 
-  /** Returns collected CSS rules as a raw string (useful for streaming SSR). */
+  /**
+   * Returns collected CSS rules as a raw string (useful for streaming SSR).
+   * See `getStyleTag` for caveats — empty unless rules were pushed manually.
+   */
   getStyles(): string {
     return this.ssrBuffer.join('')
   }

--- a/packages/styler/src/styled.ts
+++ b/packages/styler/src/styled.ts
@@ -113,10 +113,14 @@ const createStyledComponent = (
     if (!hasCss) {
       staticClassName = ''
     } else if (IS_SERVER) {
-      // SSR: need both className + rules for <style precedence> element
+      // SSR: emit a single <style precedence> element. We deliberately do NOT
+      // call `sheet.insert()` here — that would push duplicate rules into the
+      // ssrBuffer and, after the client hydrates from <style data-precedence>
+      // tags, the same rule would also get re-inserted via insertRule() on
+      // first render (cache miss → DOM duplication). React 19 collects and
+      // dedupes <style precedence> emissions automatically.
       const prepared = sheet.prepare(cssText, boost)
       staticClassName = prepared.className
-      sheet.insert(cssText, boost)
       cachedStyleEl = createElement(
         'style',
         { href: staticClassName, precedence: 'medium' },
@@ -195,10 +199,11 @@ const createStyledComponent = (
       // Cache miss — recompute
       if (cssText.length > 0) {
         if (IS_SERVER) {
-          // SSR: compute rules for <style precedence>, inject into ssrBuffer
+          // SSR: emit a <style precedence> element only. See the matching
+          // comment in the static path above for why we don't push to
+          // ssrBuffer here — TL;DR: it would duplicate on hydration.
           const prepared = sheet.prepare(cssText, boost)
           className = prepared.className
-          sheet.insert(cssText, boost)
           styleEl = createElement(
             'style',
             { href: prepared.className, precedence: 'medium' },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -15,10 +15,10 @@ export default defineConfig({
       // Bump these up when coverage improves so we never silently lose
       // what we've gained.
       thresholds: {
-        statements: 98.41,
-        branches: 94.22,
-        functions: 98.45,
-        lines: 99.1,
+        statements: 98.56,
+        branches: 94.31,
+        functions: 98.46,
+        lines: 99.29,
       },
     },
   },


### PR DESCRIPTION
## Summary

- The default React 19 SSR path emits CSS via `<style precedence>`, but `StyleSheet.mount()` only scanned `<style[data-vl]>` for hydration. The cache started empty on first paint, so the first `useInsertionEffect` cache-missed and re-injected every rule into a fresh `data-vl` sheet — every rule appeared **twice** in the DOM after hydration.
- This PR drops the redundant `ssrBuffer` push from the SSR branches of `styled` / `createGlobalStyle` (React 19 dedupes precedence emissions automatically), and pre-populates the dedup cache from `<style[data-precedence][data-href]>` tags during `mount()` so the cache hits before any duplicate gets injected.
- Two new test files cover both the unit-level mount/insert dedup logic and a full SSR ↔ client hydration roundtrip that asserts each rule appears exactly once across the whole document.

## Why double-emission existed

`styled()` and `createGlobalStyle()` were doing both:
1. emitting `<style precedence>` (collected + deduped by React 19), AND
2. pushing the same rules into `ssrBuffer` (intended for the optional `getStyleTag()` manual-mode pipeline)

…with the assumption that the client would re-use whichever surface arrived. After hydration, neither was a no-op:
- the `<style[data-precedence]>` tag is in the DOM but its `data-href` was never reflected in `StyleSheet.cache`
- `useInsertionEffect` cache-missed, hashed the cssText again, and called `insertRule()` into a freshly created `<style[data-vl]>` sheet
- result: rule lives in two `<style>` elements at once

## Changes

**Fix:**
- `packages/styler/src/styled.ts` — remove `sheet.insert()` calls from both static and dynamic SSR branches (React 19 handles dedup via `<style precedence>`)
- `packages/styler/src/globalStyle.ts` — same cleanup for both paths in `createGlobalStyle`
- `packages/styler/src/sheet.ts`:
  - new `hydrateFromPrecedenceTags()` walks `style[data-precedence][data-href^="vl-"]` and `data-href^="g-"` and pre-populates the dedup cache
  - `insertGlobal()` cache key shape aligned to `g-<hash>` so the precedence hydration is the same code path as for component styles
  - `getStyleTag` / `getStyles` JSDoc updated to reflect they're "manual mode" utilities now

**Tests:**
- `sheet-precedence-hydration.test.ts` — unit tests: `mount()` populates cache from `vl-` and `g-` precedence tags, ignores unrelated/missing hrefs, and `insert` / `insertGlobal` of a hydrated rule does NOT inject a duplicate
- `ssr-hydration-roundtrip.test.tsx` — e2e: render to string with `react-dom/server`, inject the HTML into the document head, fresh `sheet` import (so `mount()` runs against the hydrated DOM), client-render the same component, then assert each rule appears exactly once across every `<style>` element. Covers static styled, dynamic styled, `createGlobalStyle`, and a mixed case.

**Coverage:**
- Thresholds in `vitest.config.ts` bumped to the new baseline (98.56% statements / 94.31% branches / 98.46% functions / 99.29% lines) so any future regression fails CI.

## Test plan

- [x] `bun run test` — 132 files / 2614 tests pass
- [x] `bun run lint` — clean
- [x] `bun run typecheck` — all 15 packages clean
- [x] `bun run pkgs:build` — all 15 packages build
- [x] `bun run size` — all packages under their gzipped budgets
- [x] root coverage gate satisfied (98.56 / 94.31 / 98.46 / 99.29)

🤖 Generated with [Claude Code](https://claude.com/claude-code)