### PR TITLE
fix: rocketstyle isDark/isLight swap + rocketstories init interface lies

### DIFF
--- a/packages/rocketstories/src/rocketstories.tsx
+++ b/packages/rocketstories/src/rocketstories.tsx
@@ -109,9 +109,11 @@ export interface IRocketStories<
     ? ReturnType<rocketstory.RenderList<OA>>
     : ReturnType<simplestory.RenderList<OA>>
 
-  // INIT chaining method
+  // INIT — Storybook default-export object
   // --------------------------------------------------------
-  init: () => {
+  // A property literal, NOT a method. Use as `export default stories.init`
+  // (no parens) — calling it as a function fails at runtime.
+  init: {
     component: Configuration['component']
     title: Configuration['name']
     decorators: Configuration['decorators']

--- a/packages/rocketstyle/src/__tests__/rocketstyleIntegration.test.tsx
+++ b/packages/rocketstyle/src/__tests__/rocketstyleIntegration.test.tsx
@@ -198,6 +198,30 @@ describe('chaining methods', () => {
     const result = WithAttrs.getDefaultAttrs({}, {}, 'light')
     expect(result.label).toBe('default')
   })
+
+  // Regression: isDark/isLight helpers passed to .attrs() callbacks were
+  // swapped relative to `mode` for static-side calls (via getDefaultAttrs).
+  // Runtime renders were correct (via useTheme), but rocketstories' default
+  // attrs introspection received inverted helpers.
+  it('.getDefaultAttrs() passes mode helpers matching the mode', () => {
+    const ModeAware = Button.attrs(
+      (_props: any, _theme: any, helpers: any) => ({
+        mode: helpers.mode,
+        isDark: helpers.isDark,
+        isLight: helpers.isLight,
+      }),
+    )
+
+    const lightResult = ModeAware.getDefaultAttrs({}, {}, 'light')
+    expect(lightResult.mode).toBe('light')
+    expect(lightResult.isLight).toBe(true)
+    expect(lightResult.isDark).toBe(false)
+
+    const darkResult = ModeAware.getDefaultAttrs({}, {}, 'dark')
+    expect(darkResult.mode).toBe('dark')
+    expect(darkResult.isLight).toBe(false)
+    expect(darkResult.isDark).toBe(true)
+  })
 })
 
 describe('rendering', () => {

--- a/packages/rocketstyle/src/rocketstyle.tsx
+++ b/packages/rocketstyle/src/rocketstyle.tsx
@@ -529,8 +529,8 @@ const rocketComponent: RocketComponent = (options) => {
         {
           render,
           mode,
-          isDark: mode === 'light',
-          isLight: mode === 'dark',
+          isDark: mode === 'dark',
+          isLight: mode === 'light',
         },
       ]),
   })


### PR DESCRIPTION
## Summary

Two correctness bugs uncovered while auditing the docs site against current source (#201 follow-up). Both have been silently shipping; this fixes them with regression coverage.

### 1. rocketstyle — `isDark` / `isLight` swapped in `getDefaultAttrs` helpers

`rocketstyle.tsx:532-533` had:

\`\`\`ts
isDark: mode === 'light',
isLight: mode === 'dark',
\`\`\`

Inverted. Runtime renders were correct (helpers come from `useTheme` which derives correctly), but `Component.getDefaultAttrs(props, theme, mode)` — used by rocketstories to introspect default props — fed `.attrs()` callbacks the wrong helpers. Any story whose attrs branch on `helpers.isDark` / `helpers.isLight` showed inverted defaults relative to its declared `mode`. Added a regression test covering both `'light'` and `'dark'` modes under `.getDefaultAttrs()`.

### 2. rocketstories — `IRocketStories.init` interface lied about runtime shape

The interface declared:

\`\`\`ts
init: () => { component: …, title: …, decorators: … }   // callable
\`\`\`

But the impl assigns `init` as an **object literal**:

\`\`\`ts
init: {
  component: options.component,
  title: options.name,
  decorators: options.decorators,
}
\`\`\`

So `stories.init()` typechecks but throws `init is not a function` at runtime; `stories.init` (no parens) works. Tightened the interface to a property literal so the type matches runtime — code that used the correct property syntax keeps working; code that called it as a function now fails at the type level instead of at runtime, which is the safer surfacing.

Note: anyone whose code currently typechecks but fails at runtime (i.e. `export default stories.init()`) will now see a TS error pointing them at the fix. That's the intended consequence — runtime breakage was the silent prior behaviour.

## Test plan

- [x] `bun run test` — 2660 tests pass (+1 new regression test for mode helpers)
- [x] `bun run typecheck` — clean across all 15 packages
- [x] `bun run lint` — clean
- [x] `bun run pkgs:build` — all packages build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)