### PR TITLE
chore: v2.0.0 stable release

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -186,7 +186,7 @@
     },
     "packages/attrs": {
       "name": "@vitus-labs/attrs",
-      "version": "2.0.0-beta.4",
+      "version": "2.0.0",
       "devDependencies": {
         "@vitus-labs/core": "workspace:*",
         "@vitus-labs/elements": "workspace:*",
@@ -195,13 +195,13 @@
         "@vitus-labs/tools-typescript": "2.1.0",
       },
       "peerDependencies": {
-        "@vitus-labs/core": "2.0.0-beta.4",
+        "@vitus-labs/core": "2.0.0",
         "react": ">= 19",
       },
     },
     "packages/connector-emotion": {
       "name": "@vitus-labs/connector-emotion",
-      "version": "2.0.0-beta.4",
+      "version": "2.0.0",
       "devDependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
@@ -216,7 +216,7 @@
     },
     "packages/connector-native": {
       "name": "@vitus-labs/connector-native",
-      "version": "2.0.0-beta.4",
+      "version": "2.0.0",
       "devDependencies": {
         "@vitus-labs/tools-rolldown": "2.2.0",
         "@vitus-labs/tools-typescript": "2.1.0",
@@ -228,7 +228,7 @@
     },
     "packages/connector-styled-components": {
       "name": "@vitus-labs/connector-styled-components",
-      "version": "2.0.0-beta.4",
+      "version": "2.0.0",
       "devDependencies": {
         "@vitus-labs/tools-rolldown": "2.2.0",
         "@vitus-labs/tools-typescript": "2.1.0",
@@ -241,20 +241,20 @@
     },
     "packages/connector-styler": {
       "name": "@vitus-labs/connector-styler",
-      "version": "2.0.0-beta.4",
+      "version": "2.0.0",
       "devDependencies": {
         "@vitus-labs/styler": "workspace:*",
         "@vitus-labs/tools-rolldown": "2.2.0",
         "@vitus-labs/tools-typescript": "2.1.0",
       },
       "peerDependencies": {
-        "@vitus-labs/styler": "2.0.0-beta.4",
+        "@vitus-labs/styler": "2.0.0",
         "react": ">= 19",
       },
     },
     "packages/coolgrid": {
       "name": "@vitus-labs/coolgrid",
-      "version": "2.0.0-beta.4",
+      "version": "2.0.0",
       "devDependencies": {
         "@vitus-labs/core": "workspace:*",
         "@vitus-labs/tools-rolldown": "2.2.0",
@@ -264,8 +264,8 @@
         "react-native": ">=0.84.1",
       },
       "peerDependencies": {
-        "@vitus-labs/core": "2.0.0-beta.4",
-        "@vitus-labs/unistyle": "2.0.0-beta.4",
+        "@vitus-labs/core": "2.0.0",
+        "@vitus-labs/unistyle": "2.0.0",
         "react": ">= 19",
         "react-native": ">= 0.76",
       },
@@ -275,7 +275,7 @@
     },
     "packages/core": {
       "name": "@vitus-labs/core",
-      "version": "2.0.0-beta.4",
+      "version": "2.0.0",
       "dependencies": {
         "react-is": "^19.2.4",
       },
@@ -289,7 +289,7 @@
     },
     "packages/elements": {
       "name": "@vitus-labs/elements",
-      "version": "2.0.0-beta.4",
+      "version": "2.0.0",
       "dependencies": {
         "react-is": "^19.2.4",
       },
@@ -302,8 +302,8 @@
         "@vitus-labs/unistyle": "workspace:*",
       },
       "peerDependencies": {
-        "@vitus-labs/core": "2.0.0-beta.4",
-        "@vitus-labs/unistyle": "2.0.0-beta.4",
+        "@vitus-labs/core": "2.0.0",
+        "@vitus-labs/unistyle": "2.0.0",
         "react": ">= 19",
         "react-dom": ">= 19",
         "react-native": ">= 0.76",
@@ -315,7 +315,7 @@
     },
     "packages/hooks": {
       "name": "@vitus-labs/hooks",
-      "version": "2.0.0-beta.4",
+      "version": "2.0.0",
       "devDependencies": {
         "@vitus-labs/core": "workspace:*",
         "@vitus-labs/tools-rolldown": "2.2.0",
@@ -324,7 +324,7 @@
         "react-native": ">=0.84.1",
       },
       "peerDependencies": {
-        "@vitus-labs/core": "2.0.0-beta.4",
+        "@vitus-labs/core": "2.0.0",
         "react": ">= 19",
         "react-native": ">= 0.76",
       },
@@ -334,7 +334,7 @@
     },
     "packages/kinetic": {
       "name": "@vitus-labs/kinetic",
-      "version": "2.0.0-beta.4",
+      "version": "2.0.0",
       "devDependencies": {
         "@vitus-labs/hooks": "workspace:*",
         "@vitus-labs/tools-rolldown": "2.2.0",
@@ -342,7 +342,7 @@
         "react-native": ">=0.84.1",
       },
       "peerDependencies": {
-        "@vitus-labs/hooks": "2.0.0-beta.4",
+        "@vitus-labs/hooks": "2.0.0",
         "react": ">= 19",
         "react-native": ">= 0.76",
       },
@@ -352,7 +352,7 @@
     },
     "packages/kinetic-presets": {
       "name": "@vitus-labs/kinetic-presets",
-      "version": "2.0.0-beta.4",
+      "version": "2.0.0",
       "devDependencies": {
         "@vitus-labs/tools-rolldown": "2.2.0",
         "@vitus-labs/tools-typescript": "2.1.0",
@@ -363,7 +363,7 @@
     },
     "packages/rocketstories": {
       "name": "@vitus-labs/rocketstories",
-      "version": "2.0.0-beta.4",
+      "version": "2.0.0",
       "dependencies": {
         "@vitus-labs/elements": "workspace:*",
       },
@@ -377,15 +377,15 @@
       },
       "peerDependencies": {
         "@storybook/react": "10.2.8",
-        "@vitus-labs/core": "2.0.0-beta.4",
-        "@vitus-labs/rocketstyle": "2.0.0-beta.4",
-        "@vitus-labs/unistyle": "2.0.0-beta.4",
+        "@vitus-labs/core": "2.0.0",
+        "@vitus-labs/rocketstyle": "2.0.0",
+        "@vitus-labs/unistyle": "2.0.0",
         "react": ">= 19",
       },
     },
     "packages/rocketstyle": {
       "name": "@vitus-labs/rocketstyle",
-      "version": "2.0.0-beta.4",
+      "version": "2.0.0",
       "devDependencies": {
         "@vitus-labs/core": "workspace:*",
         "@vitus-labs/elements": "workspace:*",
@@ -395,13 +395,13 @@
         "@vitus-labs/unistyle": "workspace:*",
       },
       "peerDependencies": {
-        "@vitus-labs/core": "2.0.0-beta.4",
+        "@vitus-labs/core": "2.0.0",
         "react": ">= 19",
       },
     },
     "packages/styler": {
       "name": "@vitus-labs/styler",
-      "version": "2.0.0-beta.4",
+      "version": "2.0.0",
       "devDependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
@@ -416,14 +416,14 @@
     },
     "packages/unistyle": {
       "name": "@vitus-labs/unistyle",
-      "version": "2.0.0-beta.4",
+      "version": "2.0.0",
       "devDependencies": {
         "@vitus-labs/core": "workspace:*",
         "@vitus-labs/tools-rolldown": "2.2.0",
         "@vitus-labs/tools-typescript": "2.1.0",
       },
       "peerDependencies": {
-        "@vitus-labs/core": "2.0.0-beta.4",
+        "@vitus-labs/core": "2.0.0",
         "react": ">= 19",
         "react-native": ">= 0.76",
       },

--- a/packages/attrs/package.json
+++ b/packages/attrs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vitus-labs/attrs",
-  "version": "2.0.0-beta.4",
+  "version": "2.0.0",
   "license": "MIT",
   "author": "Vit Bokisch <vit@bokisch.cz>",
   "maintainers": [
@@ -59,7 +59,7 @@
     "version": "node ../../scripts/sync-peer-deps.mjs"
   },
   "peerDependencies": {
-    "@vitus-labs/core": "2.0.0-beta.4",
+    "@vitus-labs/core": "2.0.0",
     "react": ">= 19"
   },
   "devDependencies": {

--- a/packages/connector-emotion/package.json
+++ b/packages/connector-emotion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vitus-labs/connector-emotion",
-  "version": "2.0.0-beta.4",
+  "version": "2.0.0",
   "license": "MIT",
   "author": "Vit Bokisch <vit@bokisch.cz>",
   "maintainers": [

--- a/packages/connector-native/package.json
+++ b/packages/connector-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vitus-labs/connector-native",
-  "version": "2.0.0-beta.4",
+  "version": "2.0.0",
   "license": "MIT",
   "author": "Vit Bokisch <vit@bokisch.cz>",
   "maintainers": [

--- a/packages/connector-styled-components/package.json
+++ b/packages/connector-styled-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vitus-labs/connector-styled-components",
-  "version": "2.0.0-beta.4",
+  "version": "2.0.0",
   "license": "MIT",
   "author": "Vit Bokisch <vit@bokisch.cz>",
   "maintainers": [

--- a/packages/connector-styler/package.json
+++ b/packages/connector-styler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vitus-labs/connector-styler",
-  "version": "2.0.0-beta.4",
+  "version": "2.0.0",
   "license": "MIT",
   "author": "Vit Bokisch <vit@bokisch.cz>",
   "maintainers": [
@@ -51,7 +51,7 @@
     "version": "node ../../scripts/sync-peer-deps.mjs"
   },
   "peerDependencies": {
-    "@vitus-labs/styler": "2.0.0-beta.4",
+    "@vitus-labs/styler": "2.0.0",
     "react": ">= 19"
   },
   "devDependencies": {

--- a/packages/coolgrid/package.json
+++ b/packages/coolgrid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vitus-labs/coolgrid",
-  "version": "2.0.0-beta.4",
+  "version": "2.0.0",
   "license": "MIT",
   "author": "Vit Bokisch <vit@bokisch.cz>",
   "maintainers": [
@@ -62,8 +62,8 @@
     "version": "node ../../scripts/sync-peer-deps.mjs"
   },
   "peerDependencies": {
-    "@vitus-labs/core": "2.0.0-beta.4",
-    "@vitus-labs/unistyle": "2.0.0-beta.4",
+    "@vitus-labs/core": "2.0.0",
+    "@vitus-labs/unistyle": "2.0.0",
     "react": ">= 19",
     "react-native": ">= 0.76"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vitus-labs/core",
-  "version": "2.0.0-beta.4",
+  "version": "2.0.0",
   "license": "MIT",
   "author": "Vit Bokisch <vit@bokisch.cz>",
   "maintainers": [

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vitus-labs/elements",
-  "version": "2.0.0-beta.4",
+  "version": "2.0.0",
   "license": "MIT",
   "author": "Vit Bokisch <vit@bokisch.cz>",
   "maintainers": [
@@ -58,8 +58,8 @@
     "version": "node ../../scripts/sync-peer-deps.mjs"
   },
   "peerDependencies": {
-    "@vitus-labs/core": "2.0.0-beta.4",
-    "@vitus-labs/unistyle": "2.0.0-beta.4",
+    "@vitus-labs/core": "2.0.0",
+    "@vitus-labs/unistyle": "2.0.0",
     "react": ">= 19",
     "react-dom": ">= 19",
     "react-native": ">= 0.76"

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vitus-labs/hooks",
-  "version": "2.0.0-beta.4",
+  "version": "2.0.0",
   "license": "MIT",
   "author": "Vit Bokisch <vit@bokisch.cz>",
   "maintainers": [
@@ -52,7 +52,7 @@
     "node": ">= 18"
   },
   "peerDependencies": {
-    "@vitus-labs/core": "2.0.0-beta.4",
+    "@vitus-labs/core": "2.0.0",
     "react": ">= 19",
     "react-native": ">= 0.76"
   },

--- a/packages/kinetic-presets/package.json
+++ b/packages/kinetic-presets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vitus-labs/kinetic-presets",
-  "version": "2.0.0-beta.4",
+  "version": "2.0.0",
   "description": "65+ animation presets, factories, and composition utilities for @vitus-labs/kinetic",
   "license": "MIT",
   "author": "Vit Bokisch <vit@bokisch.cz>",

--- a/packages/kinetic/package.json
+++ b/packages/kinetic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vitus-labs/kinetic",
-  "version": "2.0.0-beta.4",
+  "version": "2.0.0",
   "license": "MIT",
   "author": "Vit Bokisch <vit@bokisch.cz>",
   "maintainers": [
@@ -58,7 +58,7 @@
     "node": ">= 18"
   },
   "peerDependencies": {
-    "@vitus-labs/hooks": "2.0.0-beta.4",
+    "@vitus-labs/hooks": "2.0.0",
     "react": ">= 19",
     "react-native": ">= 0.76"
   },

--- a/packages/rocketstories/package.json
+++ b/packages/rocketstories/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vitus-labs/rocketstories",
-  "version": "2.0.0-beta.4",
+  "version": "2.0.0",
   "license": "MIT",
   "author": "Vit Bokisch <vit@bokisch.cz>",
   "maintainers": [
@@ -66,9 +66,9 @@
   },
   "peerDependencies": {
     "@storybook/react": "10.2.8",
-    "@vitus-labs/core": "2.0.0-beta.4",
-    "@vitus-labs/rocketstyle": "2.0.0-beta.4",
-    "@vitus-labs/unistyle": "2.0.0-beta.4",
+    "@vitus-labs/core": "2.0.0",
+    "@vitus-labs/rocketstyle": "2.0.0",
+    "@vitus-labs/unistyle": "2.0.0",
     "react": ">= 19"
   },
   "dependencies": {

--- a/packages/rocketstyle/package.json
+++ b/packages/rocketstyle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vitus-labs/rocketstyle",
-  "version": "2.0.0-beta.4",
+  "version": "2.0.0",
   "license": "MIT",
   "author": "Vit Bokisch <vit@bokisch.cz>",
   "maintainers": [
@@ -65,7 +65,7 @@
     "version": "node ../../scripts/sync-peer-deps.mjs"
   },
   "peerDependencies": {
-    "@vitus-labs/core": "2.0.0-beta.4",
+    "@vitus-labs/core": "2.0.0",
     "react": ">= 19"
   },
   "devDependencies": {

--- a/packages/styler/package.json
+++ b/packages/styler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vitus-labs/styler",
-  "version": "2.0.0-beta.4",
+  "version": "2.0.0",
   "license": "MIT",
   "author": "Vit Bokisch <vit@bokisch.cz>",
   "maintainers": [

--- a/packages/unistyle/package.json
+++ b/packages/unistyle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vitus-labs/unistyle",
-  "version": "2.0.0-beta.4",
+  "version": "2.0.0",
   "license": "MIT",
   "author": "Vit Bokisch <vit@bokisch.cz>",
   "maintainers": [
@@ -51,7 +51,7 @@
     "node": ">= 18"
   },
   "peerDependencies": {
-    "@vitus-labs/core": "2.0.0-beta.4",
+    "@vitus-labs/core": "2.0.0",
     "react": ">= 19",
     "react-native": ">= 0.76"
   },


### PR DESCRIPTION
## Summary

Promotes all 15 packages from `2.0.0-beta.4` → `2.0.0` stable.

This is the cumulative result of the 2.0 beta cycle. After merging, the `release.yml` workflow on `main` publishes every package as a stable release on npm via OIDC trusted publishing with provenance.

## What 2.0 ships (cumulative since 1.x)

**New CSS engine** — `@vitus-labs/styler`, ~10 KB gzipped, replaces the styled-components dependency. React 19 `<style precedence>` SSR, `useInsertionEffect` client injection, `@layer` support, automatic `@media` / `@supports` / `@container` rule splitting, specificity boost. **17M ops/s** at the `styled()` factory in our benches.

**Engine-agnostic styling** — `core` + `connector-{styler,emotion,styled-components,native}`. Switch CSS engines via a single `init({ ...connector })` call without changing components.

**React Native parity** — same component definitions ship to web and native via the `.native.ts` resolution convention. Validated end-to-end with Expo SDK 55 (1,400+ modules, 2.5 MB Hermes bytecode).

**Modern monorepo** — Bun workspaces (replaced Yarn 3), Vitest (replaced Jest, 2,634 tests in ~10s), Changesets (replaced Lerna), Rolldown bundler. Coverage gate at 98.58% statements / 94.32% branches enforced on every PR. Zero lint warnings.

**Per-breakpoint CSS delta optimization** — `makeItResponsive` now diffs each breakpoint's CSS against the running cascade and only emits properties that actually changed. On the reported sample, 21 declarations across 5 breakpoints collapsed to 11.

## Beta cycle highlights

| Beta | Notable change |
|------|----------------|
| beta.1 | Initial 2.0 release with new engine + monorepo modernization |
| beta.2 | Fix: responsive `block` companion props reset cleanly across breakpoint flips |
| beta.3 | Fix: SSR double-emit — drop `ssrBuffer` push from precedence path, hydrate cache from `<style data-precedence>` tags |
| beta.4 | Feat: per-breakpoint CSS delta optimization in `makeItResponsive` |

Each fix landed with regression tests; the coverage gate moved up after every cycle and never silently down.

## Test plan

- [x] Diff is the same 16-file shape as previous version bumps (15 package.jsons + bun.lock, +56/-56)
- [x] Local pre-push hook passed (lint, typecheck, build, tests)
- [ ] CI on this PR — release.yml prerelease + main pipeline green
- [ ] After merge: `npm view @vitus-labs/styler dist-tags` shows `latest: 2.0.0`
- [ ] After publish: install fresh in a scratch project, verify `init` + `Element` render path

## Post-release follow-ups

- Bump `@vitus-labs/*` peer-dep ranges in the docs site to `^2.0.0` (currently still pinned at `^2.0.0-beta.1`)
- Migration guide for 1.x → 2.0 — the chainable API is unchanged, but connector wiring (`init({ ...connector })`) is new
- Promote experimental delta optimizer from "soak" status if no regressions report in the first week post-stable

🤖 Generated with [Claude Code](https://claude.com/claude-code)