### PR TITLE
chore: v2.0.0-beta.4 release

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -186,7 +186,7 @@
     },
     "packages/attrs": {
       "name": "@vitus-labs/attrs",
-      "version": "2.0.0-beta.3",
+      "version": "2.0.0-beta.4",
       "devDependencies": {
         "@vitus-labs/core": "workspace:*",
         "@vitus-labs/elements": "workspace:*",
@@ -195,13 +195,13 @@
         "@vitus-labs/tools-typescript": "2.1.0",
       },
       "peerDependencies": {
-        "@vitus-labs/core": "2.0.0-beta.3",
+        "@vitus-labs/core": "2.0.0-beta.4",
         "react": ">= 19",
       },
     },
     "packages/connector-emotion": {
       "name": "@vitus-labs/connector-emotion",
-      "version": "2.0.0-beta.3",
+      "version": "2.0.0-beta.4",
       "devDependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
@@ -216,7 +216,7 @@
     },
     "packages/connector-native": {
       "name": "@vitus-labs/connector-native",
-      "version": "2.0.0-beta.3",
+      "version": "2.0.0-beta.4",
       "devDependencies": {
         "@vitus-labs/tools-rolldown": "2.2.0",
         "@vitus-labs/tools-typescript": "2.1.0",
@@ -228,7 +228,7 @@
     },
     "packages/connector-styled-components": {
       "name": "@vitus-labs/connector-styled-components",
-      "version": "2.0.0-beta.3",
+      "version": "2.0.0-beta.4",
       "devDependencies": {
         "@vitus-labs/tools-rolldown": "2.2.0",
         "@vitus-labs/tools-typescript": "2.1.0",
@@ -241,20 +241,20 @@
     },
     "packages/connector-styler": {
       "name": "@vitus-labs/connector-styler",
-      "version": "2.0.0-beta.3",
+      "version": "2.0.0-beta.4",
       "devDependencies": {
         "@vitus-labs/styler": "workspace:*",
         "@vitus-labs/tools-rolldown": "2.2.0",
         "@vitus-labs/tools-typescript": "2.1.0",
       },
       "peerDependencies": {
-        "@vitus-labs/styler": "2.0.0-beta.3",
+        "@vitus-labs/styler": "2.0.0-beta.4",
         "react": ">= 19",
       },
     },
     "packages/coolgrid": {
       "name": "@vitus-labs/coolgrid",
-      "version": "2.0.0-beta.3",
+      "version": "2.0.0-beta.4",
       "devDependencies": {
         "@vitus-labs/core": "workspace:*",
         "@vitus-labs/tools-rolldown": "2.2.0",
@@ -264,8 +264,8 @@
         "react-native": ">=0.84.1",
       },
       "peerDependencies": {
-        "@vitus-labs/core": "2.0.0-beta.3",
-        "@vitus-labs/unistyle": "2.0.0-beta.3",
+        "@vitus-labs/core": "2.0.0-beta.4",
+        "@vitus-labs/unistyle": "2.0.0-beta.4",
         "react": ">= 19",
         "react-native": ">= 0.76",
       },
@@ -275,7 +275,7 @@
     },
     "packages/core": {
       "name": "@vitus-labs/core",
-      "version": "2.0.0-beta.3",
+      "version": "2.0.0-beta.4",
       "dependencies": {
         "react-is": "^19.2.4",
       },
@@ -289,7 +289,7 @@
     },
     "packages/elements": {
       "name": "@vitus-labs/elements",
-      "version": "2.0.0-beta.3",
+      "version": "2.0.0-beta.4",
       "dependencies": {
         "react-is": "^19.2.4",
       },
@@ -302,8 +302,8 @@
         "@vitus-labs/unistyle": "workspace:*",
       },
       "peerDependencies": {
-        "@vitus-labs/core": "2.0.0-beta.3",
-        "@vitus-labs/unistyle": "2.0.0-beta.3",
+        "@vitus-labs/core": "2.0.0-beta.4",
+        "@vitus-labs/unistyle": "2.0.0-beta.4",
         "react": ">= 19",
         "react-dom": ">= 19",
         "react-native": ">= 0.76",
@@ -315,7 +315,7 @@
     },
     "packages/hooks": {
       "name": "@vitus-labs/hooks",
-      "version": "2.0.0-beta.3",
+      "version": "2.0.0-beta.4",
       "devDependencies": {
         "@vitus-labs/core": "workspace:*",
         "@vitus-labs/tools-rolldown": "2.2.0",
@@ -324,7 +324,7 @@
         "react-native": ">=0.84.1",
       },
       "peerDependencies": {
-        "@vitus-labs/core": "2.0.0-beta.3",
+        "@vitus-labs/core": "2.0.0-beta.4",
         "react": ">= 19",
         "react-native": ">= 0.76",
       },
@@ -334,7 +334,7 @@
     },
     "packages/kinetic": {
       "name": "@vitus-labs/kinetic",
-      "version": "2.0.0-beta.3",
+      "version": "2.0.0-beta.4",
       "devDependencies": {
         "@vitus-labs/hooks": "workspace:*",
         "@vitus-labs/tools-rolldown": "2.2.0",
@@ -342,7 +342,7 @@
         "react-native": ">=0.84.1",
       },
       "peerDependencies": {
-        "@vitus-labs/hooks": "2.0.0-beta.3",
+        "@vitus-labs/hooks": "2.0.0-beta.4",
         "react": ">= 19",
         "react-native": ">= 0.76",
       },
@@ -352,7 +352,7 @@
     },
     "packages/kinetic-presets": {
       "name": "@vitus-labs/kinetic-presets",
-      "version": "2.0.0-beta.3",
+      "version": "2.0.0-beta.4",
       "devDependencies": {
         "@vitus-labs/tools-rolldown": "2.2.0",
         "@vitus-labs/tools-typescript": "2.1.0",
@@ -363,7 +363,7 @@
     },
     "packages/rocketstories": {
       "name": "@vitus-labs/rocketstories",
-      "version": "2.0.0-beta.3",
+      "version": "2.0.0-beta.4",
       "dependencies": {
         "@vitus-labs/elements": "workspace:*",
       },
@@ -377,15 +377,15 @@
       },
       "peerDependencies": {
         "@storybook/react": "10.2.8",
-        "@vitus-labs/core": "2.0.0-beta.3",
-        "@vitus-labs/rocketstyle": "2.0.0-beta.3",
-        "@vitus-labs/unistyle": "2.0.0-beta.3",
+        "@vitus-labs/core": "2.0.0-beta.4",
+        "@vitus-labs/rocketstyle": "2.0.0-beta.4",
+        "@vitus-labs/unistyle": "2.0.0-beta.4",
         "react": ">= 19",
       },
     },
     "packages/rocketstyle": {
       "name": "@vitus-labs/rocketstyle",
-      "version": "2.0.0-beta.3",
+      "version": "2.0.0-beta.4",
       "devDependencies": {
         "@vitus-labs/core": "workspace:*",
         "@vitus-labs/elements": "workspace:*",
@@ -395,13 +395,13 @@
         "@vitus-labs/unistyle": "workspace:*",
       },
       "peerDependencies": {
-        "@vitus-labs/core": "2.0.0-beta.3",
+        "@vitus-labs/core": "2.0.0-beta.4",
         "react": ">= 19",
       },
     },
     "packages/styler": {
       "name": "@vitus-labs/styler",
-      "version": "2.0.0-beta.3",
+      "version": "2.0.0-beta.4",
       "devDependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
@@ -416,14 +416,14 @@
     },
     "packages/unistyle": {
       "name": "@vitus-labs/unistyle",
-      "version": "2.0.0-beta.3",
+      "version": "2.0.0-beta.4",
       "devDependencies": {
         "@vitus-labs/core": "workspace:*",
         "@vitus-labs/tools-rolldown": "2.2.0",
         "@vitus-labs/tools-typescript": "2.1.0",
       },
       "peerDependencies": {
-        "@vitus-labs/core": "2.0.0-beta.3",
+        "@vitus-labs/core": "2.0.0-beta.4",
         "react": ">= 19",
         "react-native": ">= 0.76",
       },

--- a/packages/attrs/package.json
+++ b/packages/attrs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vitus-labs/attrs",
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "license": "MIT",
   "author": "Vit Bokisch <vit@bokisch.cz>",
   "maintainers": [
@@ -59,7 +59,7 @@
     "version": "node ../../scripts/sync-peer-deps.mjs"
   },
   "peerDependencies": {
-    "@vitus-labs/core": "2.0.0-beta.3",
+    "@vitus-labs/core": "2.0.0-beta.4",
     "react": ">= 19"
   },
   "devDependencies": {

--- a/packages/connector-emotion/package.json
+++ b/packages/connector-emotion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vitus-labs/connector-emotion",
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "license": "MIT",
   "author": "Vit Bokisch <vit@bokisch.cz>",
   "maintainers": [

--- a/packages/connector-native/package.json
+++ b/packages/connector-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vitus-labs/connector-native",
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "license": "MIT",
   "author": "Vit Bokisch <vit@bokisch.cz>",
   "maintainers": [

--- a/packages/connector-styled-components/package.json
+++ b/packages/connector-styled-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vitus-labs/connector-styled-components",
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "license": "MIT",
   "author": "Vit Bokisch <vit@bokisch.cz>",
   "maintainers": [

--- a/packages/connector-styler/package.json
+++ b/packages/connector-styler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vitus-labs/connector-styler",
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "license": "MIT",
   "author": "Vit Bokisch <vit@bokisch.cz>",
   "maintainers": [
@@ -51,7 +51,7 @@
     "version": "node ../../scripts/sync-peer-deps.mjs"
   },
   "peerDependencies": {
-    "@vitus-labs/styler": "2.0.0-beta.3",
+    "@vitus-labs/styler": "2.0.0-beta.4",
     "react": ">= 19"
   },
   "devDependencies": {

--- a/packages/coolgrid/package.json
+++ b/packages/coolgrid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vitus-labs/coolgrid",
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "license": "MIT",
   "author": "Vit Bokisch <vit@bokisch.cz>",
   "maintainers": [
@@ -62,8 +62,8 @@
     "version": "node ../../scripts/sync-peer-deps.mjs"
   },
   "peerDependencies": {
-    "@vitus-labs/core": "2.0.0-beta.3",
-    "@vitus-labs/unistyle": "2.0.0-beta.3",
+    "@vitus-labs/core": "2.0.0-beta.4",
+    "@vitus-labs/unistyle": "2.0.0-beta.4",
     "react": ">= 19",
     "react-native": ">= 0.76"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vitus-labs/core",
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "license": "MIT",
   "author": "Vit Bokisch <vit@bokisch.cz>",
   "maintainers": [

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vitus-labs/elements",
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "license": "MIT",
   "author": "Vit Bokisch <vit@bokisch.cz>",
   "maintainers": [
@@ -58,8 +58,8 @@
     "version": "node ../../scripts/sync-peer-deps.mjs"
   },
   "peerDependencies": {
-    "@vitus-labs/core": "2.0.0-beta.3",
-    "@vitus-labs/unistyle": "2.0.0-beta.3",
+    "@vitus-labs/core": "2.0.0-beta.4",
+    "@vitus-labs/unistyle": "2.0.0-beta.4",
     "react": ">= 19",
     "react-dom": ">= 19",
     "react-native": ">= 0.76"

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vitus-labs/hooks",
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "license": "MIT",
   "author": "Vit Bokisch <vit@bokisch.cz>",
   "maintainers": [
@@ -52,7 +52,7 @@
     "node": ">= 18"
   },
   "peerDependencies": {
-    "@vitus-labs/core": "2.0.0-beta.3",
+    "@vitus-labs/core": "2.0.0-beta.4",
     "react": ">= 19",
     "react-native": ">= 0.76"
   },

--- a/packages/kinetic-presets/package.json
+++ b/packages/kinetic-presets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vitus-labs/kinetic-presets",
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "description": "65+ animation presets, factories, and composition utilities for @vitus-labs/kinetic",
   "license": "MIT",
   "author": "Vit Bokisch <vit@bokisch.cz>",

--- a/packages/kinetic/package.json
+++ b/packages/kinetic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vitus-labs/kinetic",
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "license": "MIT",
   "author": "Vit Bokisch <vit@bokisch.cz>",
   "maintainers": [
@@ -58,7 +58,7 @@
     "node": ">= 18"
   },
   "peerDependencies": {
-    "@vitus-labs/hooks": "2.0.0-beta.3",
+    "@vitus-labs/hooks": "2.0.0-beta.4",
     "react": ">= 19",
     "react-native": ">= 0.76"
   },

--- a/packages/rocketstories/package.json
+++ b/packages/rocketstories/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vitus-labs/rocketstories",
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "license": "MIT",
   "author": "Vit Bokisch <vit@bokisch.cz>",
   "maintainers": [
@@ -66,9 +66,9 @@
   },
   "peerDependencies": {
     "@storybook/react": "10.2.8",
-    "@vitus-labs/core": "2.0.0-beta.3",
-    "@vitus-labs/rocketstyle": "2.0.0-beta.3",
-    "@vitus-labs/unistyle": "2.0.0-beta.3",
+    "@vitus-labs/core": "2.0.0-beta.4",
+    "@vitus-labs/rocketstyle": "2.0.0-beta.4",
+    "@vitus-labs/unistyle": "2.0.0-beta.4",
     "react": ">= 19"
   },
   "dependencies": {

--- a/packages/rocketstyle/package.json
+++ b/packages/rocketstyle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vitus-labs/rocketstyle",
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "license": "MIT",
   "author": "Vit Bokisch <vit@bokisch.cz>",
   "maintainers": [
@@ -65,7 +65,7 @@
     "version": "node ../../scripts/sync-peer-deps.mjs"
   },
   "peerDependencies": {
-    "@vitus-labs/core": "2.0.0-beta.3",
+    "@vitus-labs/core": "2.0.0-beta.4",
     "react": ">= 19"
   },
   "devDependencies": {

--- a/packages/styler/package.json
+++ b/packages/styler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vitus-labs/styler",
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "license": "MIT",
   "author": "Vit Bokisch <vit@bokisch.cz>",
   "maintainers": [

--- a/packages/unistyle/package.json
+++ b/packages/unistyle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vitus-labs/unistyle",
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "license": "MIT",
   "author": "Vit Bokisch <vit@bokisch.cz>",
   "maintainers": [
@@ -51,7 +51,7 @@
     "node": ">= 18"
   },
   "peerDependencies": {
-    "@vitus-labs/core": "2.0.0-beta.3",
+    "@vitus-labs/core": "2.0.0-beta.4",
     "react": ">= 19",
     "react-native": ">= 0.76"
   },


### PR DESCRIPTION
## Summary

Bumps all 15 packages from `2.0.0-beta.3` → `2.0.0-beta.4` to ship the responsive CSS delta optimizer.

## Included since beta.3

- #183 feat(unistyle): per-breakpoint CSS delta optimization (mobile-first cascade)
  - `makeItResponsive` now diffs each breakpoint's CSS at the property level against the running cascade, so `@media (min-width: …)` blocks only emit declarations that actually changed. On the reported sample, 21 declarations across 5 breakpoints collapsed to 11.
  - Engine-agnostic safety net: if any breakpoint result can't be cleanly stringified (foreign engine returning `[object Object]`), the optimizer is bypassed and the original path runs unchanged.
  - 17 unit tests for the new `optimizeBreakpointDeltas` plus 2 integration tests covering the optimized happy path and the foreign-engine fallback.

## Test plan

- [x] All 2634 tests pass on main post-merge (was 2614 → +20)
- [x] Lint, typecheck, build, size budgets clean (unistyle 9.27 → 10.53 kB gzipped, under 12 kB limit)
- [x] Coverage gate raised to new baseline (98.58 / 94.32 / 98.47 / 99.31)
- [ ] CI on this PR (release.yml prerelease + main pipeline) green
- [ ] After merge: `npm view @vitus-labs/styler dist-tags` shows `2.0.0-beta.4`

🤖 Generated with [Claude Code](https://claude.com/claude-code)