### PR TITLE
chore: shared .vscode workspace hints (Biome + Vitest, format-on-save)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,11 @@ npm-debug.log*
 # Editors & OS
 .DS_Store
 .idea/
-.vscode/
+.vscode/*
+!.vscode/extensions.json
+!.vscode/settings.json
+!.vscode/launch.json
+!.vscode/tasks.json
 
 # Dependency directories
 node_modules/

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+  "recommendations": [
+    "biomejs.biome",
+    "vitest.explorer"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,16 @@
+{
+  "editor.formatOnSave": true,
+  "editor.defaultFormatter": "biomejs.biome",
+  "editor.codeActionsOnSave": {
+    "source.organizeImports.biome": "explicit",
+    "quickfix.biome": "explicit"
+  },
+  "[json]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
+  "[jsonc]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "typescript.enablePromptUseWorkspaceTsdk": true
+}


### PR DESCRIPTION
## Summary

New contributors get red squiggles by default because Biome isn't auto-installed in VS Code. This commits a minimal shared editor config so the IDE matches the pre-push hook and CI lint step out of the box.

### Files

- **`.vscode/extensions.json`** — recommends `biomejs.biome` (the same formatter the pre-push hook runs) and `vitest.explorer` (inline test runner for the 2660-test suite). VS Code shows an "Install recommended extensions?" prompt on workspace open.
- **`.vscode/settings.json`** — `formatOnSave: true` with Biome as the default formatter for JS / TS / JSON / JSONC. Organize-imports + quickfix on save (both via Biome). Pins TS to workspace `node_modules/typescript/lib` so monorepo features like the `source` resolve condition work correctly.
- **`.gitignore`** — adopts the standard "ignore everything except shared files" pattern (`.vscode/*` + `!.vscode/extensions.json` etc.) so personal user settings (debug breakpoints, layout) stay local while shared workspace config is checked in.

`.editorconfig` already existed and matches Biome's settings (2-space, LF, trim-trailing, 80-line) — no change there.

### Skipped from this batch (with rationale)

- **`CHANGELOG.md` per package** — Changesets is already correctly configured to use `@changesets/changelog-github`. The reason no CHANGELOGs are committed is that recent version bumps (e.g. v2.1.0) bypassed the Changesets PR flow. That's a workflow change, not a config flip.
- **Dev-mode `init()` error** — `notConfigured()` in `core/config.ts:77` already prints a friendly multi-line message with the import + setup snippet. No improvement needed.

## Test plan

- [x] `bun run lint` — clean (`.vscode/` files aren't in lint scope)
- [x] `git add` works for the whitelisted files (verified locally — required `.gitignore` whitelist pattern since `.vscode/` was previously fully ignored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)