### PR TITLE
perf: clearAll resets styled caches + responsive render cache + stringify fast-paths

### DIFF
--- a/packages/styler/src/__tests__/sheet-advanced.test.ts
+++ b/packages/styler/src/__tests__/sheet-advanced.test.ts
@@ -315,6 +315,31 @@ describe('StyleSheet — advanced features', () => {
     })
   })
 
+  describe('clearAll() resets styled.ts component caches (HMR safety)', () => {
+    beforeEach(() => {
+      document.querySelectorAll('style[data-vl]').forEach((el) => {
+        el.remove()
+      })
+    })
+
+    it('sheet.clearAll() purges the static-component cache', async () => {
+      // Re-import the singleton + styled together so the subscription wires up.
+      const { sheet: liveSheet } = await import('../sheet')
+      const { styled } = await import('../styled')
+
+      // Same source location each call → same TemplateStringsArray identity →
+      // styled returns the cached component on the second call.
+      const make = () => styled('div')`color: red;`
+      const A = make()
+      const B = make()
+      expect(B).toBe(A) // hot/WeakMap cache hit
+
+      liveSheet.clearAll()
+      const C = make()
+      expect(C).not.toBe(A) // cache was reset — fresh component
+    })
+  })
+
   describe('clearAll() with rules', () => {
     beforeEach(() => {
       document.querySelectorAll('style[data-vl]').forEach((el) => {

--- a/packages/styler/src/sheet.ts
+++ b/packages/styler/src/sheet.ts
@@ -414,6 +414,8 @@ export class StyleSheet {
   /**
    * Full cleanup: clear cache and remove all CSS rules from the DOM.
    * Intended for HMR / dev-time reloads where stale styles must be purged.
+   * Also fires every callback registered via `onClear` so other modules
+   * (e.g. styled.ts's static-component cache) can purge their own state.
    *
    *   if (import.meta.hot) {
    *     import.meta.hot.accept(() => sheet.clearAll())
@@ -422,6 +424,7 @@ export class StyleSheet {
   clearAll(): void {
     this.cache.clear()
     this.insertCache.clear()
+    this.prepareCache.clear()
     clearNormCache()
     this.ssrBuffer = []
     if (this.sheet) {
@@ -429,6 +432,7 @@ export class StyleSheet {
         this.sheet.deleteRule(0)
       }
     }
+    for (const cb of clearCallbacks) cb()
   }
 
   /**
@@ -472,6 +476,18 @@ export class StyleSheet {
   get cacheSize(): number {
     return this.cache.size
   }
+}
+
+/**
+ * Subscribers fired by `clearAll()`. Other modules (e.g. styled.ts's
+ * static-component caches) register here so a single `sheet.clearAll()`
+ * resets every layer of state — useful for HMR.
+ */
+const clearCallbacks: Array<() => void> = []
+
+/** Register a callback to be invoked on `sheet.clearAll()`. */
+export const onSheetClear = (cb: () => void): void => {
+  clearCallbacks.push(cb)
 }
 
 /** Default singleton sheet for client-side use. */

--- a/packages/styler/src/styled.ts
+++ b/packages/styler/src/styled.ts
@@ -29,7 +29,7 @@ import {
 import { buildProps } from './forward'
 import { type Interpolation, normalizeCSS, resolve } from './resolve'
 import { isDynamic } from './shared'
-import { sheet } from './sheet'
+import { onSheetClear, sheet } from './sheet'
 import { useTheme } from './ThemeProvider'
 
 // SSR vs client detection — computed once at module load time.
@@ -58,16 +58,28 @@ const getDisplayName = (tag: Tag): string =>
 
 // Component cache: same template literal + tag + no options → same component.
 // WeakMap on `strings` (TemplateStringsArray is object-identity per source location).
-const staticComponentCache = new WeakMap<
+let staticComponentCache = new WeakMap<
   TemplateStringsArray,
   Map<Tag, ComponentType<any>>
 >()
 
 // Single-entry hot cache — just 3 reference comparisons, no Map/WeakMap overhead.
 // Covers the most common pattern: same styled component created repeatedly.
-let _hotStrings: TemplateStringsArray | null = null
-let _hotTag: Tag | null = null
-let _hotComponent: ComponentType<any> | null = null
+// Wrapped in an object so `sheet.clearAll()` can reset every field together
+// (HMR scenario: stale references to old components must be purged).
+const hotCache: {
+  strings: TemplateStringsArray | null
+  tag: Tag | null
+  component: ComponentType<any> | null
+} = { strings: null, tag: null, component: null }
+
+// Subscribe to `sheet.clearAll()` so HMR reloads don't leak stale components.
+onSheetClear(() => {
+  staticComponentCache = new WeakMap()
+  hotCache.strings = null
+  hotCache.tag = null
+  hotCache.component = null
+})
 
 const createStyledComponent = (
   tag: Tag,
@@ -78,17 +90,18 @@ const createStyledComponent = (
 ) => {
   // Ultra-fast hot cache: 3 reference comparisons → return immediately
   if (values.length === 0 && !options) {
-    // biome-ignore lint/style/noNonNullAssertion: invariant — when _hotStrings/_hotTag match, _hotComponent was assigned in the prior call
-    if (strings === _hotStrings && tag === _hotTag) return _hotComponent!
+    if (strings === hotCache.strings && tag === hotCache.tag)
+      // biome-ignore lint/style/noNonNullAssertion: invariant — when hotCache.strings/tag match, hotCache.component was assigned in the prior call
+      return hotCache.component!
 
     // WeakMap fallback for alternating patterns
     const tagMap = staticComponentCache.get(strings)
     if (tagMap) {
       const cached = tagMap.get(tag)
       if (cached) {
-        _hotStrings = strings
-        _hotTag = tag
-        _hotComponent = cached
+        hotCache.strings = strings
+        hotCache.tag = tag
+        hotCache.component = cached
         return cached
       }
     }
@@ -158,9 +171,9 @@ const createStyledComponent = (
         staticComponentCache.set(strings, tagMap)
       }
       tagMap.set(tag, StaticStyled)
-      _hotStrings = strings
-      _hotTag = tag
-      _hotComponent = StaticStyled
+      hotCache.strings = strings
+      hotCache.tag = tag
+      hotCache.component = StaticStyled
     }
 
     return StaticStyled

--- a/packages/unistyle/src/__tests__/makeItResponsive.test.ts
+++ b/packages/unistyle/src/__tests__/makeItResponsive.test.ts
@@ -339,6 +339,61 @@ describe('makeItResponsive', () => {
       expect(paddingZeroOccurrences.length).toBe(1)
     })
 
+    it('returns the SAME array on repeat call (cache hit) when both internalTheme and outer theme are stable', () => {
+      // Stability guarantee — used by parent styled-component caching paths
+      // to avoid re-running renderStyles + optimizeBreakpointDeltas when
+      // nothing has changed.
+      const stringStyles = ({ theme: t }: any) =>
+        `color: ${t.color}; padding: ${t.padding};`
+
+      const fn = makeItResponsive({
+        key: '$test',
+        css,
+        styles: stringStyles as any,
+      })
+
+      const internalTheme = {
+        color: 'red',
+        padding: { xs: '0', md: '1rem' },
+      }
+      const props = { theme: providerTheme, $test: internalTheme }
+
+      const first = fn(props)
+      const second = fn(props)
+      expect(second).toBe(first)
+    })
+
+    it('cache misses when the outer theme changes (dark/light toggle)', () => {
+      const stringStyles = ({ theme: t }: any) => `color: ${t.color};`
+      const fn = makeItResponsive({
+        key: '$test',
+        css,
+        styles: stringStyles as any,
+      })
+
+      const internalTheme = { color: 'red' }
+      // Two distinct outer-theme references, identical content
+      const themeA = { ...providerTheme }
+      const themeB = { ...providerTheme }
+
+      const a = fn({ theme: themeA, $test: internalTheme })
+      const b = fn({ theme: themeB, $test: internalTheme })
+      expect(b).not.toBe(a) // different outer theme reference → cache miss
+    })
+
+    it('cache misses when the internal theme reference changes', () => {
+      const stringStyles = ({ theme: t }: any) => `color: ${t.color};`
+      const fn = makeItResponsive({
+        key: '$test',
+        css,
+        styles: stringStyles as any,
+      })
+
+      const a = fn({ theme: providerTheme, $test: { color: 'red' } })
+      const b = fn({ theme: providerTheme, $test: { color: 'red' } })
+      expect(b).not.toBe(a) // fresh internalTheme reference → cache miss
+    })
+
     it('falls back to unoptimized path when a styles callback result is not stringifiable', () => {
       // Styles callback returning a plain object whose default toString
       // resolves to "[object Object]" — triggers the safety bail-out and

--- a/packages/unistyle/src/responsive/makeItResponsive.ts
+++ b/packages/unistyle/src/responsive/makeItResponsive.ts
@@ -21,8 +21,16 @@ import transformTheme from './transformTheme'
 const stringifyResult = (result: unknown): string | null => {
   if (result == null) return ''
   if (typeof result === 'string') return result
+  // CSSResult duck-type fast path: has `strings` (TemplateStringsArray) and
+  // `values`. We know its toString() resolves to clean CSS, so we can skip
+  // the "[object Foo]" validation for the common path.
+  if (typeof result === 'object' && 'strings' in result && 'values' in result) {
+    return String(result)
+  }
+  // Foreign engine result — coerce and validate. Default
+  // Object.prototype.toString → "[object Foo]" → bail out so caller can fall
+  // back to the unoptimized path.
   const text = String(result)
-  // Default Object.prototype.toString → "[object Foo]" — bail out.
   return text.includes('[object ') ? null : text
 }
 
@@ -78,13 +86,24 @@ export type MakeItResponsive = ({
  *    breakpoint-per-property), optimizes (deduplicates identical breakpoints),
  *    and wraps each breakpoint's styles in the appropriate `@media` query.
  */
-const themeCache = new WeakMap<
-  object,
-  { breakpoints: unknown; optimized: Record<string, Record<string, unknown>> }
->()
+interface ThemeCacheEntry {
+  breakpoints: unknown
+  optimized: Record<string, Record<string, unknown>>
+  /**
+   * Memoized final responsive output (array of media-wrapped CSSResults),
+   * keyed by the outer `theme` reference. Hit when the same internal theme
+   * AND the same outer theme render again — which is the common case when
+   * the ThemeProvider value is stable. Avoids re-running renderStyles +
+   * optimizeBreakpointDeltas on every parent re-render.
+   */
+  rendered?: WeakMap<object, unknown[]>
+}
+
+const themeCache = new WeakMap<object, ThemeCacheEntry>()
 
 const makeItResponsive: MakeItResponsive =
   ({ theme: customTheme, key = '', css, styles, normalize = true }) =>
+  // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: hot-path responsive engine — theme cache + render cache + breakpoint pipeline + optimizer dispatch all inlined per render
   ({ theme = {}, ...props }) => {
     const internalTheme = customTheme || props[key]
 
@@ -110,10 +129,19 @@ const makeItResponsive: MakeItResponsive =
     const { media, sortedBreakpoints } = __VITUS_LABS__!
 
     let optimizedTheme: Record<string, Record<string, unknown>>
+    const entry = themeCache.get(internalTheme)
+    const breakpointsMatch = entry?.breakpoints === sortedBreakpoints
 
-    const cached = themeCache.get(internalTheme)
-    if (cached && cached.breakpoints === sortedBreakpoints) {
-      optimizedTheme = cached.optimized
+    // Full-render cache: same internal theme + same outer theme → return
+    // the previous render's output verbatim. CSSResult instances are immutable
+    // so reusing them is safe.
+    if (entry && breakpointsMatch && entry.rendered) {
+      const memoized = entry.rendered.get(theme as object)
+      if (memoized) return memoized
+    }
+
+    if (entry && breakpointsMatch) {
+      optimizedTheme = entry.optimized
     } else {
       let helperTheme = internalTheme
 
@@ -137,6 +165,11 @@ const makeItResponsive: MakeItResponsive =
       themeCache.set(internalTheme, {
         breakpoints: sortedBreakpoints,
         optimized: optimizedTheme,
+        // Preserve any pre-existing rendered cache when re-entering with a
+        // changed sortedBreakpoints reference — usually this is unreachable
+        // because breakpoints come from a stable Provider value, but the
+        // explicit handling avoids a memory cliff in tests / HMR.
+        rendered: entry?.rendered,
       })
     }
 
@@ -153,26 +186,36 @@ const makeItResponsive: MakeItResponsive =
     )
 
     const canOptimize = renderedTexts.every((t) => t !== null)
+    let result: unknown[]
     if (canOptimize) {
       const deltas = optimizeBreakpointDeltas(renderedTexts as string[])
-      return sortedBreakpoints.map((item: string, i: number) => {
+      result = sortedBreakpoints.map((item: string, i: number) => {
         const css = deltas[i]
         if (!css || !media) return ''
         return (media as Record<string, any>)[item]`${css}`
       })
+    } else {
+      result = sortedBreakpoints.map((item: string) => {
+        const breakpointTheme = optimizedTheme[item]
+        if (!breakpointTheme || !media) return ''
+        const r = renderStyles(breakpointTheme)
+        return (media as Record<string, any>)[item]`
+          ${r};
+        `
+      })
     }
 
-    return sortedBreakpoints.map((item: string) => {
-      const breakpointTheme = optimizedTheme[item]
+    // Memoize the final rendered output by outer theme reference. Stable
+    // theme + stable internal theme => future renders return immediately.
+    // Invariant: by this point themeCache always has an entry for
+    // internalTheme — earlier paths either hit the rendered-cache and
+    // returned, or wrote one via themeCache.set above.
+    // biome-ignore lint/style/noNonNullAssertion: invariant — see comment above
+    const cacheEntry = themeCache.get(internalTheme)!
+    if (!cacheEntry.rendered) cacheEntry.rendered = new WeakMap()
+    cacheEntry.rendered.set(theme as object, result)
 
-      if (!breakpointTheme || !media) return ''
-
-      const result = renderStyles(breakpointTheme)
-
-      return (media as Record<string, any>)[item]`
-        ${result};
-      `
-    })
+    return result
   }
 
 export default makeItResponsive

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -15,8 +15,8 @@ export default defineConfig({
       // Bump these up when coverage improves so we never silently lose
       // what we've gained.
       thresholds: {
-        statements: 98.58,
-        branches: 94.32,
+        statements: 98.61,
+        branches: 94.35,
         functions: 98.47,
         lines: 99.31,
       },


### PR DESCRIPTION
## Summary

Three perf-audit findings (#3, #4, #5 from the post-2.0 audit). All internal changes — no public API breaks, no class-name shape change.

**#1 (hash 64-bit) was struck on second thought.** I originally pitched it as a long-tail collision-safety fix, but on closer inspection: byte cost was real (~6 extra chars per className on every page), benefit was theoretical at realistic scale (1-in-8.6M at 1k rules; 5+ years of zero observed collisions). Doing collision detection *right* with SSR hydration is significantly more complex than a one-line "add disambiguator" (cache reshape + precedence-tag textContent parsing + deterministic secondary hash). Net call: keep 32-bit, accept the empirical track record. **#2 was already struck during audit** (the existing pattern is correct).

## Changes

### #3 — `sheet.clearAll()` resets styled.ts caches (HMR safety)
Previously: `clearAll()` reset the dedup/insert/prepare/norm caches but did not touch the styled.ts static-component WeakMap or single-entry hot cache. Stale component references survived HMR reloads.
Now: a small `onSheetClear` callback registry in `sheet.ts`; styled.ts subscribes itself on module load and resets all four pieces of state when invoked. No circular import. Hot-cache vars consolidated into one object so all fields reset together.

### #4 — Memoize `makeItResponsive`'s final rendered output
The existing `themeCache` (WeakMap on internalTheme) memoized only the normalize/transform/optimize pipeline — `renderStyles` × N breakpoints + `optimizeBreakpointDeltas` ran on every render.
Now: `themeCache` entries also carry a `WeakMap<theme, finalArray>` keyed by the outer theme reference. With a stable ThemeProvider value (the common case), repeat renders return the previous output verbatim. CSSResult instances are immutable so reusing them is safe. For component-heavy trees this saves hundreds of μs per render.
Cache misses gracefully on outer theme change (dark/light toggle) or fresh internal theme reference.

### #5 — `stringifyResult` adds CSSResult duck-type fast path
Previously every per-breakpoint result paid `String(result)` + `text.includes('[object ')` validation. CSSResult-shaped objects now skip the validation since we know their toString is clean. Marginal perf, cleaner code.

## Tests

| Change | Test |
|---|---|
| #3 | `sheet.clearAll()` purges the static-component cache (same template literal source location used twice → same component before clearAll, different component after) |
| #4 | Repeat call with stable `(internalTheme, theme)` returns the SAME array reference; cache misses on outer theme change; cache misses on internal theme reference change |
| #5 | Existing makeItResponsive integration tests still pass (the fallback path is unchanged, only the fast paths added) |

Plus existing 2,634 tests still pass — all behavior preserved.

## Test plan

- [x] All 2,638 tests pass (was 2,634 → +4 new)
- [x] Lint clean
- [x] Typecheck clean across all 15 packages
- [x] All packages build
- [x] All packages within size budgets (styler 10.14 → 10.38 KB; unistyle 10.53 → 10.46 KB)
- [x] Coverage gate raised to new baseline (98.61 / 94.35 / 98.47 / 99.31)

## Release plan

Ships as 2.0.x patch — purely internal, no breaking change. No CDN cache invalidation needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)