### PR TITLE
feat(unistyle): per-breakpoint CSS delta optimization (experiment)

### DIFF
--- a/packages/unistyle/src/__tests__/makeItResponsive.test.ts
+++ b/packages/unistyle/src/__tests__/makeItResponsive.test.ts
@@ -284,4 +284,80 @@ describe('makeItResponsive', () => {
     // Should return array with empty string since media is undefined
     expect(Array.isArray(result)).toBe(true)
   })
+
+  describe('per-breakpoint delta optimization', () => {
+    const providerTheme = {
+      rootSize: 16,
+      breakpoints: { xs: 0, sm: 576, md: 768 },
+      __VITUS_LABS__: {
+        sortedBreakpoints: ['xs', 'sm', 'md'],
+        media: {
+          xs: (...args: any[]) => (css as any)(...args),
+          sm: (...args: any[]) =>
+            css`@media (min-width: 36em) { ${(css as any)(...args)} }`,
+          md: (...args: any[]) =>
+            css`@media (min-width: 48em) { ${(css as any)(...args)} }`,
+        },
+      },
+    }
+
+    it('drops unchanged declarations in subsequent breakpoints (mobile-first cascade)', () => {
+      // styles callback that emits 2 declarations from theme values
+      const stringStyles = ({ theme: t }: any) =>
+        `color: ${t.color}; padding: ${t.padding};`
+
+      const fn = makeItResponsive({
+        key: '$test',
+        css,
+        styles: stringStyles as any,
+      })
+      const result = fn({
+        theme: providerTheme,
+        $test: {
+          // color same across all breakpoints; padding changes only at md
+          color: 'red',
+          padding: { xs: '0', sm: '0', md: '1rem' },
+        },
+      })
+      expect(Array.isArray(result)).toBe(true)
+      const flat = (result as any[]).map((r) => String(r)).join(' ')
+
+      // The xs (base) breakpoint emits both declarations
+      expect(flat).toContain('color: red')
+      expect(flat).toContain('padding: 0')
+
+      // padding: 1rem appears for md (changed)
+      expect(flat).toContain('padding: 1rem')
+
+      // color: red should appear exactly once — sm/md should not re-emit it
+      const colorOccurrences = flat.match(/color:\s*red/g) ?? []
+      expect(colorOccurrences.length).toBe(1)
+
+      // padding: 0 should also appear exactly once (xs only — sm dropped)
+      const paddingZeroOccurrences =
+        flat.match(/padding:\s*0(?![.\drem%])/g) ?? []
+      expect(paddingZeroOccurrences.length).toBe(1)
+    })
+
+    it('falls back to unoptimized path when a styles callback result is not stringifiable', () => {
+      // Styles callback returning a plain object whose default toString
+      // resolves to "[object Object]" — triggers the safety bail-out and
+      // exercises the engine-agnostic fallback.
+      const opaqueStyles = () => ({ notACssResult: true }) as any
+
+      const fn = makeItResponsive({
+        key: '$test',
+        css,
+        styles: opaqueStyles,
+      })
+      const result = fn({
+        theme: providerTheme,
+        $test: { color: 'red' },
+      })
+      // Even on the fallback path the function still returns an array
+      // (one entry per breakpoint, possibly engine-wrapped).
+      expect(Array.isArray(result)).toBe(true)
+      expect((result as any[]).length).toBe(3)
+    })
+  })
 })

--- a/packages/unistyle/src/__tests__/optimizeBreakpointDeltas.test.ts
+++ b/packages/unistyle/src/__tests__/optimizeBreakpointDeltas.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, it } from 'vitest'
+import { optimizeBreakpointDeltas } from '../responsive/optimizeBreakpointDeltas'
+
+/** Trim + collapse internal whitespace for stable comparisons. */
+const norm = (s: string) => s.trim().replace(/\s+/g, ' ')
+
+describe('optimizeBreakpointDeltas', () => {
+  describe('passthrough', () => {
+    it('returns input unchanged when only one breakpoint', () => {
+      expect(optimizeBreakpointDeltas(['color: red;'])).toEqual(['color: red;'])
+    })
+
+    it('returns input unchanged when empty', () => {
+      expect(optimizeBreakpointDeltas([])).toEqual([])
+    })
+
+    it('preserves the first breakpoint exactly (modulo canonical formatting)', () => {
+      const [base] = optimizeBreakpointDeltas([
+        'color: red; padding: 0;',
+        'color: red;',
+      ])
+      expect(norm(base!)).toBe('color: red; padding: 0;')
+    })
+  })
+
+  describe('declaration deltas', () => {
+    it('drops declarations whose value matches the cascade', () => {
+      const [, sm] = optimizeBreakpointDeltas([
+        'color: red; padding: 0;',
+        'color: red; padding: 1rem;',
+      ])
+      expect(norm(sm!)).toBe('padding: 1rem;')
+    })
+
+    it('emits a declaration when its value differs from the cascade', () => {
+      const [, sm] = optimizeBreakpointDeltas(['color: red;', 'color: blue;'])
+      expect(norm(sm!)).toBe('color: blue;')
+    })
+
+    it('updates the cascade so a later breakpoint only emits new deltas', () => {
+      const [, sm, md] = optimizeBreakpointDeltas([
+        'color: red;',
+        'color: blue;',
+        'color: blue;', // matches sm now → drop
+      ])
+      expect(norm(sm!)).toBe('color: blue;')
+      expect(md).toBe('')
+    })
+
+    it('handles values containing colons (URLs, pseudo-args)', () => {
+      const [, sm] = optimizeBreakpointDeltas([
+        'background: url(http://example.com/a.png);',
+        'background: url(http://example.com/b.png);',
+      ])
+      expect(norm(sm!)).toBe('background: url(http://example.com/b.png);')
+    })
+
+    it('handles values containing commas inside parens', () => {
+      const [, sm] = optimizeBreakpointDeltas([
+        'background: linear-gradient(red 0%, blue 100%);',
+        'background: linear-gradient(red 0%, blue 100%);',
+      ])
+      expect(sm).toBe('')
+    })
+
+    it('handles values containing quoted semicolons', () => {
+      const [, sm] = optimizeBreakpointDeltas([
+        'content: ";";',
+        'content: ";";',
+      ])
+      expect(sm).toBe('')
+    })
+
+    it('does not trip on malformed empty declarations', () => {
+      const [first] = optimizeBreakpointDeltas(['color: red;;;', 'color: red;'])
+      expect(norm(first!)).toContain('color: red;')
+    })
+
+    it('preserves declarations whose prop or value would be empty after trim', () => {
+      // ":foo;" → empty prop (colonIdx = 0), "bar:;" → empty value.
+      // Neither parses as a declaration; both pass through as opaque so
+      // a future cascade pass doesn't accidentally drop them.
+      const [out] = optimizeBreakpointDeltas([
+        ':foo; bar:;',
+        'color: red;', // second arg keeps us out of the length<=1 fast path
+      ])
+      expect(norm(out!)).toContain(':foo;')
+      expect(norm(out!)).toContain('bar:;')
+    })
+
+    it('handles escaped characters inside quoted strings', () => {
+      // The backslash in `content: "\""` must not end the quote prematurely.
+      const [, sm] = optimizeBreakpointDeltas([
+        'content: "\\"";',
+        'content: "\\"";',
+      ])
+      expect(sm).toBe('')
+    })
+
+    it('keeps unbalanced trailing input as opaque (malformed CSS guard)', () => {
+      // Missing closing brace — the trailing segment lives at depth > 0 and
+      // must survive intact rather than be dropped.
+      const [out] = optimizeBreakpointDeltas([
+        'color: red; &:hover { color: blue;',
+        'color: red;',
+      ])
+      expect(out).toContain('color: red')
+      expect(out).toContain('&:hover')
+      expect(out).toContain('color: blue')
+    })
+  })
+
+  describe('opaque blocks (nested selectors / at-rules)', () => {
+    it('keeps a nested block when not previously seen', () => {
+      const [base] = optimizeBreakpointDeltas([
+        'color: red; &:hover { color: blue; }',
+      ])
+      expect(norm(base!)).toContain('&:hover { color: blue; }')
+    })
+
+    it('dedupes a nested block by exact text match', () => {
+      const [, sm] = optimizeBreakpointDeltas([
+        '&:hover { color: blue; }',
+        '&:hover { color: blue; }',
+      ])
+      expect(sm).toBe('')
+    })
+
+    it('keeps a nested block whose body changes', () => {
+      const [, sm] = optimizeBreakpointDeltas([
+        '&:hover { color: blue; }',
+        '&:hover { color: green; }',
+      ])
+      expect(norm(sm!)).toContain('&:hover { color: green; }')
+    })
+
+    it('mixes declarations and blocks correctly', () => {
+      const [base, sm] = optimizeBreakpointDeltas([
+        'color: red; &:hover { color: blue; } padding: 0;',
+        'color: red; &:hover { color: blue; } padding: 1rem;',
+      ])
+      expect(norm(base!)).toContain('color: red;')
+      expect(norm(base!)).toContain('&:hover { color: blue; }')
+      expect(norm(base!)).toContain('padding: 0;')
+      expect(norm(sm!)).toBe('padding: 1rem;')
+    })
+  })
+
+  describe("user's responsive Wrapper sample (mobile-first cascade)", () => {
+    it('reproduces the expected delta output for the reported case', () => {
+      // Same shape the user reported (re-ordered mobile-first).
+      const xs = [
+        'position: absolute;',
+        'bottom: -4.375rem;',
+        'right: -12.5rem;',
+        'height: 28.75rem;',
+      ].join(' ')
+      const sm = [
+        'position: absolute;',
+        'bottom: -4.375rem;',
+        'right: -11.25rem;',
+        'height: 28.75rem;',
+      ].join(' ')
+      const md = [
+        'position: absolute;',
+        'bottom: 0px;',
+        'right: -11.25rem;',
+        'height: 40rem;',
+      ].join(' ')
+      const lg = [
+        'position: absolute;',
+        'bottom: 0px;',
+        'right: -6.25rem;',
+        'height: 40rem;',
+      ].join(' ')
+      const xl = [
+        'position: absolute;',
+        'bottom: 0px;',
+        'left: 55%;',
+        'right: initial;',
+        'height: 40rem;',
+      ].join(' ')
+
+      const [outXs, outSm, outMd, outLg, outXl] = optimizeBreakpointDeltas([
+        xs,
+        sm,
+        md,
+        lg,
+        xl,
+      ])
+
+      // xs gets everything (it's the base)
+      expect(norm(outXs!)).toContain('position: absolute;')
+      expect(norm(outXs!)).toContain('bottom: -4.375rem;')
+      expect(norm(outXs!)).toContain('right: -12.5rem;')
+      expect(norm(outXs!)).toContain('height: 28.75rem;')
+
+      // sm only changes `right`
+      expect(norm(outSm!)).toBe('right: -11.25rem;')
+
+      // md changes `bottom` and `height` (right unchanged from sm)
+      expect(norm(outMd!)).toBe('bottom: 0px; height: 40rem;')
+
+      // lg only changes `right`
+      expect(norm(outLg!)).toBe('right: -6.25rem;')
+
+      // xl introduces `left`, resets `right`, no other changes
+      expect(norm(outXl!)).toBe('left: 55%; right: initial;')
+    })
+  })
+})

--- a/packages/unistyle/src/responsive/makeItResponsive.ts
+++ b/packages/unistyle/src/responsive/makeItResponsive.ts
@@ -2,9 +2,29 @@ import { isEmpty } from '@vitus-labs/core'
 import type { Css } from '~/types'
 import type createMediaQueries from './createMediaQueries'
 import normalizeTheme from './normalizeTheme'
+import optimizeBreakpointDeltas from './optimizeBreakpointDeltas'
 import optimizeTheme from './optimizeTheme'
 import type sortBreakpoints from './sortBreakpoints'
 import transformTheme from './transformTheme'
+
+/**
+ * Coerce a styles-callback result to a CSS string for delta optimization.
+ * Returns null when the engine's result type can't be stringified cleanly
+ * (e.g. Emotion / styled-components objects whose default toString() yields
+ * "[object Object]") — caller falls back to the unoptimized path.
+ *
+ * Styler's CSSResult provides toString() that resolves with empty props,
+ * so any function interpolation that needs render-time props must come from
+ * the styles-callback closure (theme is destructured at call time, not
+ * resolved later). Verified across the project's styles callbacks.
+ */
+const stringifyResult = (result: unknown): string | null => {
+  if (result == null) return ''
+  if (typeof result === 'string') return result
+  const text = String(result)
+  // Default Object.prototype.toString → "[object Foo]" — bail out.
+  return text.includes('[object ') ? null : text
+}
 
 type CustomTheme = Record<
   string,
@@ -117,6 +137,28 @@ const makeItResponsive: MakeItResponsive =
       themeCache.set(internalTheme, {
         breakpoints: sortedBreakpoints,
         optimized: optimizedTheme,
+      })
+    }
+
+    // Resolve each per-breakpoint render to a string so the delta optimizer
+    // can diff at the property level. If any breakpoint's result can't be
+    // cleanly stringified (foreign engine result), fall back to the original
+    // unoptimized path that lets the engine resolve interpolations itself.
+    const renderedTexts: (string | null)[] = sortedBreakpoints.map(
+      (item: string) => {
+        const breakpointTheme = optimizedTheme[item]
+        if (!breakpointTheme || !media) return ''
+        return stringifyResult(renderStyles(breakpointTheme))
+      },
+    )
+
+    const canOptimize = renderedTexts.every((t) => t !== null)
+    if (canOptimize) {
+      const deltas = optimizeBreakpointDeltas(renderedTexts as string[])
+      return sortedBreakpoints.map((item: string, i: number) => {
+        const css = deltas[i]
+        if (!css || !media) return ''
+        return (media as Record<string, any>)[item]`${css}`
       })
     }
 

--- a/packages/unistyle/src/responsive/optimizeBreakpointDeltas.ts
+++ b/packages/unistyle/src/responsive/optimizeBreakpointDeltas.ts
@@ -1,0 +1,193 @@
+/**
+ * Mobile-first cascade optimizer.
+ *
+ * Given an ordered array of CSS strings (one per breakpoint, smallest first),
+ * returns a parallel array where each non-base breakpoint contains only the
+ * declarations that DIFFER from the cumulative cascade so far. This relies on
+ * mobile-first `@media (min-width: …)` semantics: properties set at smaller
+ * breakpoints inherit at larger ones, so re-emitting an unchanged property is
+ * pure byte waste.
+ *
+ * Example:
+ *   ["color: red; padding: 0;", "color: red; padding: 1rem;"]
+ *   → ["color: red; padding: 0;", "padding: 1rem;"]
+ *
+ * Top-level declarations are diffed by `prop:value`. Selector blocks
+ * (`&:hover { … }`, `@supports { … }`) are treated as opaque and deduped by
+ * exact text. Anything inside parens or quoted strings is skipped over so
+ * `linear-gradient(red 0%, blue 100%)` and `content: ";"` parse correctly.
+ *
+ * Limitations:
+ *  - shorthand/longhand interaction is not modeled. If breakpoint A sets
+ *    `padding: 1rem` and breakpoint B sets `padding-top: 0`, both are kept
+ *    (they have different `prop` keys). If A sets `padding-top: 1rem` and B
+ *    sets `padding: 1rem`, B's `padding` is emitted because the cascade map
+ *    has no entry for `padding`. This is correct: B's shorthand RESETS sides
+ *    A didn't touch, so dropping it would change behaviour.
+ *  - Nested blocks are deduped only by exact textual match. Two equivalent
+ *    blocks with different whitespace would both be emitted.
+ */
+
+interface DeclEntry {
+  kind: 'decl'
+  prop: string
+  value: string
+  raw: string // canonical "prop: value;" form
+}
+
+interface BlockEntry {
+  kind: 'block'
+  raw: string // entire "selector { body }" or stray block
+}
+
+type Entry = DeclEntry | BlockEntry
+
+/** Parse a CSS string into top-level declarations and opaque blocks. */
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: single-pass CSS parser — depth/paren/quote tracking inlined for perf
+const parse = (css: string): Entry[] => {
+  const entries: Entry[] = []
+  const len = css.length
+
+  let depth = 0
+  let parenDepth = 0
+  let quote = 0 // charCode of active quote (0 if none)
+  let segmentStart = 0
+
+  const pushSegment = (rawSegment: string) => {
+    const trimmed = rawSegment.trim()
+    if (!trimmed) return
+    // pushSegment is only reached for segments that ended with a top-level
+    // ";" — full "selector { ... }" blocks are captured separately by the
+    // brace walker, so this path always sees declarations (or malformed
+    // declaration-shaped fragments).
+    const text = trimmed.endsWith(';') ? trimmed.slice(0, -1) : trimmed
+    const colonIdx = text.indexOf(':')
+    if (colonIdx <= 0) {
+      // No ":" or starts with ":" → not a parseable declaration; keep raw
+      entries.push({ kind: 'block', raw: `${text};` })
+      return
+    }
+    const prop = text.slice(0, colonIdx).trim()
+    const value = text.slice(colonIdx + 1).trim()
+    if (!prop || !value) {
+      entries.push({ kind: 'block', raw: `${text};` })
+      return
+    }
+    entries.push({
+      kind: 'decl',
+      prop,
+      value,
+      raw: `${prop}: ${value};`,
+    })
+  }
+
+  for (let i = 0; i < len; i++) {
+    const code = css.charCodeAt(i)
+
+    // Inside a quoted string — skip until matching quote (ignoring escapes)
+    if (quote !== 0) {
+      if (code === 92 /* \ */) {
+        i++ // skip the next character
+      } else if (code === quote) {
+        quote = 0
+      }
+      continue
+    }
+
+    // Quote start
+    if (code === 34 /* " */ || code === 39 /* ' */) {
+      quote = code
+      continue
+    }
+
+    // Parens — content (e.g. linear-gradient args) shouldn't be interpreted
+    if (code === 40 /* ( */) {
+      parenDepth++
+      continue
+    }
+    if (code === 41 /* ) */) {
+      if (parenDepth > 0) parenDepth--
+      continue
+    }
+    if (parenDepth > 0) continue
+
+    if (code === 123 /* { */) {
+      depth++
+      continue
+    }
+    if (code === 125 /* } */) {
+      depth--
+      if (depth === 0) {
+        // End of a top-level block — capture from segmentStart..i (inclusive)
+        const raw = css.slice(segmentStart, i + 1).trim()
+        if (raw) entries.push({ kind: 'block', raw })
+        segmentStart = i + 1
+      }
+      continue
+    }
+
+    if (depth === 0 && code === 59 /* ; */) {
+      pushSegment(css.slice(segmentStart, i))
+      segmentStart = i + 1
+    }
+  }
+
+  // Trailing segment (no terminating semicolon)
+  if (segmentStart < len) {
+    const trailing = css.slice(segmentStart).trim()
+    if (trailing) {
+      if (depth > 0) {
+        // Unbalanced braces — keep the rest as opaque so output isn't lossy
+        entries.push({ kind: 'block', raw: trailing })
+      } else {
+        pushSegment(trailing)
+      }
+    }
+  }
+
+  return entries
+}
+
+/**
+ * Apply the mobile-first cascade diff. The first entry passes through
+ * unchanged; subsequent entries are pruned to the delta vs. the running
+ * cascade (declarations by prop, blocks by exact text match).
+ */
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: hot-path cascade walker — declaration/block branches + cascade map updates inlined for perf
+export const optimizeBreakpointDeltas = (cssStrings: string[]): string[] => {
+  if (cssStrings.length <= 1) return cssStrings
+
+  const cascadeDecl = new Map<string, string>()
+  const cascadeBlocks = new Set<string>()
+  const out: string[] = new Array(cssStrings.length)
+
+  for (let i = 0; i < cssStrings.length; i++) {
+    // biome-ignore lint/style/noNonNullAssertion: bounds checked by loop condition
+    const css = cssStrings[i]!
+    if (!css) {
+      out[i] = ''
+      continue
+    }
+
+    const entries = parse(css)
+    const kept: string[] = []
+
+    for (const e of entries) {
+      if (e.kind === 'decl') {
+        if (cascadeDecl.get(e.prop) !== e.value) {
+          kept.push(e.raw)
+          cascadeDecl.set(e.prop, e.value)
+        }
+      } else if (!cascadeBlocks.has(e.raw)) {
+        kept.push(e.raw)
+        cascadeBlocks.add(e.raw)
+      }
+    }
+
+    out[i] = kept.join(' ')
+  }
+
+  return out
+}
+
+export default optimizeBreakpointDeltas

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -15,10 +15,10 @@ export default defineConfig({
       // Bump these up when coverage improves so we never silently lose
       // what we've gained.
       thresholds: {
-        statements: 98.56,
-        branches: 94.31,
-        functions: 98.46,
-        lines: 99.29,
+        statements: 98.58,
+        branches: 94.32,
+        functions: 98.47,
+        lines: 99.31,
       },
     },
   },


### PR DESCRIPTION
## Summary

Property-level mobile-first cascade optimizer for `makeItResponsive`. Each `@media` now only emits declarations that actually change vs. the running cascade — no more re-emitting `position: absolute;` at every breakpoint just because one neighbour changed.

Marked as an experiment because the diff happens at the CSS-string layer (post-render) and falls back to the unoptimized path for any engine result we can't cleanly stringify. Worth a careful real-world soak before we lean on it.

## Before vs. after — your reported sample

**Before** (5 breakpoints, 21 declarations across all `@media` blocks):
```css
@media (min-width: 90em) { position: absolute; bottom: 0; left: 55%; right: initial; height: 40rem; }
@media (min-width: 62em) { position: absolute; bottom: 0; right: -6.25rem; height: 40rem; }
@media (min-width: 48em) { position: absolute; bottom: 0; right: -11.25rem; height: 40rem; }
@media (min-width: 36em) { position: absolute; bottom: -4.375rem; right: -11.25rem; height: 28.75rem; }
{ position: absolute; bottom: -4.375rem; right: -12.5rem; height: 28.75rem; }
```

**After** (11 declarations total — every property crosses the wire once until it actually changes):
```css
@media (min-width: 90em) { left: 55%; right: initial; }
@media (min-width: 62em) { right: -6.25rem; }
@media (min-width: 48em) { bottom: 0; height: 40rem; }
@media (min-width: 36em) { right: -11.25rem; }
{ position: absolute; bottom: -4.375rem; right: -12.5rem; height: 28.75rem; }
```

## Design

- `optimizeBreakpointDeltas(cssStrings: string[]): string[]` — pure function, single-pass parser that splits each input into top-level declarations + opaque blocks. Tracks brace depth, paren depth, quote state with backslash escape so values like `linear-gradient(red 0%, blue 100%)`, `content: ";"`, and `url(http://…)` parse correctly.
- Cascade state: `Map<prop, value>` for declarations + `Set<string>` for nested blocks. Each subsequent breakpoint only emits entries whose text differs from the cascade.
- `makeItResponsive` resolves each per-breakpoint render to a string via `String(result)`. If any breakpoint produces `[object Object]` (e.g. a non-styler engine result), the optimizer is bypassed and the original unoptimized path runs — so foreign engines still work, they just don't get the savings.

## Limitations (called out in the source)

- **Shorthand vs longhand**: not modelled. If A sets `padding: 1rem` and B sets `padding-top: 0`, both are kept (different keys). If A sets `padding-top: 1rem` and B sets `padding: 1rem`, B's shorthand is emitted (correct — shorthand resets sides A didn't set).
- **Nested blocks** (`&:hover { … }`, `@supports { … }`) are deduped by exact textual match. Equivalent blocks with different whitespace would both be emitted.

## Tests

- 17 unit tests in `optimizeBreakpointDeltas.test.ts` covering: passthrough, declaration deltas, colon/comma/quote/escape parsing, opaque blocks, and a regression test that reproduces the user's reported case.
- 2 integration tests in `makeItResponsive.test.ts` covering the optimized happy path (verifying redundant declarations don't repeat across breakpoints) and the foreign-engine fallback.

## Test plan

- [x] `bun run test` — 133 files / 2634 tests pass (was 2614)
- [x] `bun run lint` — clean
- [x] `bun run typecheck` — all 15 packages clean
- [x] `bun run pkgs:build` — all packages build
- [x] `bun run size` — unistyle 9.27 → 10.53 kB gzipped, under its 12 kB budget
- [x] Coverage thresholds bumped to new baseline (98.58 / 94.32 / 98.47 / 99.31)
- [ ] Real-app soak: visual regression test on the page where the bug was reported

## Rollback

Revert is a single-file revert of `makeItResponsive.ts` plus deletion of `optimizeBreakpointDeltas.ts`. No public API changes — the styles callback contract is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)