### PR TITLE
ci(release): auto-promote workspace packages to npm `latest` after merge

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,6 +72,16 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      # When releases are driven by hand-bumped versions (no .changeset/* files),
+      # the changesets action above is a no-op — but the package was still
+      # published earlier under the `next` tag by the prerelease job on the
+      # release/** branch. Promote it to `latest` here so `npm install`
+      # resolves to the freshly-merged version instead of stale code.
+      - name: Promote workspace packages to npm latest
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: bun run promote-latest
+
   # ── Prerelease (feature/release branches) ───────────────────────
   prerelease:
     if: github.ref != 'refs/heads/main'

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "changeset": "changeset",
     "version-packages": "changeset version",
     "release": "changeset publish",
+    "promote-latest": "node scripts/promote-latest.mjs",
     "lint": "biome check packages/*/src/",
     "pkgs:clean": "rm -rf node_modules/ bun.lock && bun install",
     "pkgs:build": "bun run --filter './packages/*' build",

--- a/scripts/promote-latest.mjs
+++ b/scripts/promote-latest.mjs
@@ -1,0 +1,104 @@
+/**
+ * Promotes each workspace package's current package.json version to the
+ * `latest` npm dist-tag.
+ *
+ * Why this exists: the prerelease job on `release/**` branches publishes
+ * versions to npm under the `next` tag. When the release PR merges to
+ * `main`, the stable job runs `changeset publish` — which is a no-op when
+ * there are no `.changeset/*` files (we use hand-bumped versions, not
+ * changesets). Without an explicit promotion step, `latest` stays pinned
+ * at whatever it was before the release, and `npm install` resolves to
+ * stale code.
+ *
+ * Behaviour:
+ *  - Walks every directory under `packages/`
+ *  - Reads each `package.json`
+ *  - Skips private / non-`@vitus-labs/*` packages
+ *  - For each public package whose local version differs from the live
+ *    `latest` dist-tag, runs `npm dist-tag add @scope/name@version latest`
+ *  - Idempotent — already-promoted versions are skipped silently
+ *
+ * Auth: requires `NODE_AUTH_TOKEN` (set by `actions/setup-node` from a
+ * granular automation token). Falls back to whatever `~/.npmrc` provides
+ * locally (e.g. `npm login` interactive auth) when run by hand.
+ */
+
+import { execSync } from "node:child_process"
+import { readdirSync, readFileSync } from "node:fs"
+import { resolve } from "node:path"
+
+const PACKAGES_DIR = resolve(process.cwd(), "packages")
+const SCOPE = "@vitus-labs/"
+
+const dirs = readdirSync(PACKAGES_DIR, { withFileTypes: true })
+	.filter((d) => d.isDirectory())
+	.map((d) => d.name)
+
+let promoted = 0
+let alreadyCurrent = 0
+let skipped = 0
+const failures = []
+
+for (const dir of dirs) {
+	const pkgPath = resolve(PACKAGES_DIR, dir, "package.json")
+	let pkg
+	try {
+		pkg = JSON.parse(readFileSync(pkgPath, "utf8"))
+	} catch {
+		skipped++
+		continue
+	}
+
+	if (pkg.private) {
+		console.log(`skip ${pkg.name} (private)`)
+		skipped++
+		continue
+	}
+
+	if (!pkg.name?.startsWith(SCOPE)) {
+		console.log(`skip ${pkg.name} (not ${SCOPE}*)`)
+		skipped++
+		continue
+	}
+
+	const { name, version } = pkg
+	let currentLatest = ""
+	try {
+		currentLatest = execSync(`npm view ${name} dist-tags.latest`, {
+			encoding: "utf8",
+			stdio: ["ignore", "pipe", "ignore"],
+		}).trim()
+	} catch {
+		// Package may not yet exist on npm — treat as no current latest
+	}
+
+	if (version === currentLatest) {
+		console.log(`✓ ${name}@${version} is already latest`)
+		alreadyCurrent++
+		continue
+	}
+
+	console.log(
+		`→ promoting ${name}@${version} to latest (was ${currentLatest || "<unset>"})`,
+	)
+	try {
+		execSync(`npm dist-tag add ${name}@${version} latest`, {
+			stdio: "inherit",
+		})
+		promoted++
+	} catch (err) {
+		failures.push({ name, version, error: err.message })
+	}
+}
+
+console.log(
+	`\nDone: ${promoted} promoted, ${alreadyCurrent} already current, ${skipped} skipped`,
+)
+
+if (failures.length > 0) {
+	console.error(`\n${failures.length} failure(s):`)
+	for (const f of failures) {
+		console.error(`  ${f.name}@${f.version} — ${f.error}`)
+	}
+	process.exit(1)
+}


### PR DESCRIPTION
## Summary

Fixes the dist-tag drift that caused the 2.0.0 stable release to land on npm under `next` while `latest` stayed pinned at `2.0.0-alpha.20`.

When the release flow is driven by hand-bumped versions (no `.changeset/*` files), `changesets/action` in the stable job is a no-op — but the prerelease job on `release/**` has already published the new version under the `next` tag. Without an explicit promotion step, `latest` never moves and `npm install` resolves to stale code. We hit this exactly with 2.0.0 and had to manually `npm dist-tag add` 15 packages with an interactive OTP. This makes that automatic on every future merge.

## Changes

- New `scripts/promote-latest.mjs`. Walks `packages/*`, reads each `package.json`, and runs `npm dist-tag add @scope/name@version latest` for every public `@vitus-labs/*` package whose local version differs from the live `latest`. Idempotent — already-current versions are skipped silently. Errors are aggregated and the script exits non-zero if any promotion fails.
- Wired into `release.yml`'s stable job as a final step, after the existing `changesets/action` (left in place for any future changeset-driven flow). Authenticated via `NODE_AUTH_TOKEN` from the `NPM_TOKEN` secret — `actions/setup-node` automatically configures `~/.npmrc` to use it.
- New `bun run promote-latest` script in the root `package.json` for manual runs.

## Setup required before this lands

The workflow step needs an `NPM_TOKEN` secret to authenticate. **npm trusted publishing only covers `npm publish`**, not `npm dist-tag` — that's why this can't reuse OIDC.

1. **npmjs.com** → *Access Tokens* → *Generate New Token* → **Classic** → **Automation**
   - Scope: read+write to all `@vitus-labs/*` packages
   - No expiration (or set a long one and rotate)
2. **GitHub repo** → *Settings* → *Secrets and variables* → *Actions* → *New repository secret*
   - Name: `NPM_TOKEN`
   - Value: (paste the npm token)

Without `NPM_TOKEN`, the workflow step will fail with an auth error — no silent regression.

## Test plan

- [x] Local dry-run: `bun run promote-latest` reports all 15 packages already current, exits 0
- [x] Lint clean
- [ ] After merge + `NPM_TOKEN` secret added: next release verifies the workflow step actually runs and promotes correctly. (Could also force-test by reverting the dist-tag of one package and re-running the workflow on `main` via `workflow_dispatch` — happy to add a `workflow_dispatch` trigger if you want a safer test path.)

## Why not just remove changesets entirely

Kept the `changesets/action` step in place — it's harmless when there are no changesets, and if you ever add `.changeset/*` files to drive a release, both flows compose: changesets bumps + publishes, then `promote-latest` is a no-op (already current). Smaller blast radius than ripping out the existing setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)