### PR TITLE
chore: v2.1.0 release

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -186,7 +186,7 @@
     },
     "packages/attrs": {
       "name": "@vitus-labs/attrs",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "devDependencies": {
         "@vitus-labs/core": "workspace:*",
         "@vitus-labs/elements": "workspace:*",
@@ -195,13 +195,13 @@
         "@vitus-labs/tools-typescript": "2.3.0",
       },
       "peerDependencies": {
-        "@vitus-labs/core": "2.0.0",
+        "@vitus-labs/core": "2.1.0",
         "react": ">= 19",
       },
     },
     "packages/connector-emotion": {
       "name": "@vitus-labs/connector-emotion",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "devDependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
@@ -216,7 +216,7 @@
     },
     "packages/connector-native": {
       "name": "@vitus-labs/connector-native",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "devDependencies": {
         "@vitus-labs/tools-rolldown": "2.3.0",
         "@vitus-labs/tools-typescript": "2.3.0",
@@ -228,7 +228,7 @@
     },
     "packages/connector-styled-components": {
       "name": "@vitus-labs/connector-styled-components",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "devDependencies": {
         "@vitus-labs/tools-rolldown": "2.3.0",
         "@vitus-labs/tools-typescript": "2.3.0",
@@ -241,20 +241,20 @@
     },
     "packages/connector-styler": {
       "name": "@vitus-labs/connector-styler",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "devDependencies": {
         "@vitus-labs/styler": "workspace:*",
         "@vitus-labs/tools-rolldown": "2.3.0",
         "@vitus-labs/tools-typescript": "2.3.0",
       },
       "peerDependencies": {
-        "@vitus-labs/styler": "2.0.0",
+        "@vitus-labs/styler": "2.1.0",
         "react": ">= 19",
       },
     },
     "packages/coolgrid": {
       "name": "@vitus-labs/coolgrid",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "devDependencies": {
         "@vitus-labs/core": "workspace:*",
         "@vitus-labs/tools-rolldown": "2.3.0",
@@ -264,8 +264,8 @@
         "react-native": ">=0.84.1",
       },
       "peerDependencies": {
-        "@vitus-labs/core": "2.0.0",
-        "@vitus-labs/unistyle": "2.0.0",
+        "@vitus-labs/core": "2.1.0",
+        "@vitus-labs/unistyle": "2.1.0",
         "react": ">= 19",
         "react-native": ">= 0.76",
       },
@@ -275,7 +275,7 @@
     },
     "packages/core": {
       "name": "@vitus-labs/core",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "dependencies": {
         "react-is": "^19.2.4",
       },
@@ -289,7 +289,7 @@
     },
     "packages/elements": {
       "name": "@vitus-labs/elements",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "dependencies": {
         "react-is": "^19.2.4",
       },
@@ -302,8 +302,8 @@
         "@vitus-labs/unistyle": "workspace:*",
       },
       "peerDependencies": {
-        "@vitus-labs/core": "2.0.0",
-        "@vitus-labs/unistyle": "2.0.0",
+        "@vitus-labs/core": "2.1.0",
+        "@vitus-labs/unistyle": "2.1.0",
         "react": ">= 19",
         "react-dom": ">= 19",
         "react-native": ">= 0.76",
@@ -315,7 +315,7 @@
     },
     "packages/hooks": {
       "name": "@vitus-labs/hooks",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "devDependencies": {
         "@vitus-labs/core": "workspace:*",
         "@vitus-labs/tools-rolldown": "2.3.0",
@@ -324,7 +324,7 @@
         "react-native": ">=0.84.1",
       },
       "peerDependencies": {
-        "@vitus-labs/core": "2.0.0",
+        "@vitus-labs/core": "2.1.0",
         "react": ">= 19",
         "react-native": ">= 0.76",
       },
@@ -334,7 +334,7 @@
     },
     "packages/kinetic": {
       "name": "@vitus-labs/kinetic",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "devDependencies": {
         "@vitus-labs/hooks": "workspace:*",
         "@vitus-labs/tools-rolldown": "2.3.0",
@@ -342,7 +342,7 @@
         "react-native": ">=0.84.1",
       },
       "peerDependencies": {
-        "@vitus-labs/hooks": "2.0.0",
+        "@vitus-labs/hooks": "2.1.0",
         "react": ">= 19",
         "react-native": ">= 0.76",
       },
@@ -352,7 +352,7 @@
     },
     "packages/kinetic-presets": {
       "name": "@vitus-labs/kinetic-presets",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "devDependencies": {
         "@vitus-labs/tools-rolldown": "2.3.0",
         "@vitus-labs/tools-typescript": "2.3.0",
@@ -363,7 +363,7 @@
     },
     "packages/rocketstories": {
       "name": "@vitus-labs/rocketstories",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "dependencies": {
         "@vitus-labs/elements": "workspace:*",
       },
@@ -377,15 +377,15 @@
       },
       "peerDependencies": {
         "@storybook/react": "10.3.6",
-        "@vitus-labs/core": "2.0.0",
-        "@vitus-labs/rocketstyle": "2.0.0",
-        "@vitus-labs/unistyle": "2.0.0",
+        "@vitus-labs/core": "2.1.0",
+        "@vitus-labs/rocketstyle": "2.1.0",
+        "@vitus-labs/unistyle": "2.1.0",
         "react": ">= 19",
       },
     },
     "packages/rocketstyle": {
       "name": "@vitus-labs/rocketstyle",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "devDependencies": {
         "@vitus-labs/core": "workspace:*",
         "@vitus-labs/elements": "workspace:*",
@@ -395,13 +395,13 @@
         "@vitus-labs/unistyle": "workspace:*",
       },
       "peerDependencies": {
-        "@vitus-labs/core": "2.0.0",
+        "@vitus-labs/core": "2.1.0",
         "react": ">= 19",
       },
     },
     "packages/styler": {
       "name": "@vitus-labs/styler",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "devDependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
@@ -416,14 +416,14 @@
     },
     "packages/unistyle": {
       "name": "@vitus-labs/unistyle",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "devDependencies": {
         "@vitus-labs/core": "workspace:*",
         "@vitus-labs/tools-rolldown": "2.3.0",
         "@vitus-labs/tools-typescript": "2.3.0",
       },
       "peerDependencies": {
-        "@vitus-labs/core": "2.0.0",
+        "@vitus-labs/core": "2.1.0",
         "react": ">= 19",
         "react-native": ">= 0.76",
       },

--- a/packages/attrs/package.json
+++ b/packages/attrs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vitus-labs/attrs",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "license": "MIT",
   "author": "Vit Bokisch <vit@bokisch.cz>",
   "maintainers": [
@@ -59,7 +59,7 @@
     "version": "node ../../scripts/sync-peer-deps.mjs"
   },
   "peerDependencies": {
-    "@vitus-labs/core": "2.0.0",
+    "@vitus-labs/core": "2.1.0",
     "react": ">= 19"
   },
   "devDependencies": {

--- a/packages/connector-emotion/package.json
+++ b/packages/connector-emotion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vitus-labs/connector-emotion",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "license": "MIT",
   "author": "Vit Bokisch <vit@bokisch.cz>",
   "maintainers": [

--- a/packages/connector-native/package.json
+++ b/packages/connector-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vitus-labs/connector-native",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "license": "MIT",
   "author": "Vit Bokisch <vit@bokisch.cz>",
   "maintainers": [

--- a/packages/connector-styled-components/package.json
+++ b/packages/connector-styled-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vitus-labs/connector-styled-components",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "license": "MIT",
   "author": "Vit Bokisch <vit@bokisch.cz>",
   "maintainers": [

--- a/packages/connector-styler/package.json
+++ b/packages/connector-styler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vitus-labs/connector-styler",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "license": "MIT",
   "author": "Vit Bokisch <vit@bokisch.cz>",
   "maintainers": [
@@ -51,7 +51,7 @@
     "version": "node ../../scripts/sync-peer-deps.mjs"
   },
   "peerDependencies": {
-    "@vitus-labs/styler": "2.0.0",
+    "@vitus-labs/styler": "2.1.0",
     "react": ">= 19"
   },
   "devDependencies": {

--- a/packages/coolgrid/package.json
+++ b/packages/coolgrid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vitus-labs/coolgrid",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "license": "MIT",
   "author": "Vit Bokisch <vit@bokisch.cz>",
   "maintainers": [
@@ -62,8 +62,8 @@
     "version": "node ../../scripts/sync-peer-deps.mjs"
   },
   "peerDependencies": {
-    "@vitus-labs/core": "2.0.0",
-    "@vitus-labs/unistyle": "2.0.0",
+    "@vitus-labs/core": "2.1.0",
+    "@vitus-labs/unistyle": "2.1.0",
     "react": ">= 19",
     "react-native": ">= 0.76"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vitus-labs/core",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "license": "MIT",
   "author": "Vit Bokisch <vit@bokisch.cz>",
   "maintainers": [

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vitus-labs/elements",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "license": "MIT",
   "author": "Vit Bokisch <vit@bokisch.cz>",
   "maintainers": [
@@ -58,8 +58,8 @@
     "version": "node ../../scripts/sync-peer-deps.mjs"
   },
   "peerDependencies": {
-    "@vitus-labs/core": "2.0.0",
-    "@vitus-labs/unistyle": "2.0.0",
+    "@vitus-labs/core": "2.1.0",
+    "@vitus-labs/unistyle": "2.1.0",
     "react": ">= 19",
     "react-dom": ">= 19",
     "react-native": ">= 0.76"

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vitus-labs/hooks",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "license": "MIT",
   "author": "Vit Bokisch <vit@bokisch.cz>",
   "maintainers": [
@@ -52,7 +52,7 @@
     "node": ">= 18"
   },
   "peerDependencies": {
-    "@vitus-labs/core": "2.0.0",
+    "@vitus-labs/core": "2.1.0",
     "react": ">= 19",
     "react-native": ">= 0.76"
   },

--- a/packages/kinetic-presets/package.json
+++ b/packages/kinetic-presets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vitus-labs/kinetic-presets",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "65+ animation presets, factories, and composition utilities for @vitus-labs/kinetic",
   "license": "MIT",
   "author": "Vit Bokisch <vit@bokisch.cz>",

--- a/packages/kinetic/package.json
+++ b/packages/kinetic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vitus-labs/kinetic",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "license": "MIT",
   "author": "Vit Bokisch <vit@bokisch.cz>",
   "maintainers": [
@@ -58,7 +58,7 @@
     "node": ">= 18"
   },
   "peerDependencies": {
-    "@vitus-labs/hooks": "2.0.0",
+    "@vitus-labs/hooks": "2.1.0",
     "react": ">= 19",
     "react-native": ">= 0.76"
   },

--- a/packages/rocketstories/package.json
+++ b/packages/rocketstories/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vitus-labs/rocketstories",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "license": "MIT",
   "author": "Vit Bokisch <vit@bokisch.cz>",
   "maintainers": [
@@ -66,9 +66,9 @@
   },
   "peerDependencies": {
     "@storybook/react": "10.3.6",
-    "@vitus-labs/core": "2.0.0",
-    "@vitus-labs/rocketstyle": "2.0.0",
-    "@vitus-labs/unistyle": "2.0.0",
+    "@vitus-labs/core": "2.1.0",
+    "@vitus-labs/rocketstyle": "2.1.0",
+    "@vitus-labs/unistyle": "2.1.0",
     "react": ">= 19"
   },
   "dependencies": {

--- a/packages/rocketstyle/package.json
+++ b/packages/rocketstyle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vitus-labs/rocketstyle",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "license": "MIT",
   "author": "Vit Bokisch <vit@bokisch.cz>",
   "maintainers": [
@@ -65,7 +65,7 @@
     "version": "node ../../scripts/sync-peer-deps.mjs"
   },
   "peerDependencies": {
-    "@vitus-labs/core": "2.0.0",
+    "@vitus-labs/core": "2.1.0",
     "react": ">= 19"
   },
   "devDependencies": {

--- a/packages/styler/package.json
+++ b/packages/styler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vitus-labs/styler",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "license": "MIT",
   "author": "Vit Bokisch <vit@bokisch.cz>",
   "maintainers": [

--- a/packages/unistyle/package.json
+++ b/packages/unistyle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vitus-labs/unistyle",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "license": "MIT",
   "author": "Vit Bokisch <vit@bokisch.cz>",
   "maintainers": [
@@ -51,7 +51,7 @@
     "node": ">= 18"
   },
   "peerDependencies": {
-    "@vitus-labs/core": "2.0.0",
+    "@vitus-labs/core": "2.1.0",
     "react": ">= 19",
     "react-native": ">= 0.76"
   },


### PR DESCRIPTION
## Summary

First minor after 2.0.0 stable. Internal correctness + perf wins, no breaking changes — `npm install @vitus-labs/<x>` continues to work without changes.

## What's in 2.1.0 (since 2.0.0)

**#194 fix: stabilize HOC/hook deps + port TransitionGroup.native callback cache**
- attrs: `useMemo` deps no longer cascade-invalidate on every parent re-render (props ref was always-new). The `.attrs()` callbacks now actually run once per content-change instead of every render.
- coolgrid: same fix for `useGridContext` — native grid layout no longer churns when parent re-renders with content-stable props.
- kinetic: ported the per-key callback cache from web `TransitionGroup` to the native version. One leaving child no longer triggers fresh callback props on every sibling.

**#193 perf: clearAll resets styled caches + responsive render cache + stringify fast-paths**
- `sheet.clearAll()` now also resets the styled.ts static-component WeakMap and hot cache (HMR safety — stale component refs no longer survive).
- `makeItResponsive` memoizes the final rendered output by `(internalTheme, theme)` pair on top of the existing themeCache. With a stable ThemeProvider value, repeat renders return the previous output verbatim.
- `stringifyResult` adds CSSResult duck-type fast path.

**#196 chore: unpin tools-typescript + ts-patch major bump**
- Build-tooling only; affects this repo's CI/build, not consumers' bundles.

**#195 chore: routine deps + CI updates**
- biome 2.4.13 → 2.4.14, jsdom 29.1.0 → 29.1.1, tools-X 2.2.0 → 2.3.0, GH actions current.

## Test plan

- [x] Same 16-file shape as past releases (15 package.jsons + bun.lock, +56/-56)
- [x] Pre-push hook passed locally
- [ ] CI on this PR — release.yml prerelease + main pipeline green
- [ ] After merge + manual dist-tag promotion: `npm view @vitus-labs/styler dist-tags` shows `latest: 2.1.0`

## Post-merge

Same manual OTP dance as 2.0.0 — `release.yml`'s stable job is a no-op on hand-bumped versions, so `next` gets 2.1.0 from the prerelease job and `latest` has to be moved by hand. Until the workflow fix lands, expect to run:

```bash
OTP=<6-digit code>
for pkg in core styler unistyle elements attrs rocketstyle rocketstories \
           connector-styler connector-emotion connector-styled-components \
           connector-native coolgrid kinetic kinetic-presets hooks; do
  npm dist-tag add "@vitus-labs/$pkg@2.1.0" latest --otp=$OTP
done
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)