### PR TITLE
refactor(rocketstories): isolate per-storyOf theme + cover ignore-list edge cases

### DIFF
--- a/packages/rocketstories/src/__tests__/builders.test.ts
+++ b/packages/rocketstories/src/__tests__/builders.test.ts
@@ -84,6 +84,50 @@ describe('init and rocketstories factories', () => {
     setTheme({ rootSize: 16 })
   })
 
+  it('init snapshots theme into builder.CONFIG (no singleton dependency at story time)', () => {
+    const themeA = { rootSize: 16, brand: 'A' }
+    const themeB = { rootSize: 24, brand: 'B' }
+
+    // First storyOf instance with themeA
+    const factoryA = init({ theme: themeA })
+    const builderA = factoryA(MockComponent)
+    expect(builderA.CONFIG.theme).toEqual(themeA)
+
+    // Second storyOf with themeB — must NOT retroactively
+    // affect builderA's theme.
+    const factoryB = init({ theme: themeB })
+    const builderB = factoryB(MockComponent)
+    expect(builderB.CONFIG.theme).toEqual(themeB)
+    expect(builderA.CONFIG.theme).toEqual(themeA)
+
+    // Reset
+    setTheme({ rootSize: 16 })
+  })
+
+  it('rocketstories factory snapshots singleton when no explicit theme is passed', () => {
+    setTheme({ rootSize: 18, brand: 'singleton' })
+    const builder = rocketstories(MockComponent)
+    expect(builder.CONFIG.theme).toEqual({ rootSize: 18, brand: 'singleton' })
+
+    // Mutate singleton afterwards — builder's snapshot must not change.
+    setTheme({ rootSize: 99, brand: 'mutated' })
+    expect(builder.CONFIG.theme).toEqual({ rootSize: 18, brand: 'singleton' })
+
+    // Reset
+    setTheme({ rootSize: 16 })
+  })
+
+  it('rocketstories factory prefers explicit theme over singleton', () => {
+    setTheme({ rootSize: 18, brand: 'singleton' })
+    const builder = rocketstories(MockComponent, {
+      theme: { rootSize: 32, brand: 'explicit' },
+    })
+    expect(builder.CONFIG.theme).toEqual({ rootSize: 32, brand: 'explicit' })
+
+    // Reset
+    setTheme({ rootSize: 16 })
+  })
+
   it('init passes decorators through', () => {
     const decorator = () => null
     const factory = init({ decorators: [decorator] })

--- a/packages/rocketstories/src/__tests__/rocketstyleStories.test.tsx
+++ b/packages/rocketstories/src/__tests__/rocketstyleStories.test.tsx
@@ -466,6 +466,119 @@ describe('renderDimension', () => {
     expect(container.querySelector('[data-story="state-primary"]')).toBeNull()
   })
 
+  it('ignore list with non-existent value is a no-op', () => {
+    const story = renderDimension('state' as any, {
+      name: 'IgnoreNonexistent',
+      component: MockRSComponent as any,
+      attrs: {},
+      controls: {},
+      storyOptions: {
+        gap: 16,
+        direction: 'rows',
+        alignX: 'left',
+        alignY: 'top',
+      },
+      decorators: [],
+      ignore: ['ghost-value-that-does-not-exist'],
+    })
+
+    const { container } = render(createElement(story, {}))
+    // All real values still render — ignoring a non-existent value
+    // shouldn't filter out anything.
+    expect(container.querySelector('[data-story="state-primary"]')).toBeTruthy()
+    expect(
+      container.querySelector('[data-story="state-secondary"]'),
+    ).toBeTruthy()
+  })
+
+  it('ignore list containing all values renders no items', () => {
+    const story = renderDimension('state' as any, {
+      name: 'IgnoreAll',
+      component: MockRSComponent as any,
+      attrs: {},
+      controls: {},
+      storyOptions: {
+        gap: 16,
+        direction: 'rows',
+        alignX: 'left',
+        alignY: 'top',
+      },
+      decorators: [],
+      ignore: ['primary', 'secondary'],
+    })
+
+    const { container } = render(createElement(story, {}))
+    // Wrapper renders, but no dimension-value items inside.
+    expect(container.querySelector('[data-story]')).toBeNull()
+  })
+
+  it('ignore list with multiple values filters all of them', () => {
+    const story = renderDimension('size' as any, {
+      name: 'IgnoreMultiple',
+      component: MockRSComponent as any,
+      attrs: {},
+      controls: {},
+      storyOptions: {
+        gap: 16,
+        direction: 'rows',
+        alignX: 'left',
+        alignY: 'top',
+      },
+      decorators: [],
+      ignore: ['small', 'large'],
+    })
+
+    const { container } = render(createElement(story, {}))
+    // MockRSComponent only has small + large for size — both ignored.
+    expect(container.querySelector('[data-story="size-small"]')).toBeNull()
+    expect(container.querySelector('[data-story="size-large"]')).toBeNull()
+  })
+
+  it('ignore list works with multi-key dimension', () => {
+    const story = renderDimension('tags' as any, {
+      name: 'IgnoreMultiKey',
+      component: MockMultiKeyComponent as any,
+      attrs: {},
+      controls: {},
+      storyOptions: {
+        gap: 16,
+        direction: 'rows',
+        alignX: 'left',
+        alignY: 'top',
+      },
+      decorators: [],
+      ignore: ['tagA'],
+    })
+
+    const { container } = render(createElement(story, {}))
+    expect(container.querySelector('[data-story="tags-tagA"]')).toBeNull()
+    expect(container.querySelector('[data-story="tags-tagB"]')).toBeTruthy()
+  })
+
+  it('ignore list works alongside pseudo-state mode', () => {
+    const story = renderDimension('state' as any, {
+      name: 'IgnorePseudo',
+      component: MockRSComponent as any,
+      attrs: {},
+      controls: {},
+      storyOptions: {
+        gap: 16,
+        direction: 'rows',
+        alignX: 'left',
+        alignY: 'top',
+        pseudo: true,
+      },
+      decorators: [],
+      ignore: ['primary'],
+    })
+
+    const { container } = render(createElement(story, {}))
+    // Pseudo mode renders a heading per dimension value, plus a
+    // PseudoList. The ignored value's heading must not appear.
+    expect(container.textContent).not.toContain('Primary')
+    expect(container.textContent).toContain('Secondary')
+  })
+
   it('renders story component with items', () => {
     const story = renderDimension('state' as any, {
       name: 'RenderTest',

--- a/packages/rocketstories/src/init.ts
+++ b/packages/rocketstories/src/init.ts
@@ -1,9 +1,11 @@
 import type { IRocketStories } from '~/rocketstories'
 import createRocketStories from '~/rocketstories'
 import type { Configuration, ExtractProps, RocketType } from '~/types'
-import { setTheme } from '~/utils/theme'
+import getTheme, { setTheme } from '~/utils/theme'
 
-type InitParams = Partial<Omit<Configuration, 'component' | 'attrs'>> & {
+type InitParams = Partial<
+  Omit<Configuration, 'component' | 'attrs' | 'theme'>
+> & {
   theme?: Record<string, unknown>
 }
 
@@ -28,7 +30,7 @@ const init: Init = ({ decorators = [], storyOptions = {}, theme, ...rest }) => {
   if (theme) setTheme(theme)
 
   return (component) =>
-    rocketstories(component, { decorators, storyOptions, ...rest })
+    rocketstories(component, { decorators, storyOptions, theme, ...rest })
 }
 
 /**
@@ -38,7 +40,9 @@ const init: Init = ({ decorators = [], storyOptions = {}, theme, ...rest }) => {
  */
 export type Rocketstories = <C extends Configuration['component']>(
   component: C,
-  options?: Partial<Omit<Configuration, 'component' | 'attrs'>>,
+  options?: Partial<Omit<Configuration, 'component' | 'attrs' | 'theme'>> & {
+    theme?: Record<string, unknown>
+  },
 ) => C extends RocketType
   ? IRocketStories<ExtractProps<C>, C['$$rocketstyle'], true>
   : IRocketStories<ExtractProps<C>, unknown, false>
@@ -47,7 +51,7 @@ export type Rocketstories = <C extends Configuration['component']>(
 // @ts-expect-error — `Rocketstories` is a conditional generic over `C extends RocketType`;
 // the impl returns the right runtime shape but TS can't unify both branches at the value level
 const rocketstories: Rocketstories = (component, options = {}) => {
-  const { decorators = [], storyOptions = {} } = options
+  const { decorators = [], storyOptions = {}, theme } = options
 
   const result: Configuration = {
     component,
@@ -62,6 +66,12 @@ const rocketstories: Rocketstories = (component, options = {}) => {
     },
     decorators,
     controls: {},
+    // Snapshot the theme at construction time. Prefer the explicit
+    // `options.theme`; fall back to the singleton so legacy callers that
+    // only set `setTheme(...)` still work. Either way, this storyOf
+    // instance now owns its theme — later `setTheme` calls or competing
+    // `init({ theme })` invocations don't affect it.
+    theme: theme ?? getTheme(),
   }
 
   return createRocketStories(result)

--- a/packages/rocketstories/src/internal/RocketStoryHoc.tsx
+++ b/packages/rocketstories/src/internal/RocketStoryHoc.tsx
@@ -15,7 +15,6 @@ import {
   makeStorybookControls,
 } from '~/utils/controls'
 import { extractDefaultBooleanProps } from '~/utils/dimensions'
-import getTheme from '~/utils/theme'
 
 export type RocketStory<P = {}> = (
   WrappedComponent: any,
@@ -23,11 +22,10 @@ export type RocketStory<P = {}> = (
 
 const rocketStory: RocketStory =
   (WrappedComponent) =>
-  ({ name, component, attrs, controls }) => {
+  ({ name, component, attrs, controls, theme = {} }) => {
     // ------------------------------------------------------
     // ROCKETSTYLE COMPONENT INFO
     // ------------------------------------------------------
-    const theme = getTheme()
     const statics = component.getStaticDimensions(theme)
     const defaultAttrs = component.getDefaultAttrs(attrs, theme, 'light')
     const { dimensions, useBooleans, multiKeys } = statics

--- a/packages/rocketstories/src/stories/rocketstories/renderDimension/index.tsx
+++ b/packages/rocketstories/src/stories/rocketstories/renderDimension/index.tsx
@@ -22,7 +22,6 @@ import {
   getDefaultVitusLabsControls,
   makeStorybookControls,
 } from '~/utils/controls'
-import getTheme from '~/utils/theme'
 import Item from './components/Item'
 import PseudoList from './components/PseudoList'
 import Provider from './context'
@@ -36,12 +35,19 @@ export type RenderDimension<P = {}> = (
 
 const renderDimension: RenderDimension = (
   dimension,
-  { name, component, attrs = {}, controls, storyOptions = {}, ignore = [] },
+  {
+    name,
+    component,
+    attrs = {},
+    controls,
+    storyOptions = {},
+    ignore = [],
+    theme = {},
+  },
 ) => {
   // ------------------------------------------------------
   // ROCKETSTYLE COMPONENT INFO
   // ------------------------------------------------------
-  const theme = getTheme()
   const statics = component.getStaticDimensions(theme)
   const defaultAttrs = component.getDefaultAttrs(attrs, theme, 'light')
   const { dimensions, useBooleans, multiKeys } = statics

--- a/packages/rocketstories/src/types.ts
+++ b/packages/rocketstories/src/types.ts
@@ -99,6 +99,16 @@ export type Configuration = {
   }>
   controls: Record<string, Control>
   decorators: Decorator[]
+  /**
+   * Theme used at story-construction time when introspecting rocketstyle
+   * components (`getStaticDimensions`, `getDefaultAttrs`). The
+   * `rocketstories` factory snapshots this from the module-level singleton
+   * (`utils/theme.ts`) so each `storyOf(component)` instance is isolated
+   * from later `setTheme` mutations or competing `init({ theme })` calls
+   * in the same process. Optional in the type to ease direct test
+   * construction; consumers via the factory always receive a value.
+   */
+  theme?: Record<string, unknown>
 }
 
 export type RocketStoryConfiguration = Omit<Configuration, 'component'> & {


### PR DESCRIPTION
## Summary

Tier-2 follow-ups from the docs audit: the audit subagent flagged "theme global state coupling" and "test coverage gaps in `renderDimension` ignore-list" — both deferred from PR #201. This PR closes them out.

### Bug fixed: theme leaks across `storyOf` instances

`getTheme()` / `setTheme()` was a module-level singleton that `RocketStoryHoc` and `renderDimension` read at story-construction time. Two `storyOf` instances with different themes — or any later `setTheme` call — corrupted the first one's introspection: the **latest** singleton value won at story time, even for builders constructed earlier.

```ts
const a = init({ theme: themeA })  // setTheme(themeA), build builderA
const b = init({ theme: themeB })  // setTheme(themeB) — now builderA's introspection sees themeB too
```

### Fix

- `Configuration` grows an optional `theme: Record<string, unknown>` field.
- The `rocketstories()` factory snapshots `getTheme()` (or `options.theme` if explicit) into the Configuration **once**, at construction time.
- `RocketStoryHoc` and `renderDimension` now read theme from the Configuration they receive — not from the singleton.
- The singleton + default `Theme` decorator path is unchanged. That decorator still calls `getTheme()` at *render* time, so existing usage (`init({ theme }) + decorators: [Theme]`) keeps working. The introspection-time bug is what's actually fixed.
- `init({ theme })` still calls `setTheme(theme)` (back-compat for the default decorator) AND now passes `theme` through to the factory so the snapshot uses the explicit value, not the just-mutated singleton — both paths stay consistent.

### Tests

**Theme isolation (3 new)** in `builders.test.ts`:
- Two `init({ theme })` calls produce builders whose `CONFIG.theme` stays isolated — later `init` doesn't mutate earlier builder's snapshot.
- Factory snapshots singleton when no explicit theme — later `setTheme` calls don't change the snapshot.
- Factory prefers explicit `theme` option over the singleton.

**`renderDimension` ignore-list edge cases (5 new)** in `rocketstyleStories.test.tsx`:
- Ignoring a non-existent value is a no-op (real values still render).
- Ignoring all values renders the wrapper but no `[data-story]` items.
- Multiple ignored values filter all of them.
- Ignore + multi-key dimension works (`tagA` filtered, `tagB` rendered).
- Ignore + pseudo-state mode works (ignored value's heading absent).

## Test plan

- [x] `bun run test` — 2668 tests pass (was 2660, +8 new)
- [x] `bun run lint` — clean
- [x] `bun run typecheck` — clean across all 15 packages
- [x] `bun run pkgs:build` — all packages build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)