### PR TITLE
chore(release): foundation for Changesets-driven release flow

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,6 +8,13 @@
 
 -
 
+## Release Impact
+
+- [ ] I've added a changeset (`bun changeset`) describing the user-facing change
+- [ ] OR this PR doesn't ship to consumers (chore / CI / internal refactor) and I've added the `skip-changeset` label
+
+CI's `Changeset` check enforces this for any PR touching `packages/**`. See [CONTRIBUTING.md → Releases](../blob/main/CONTRIBUTING.md#releases--changesets).
+
 ## Testing
 
 <!-- How were the changes tested? -->

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -1,0 +1,265 @@
+name: PR Comments
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: pr-comments-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  # ─────────────────────────────────────────────────────────────────
+  # Bundle-size diff — builds base + PR, posts sticky comment with deltas
+  # ─────────────────────────────────────────────────────────────────
+  bundle-size:
+    name: Bundle size diff
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+
+      - name: Cache bun dependencies
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: bun-${{ runner.os }}-
+
+      - name: Install (PR head)
+        run: bun install --frozen-lockfile
+
+      - name: Build (PR head)
+        run: bun run pkgs:build
+
+      - name: Measure (PR head)
+        run: bun run size --json > /tmp/pr.json
+
+      - name: Checkout base
+        run: |
+          git fetch origin "${{ github.event.pull_request.base.ref }}"
+          git checkout "origin/${{ github.event.pull_request.base.ref }}"
+
+      - name: Install (base)
+        run: bun install --frozen-lockfile
+
+      - name: Build (base)
+        run: bun run pkgs:build
+
+      - name: Measure (base)
+        run: bun run size --json > /tmp/base.json
+
+      - name: Diff and comment
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v8.0.0
+        with:
+          script: |
+            const fs = require('fs')
+            const base = JSON.parse(fs.readFileSync('/tmp/base.json', 'utf8'))
+            const pr = JSON.parse(fs.readFileSync('/tmp/pr.json', 'utf8'))
+
+            const formatBytes = (n) => {
+              if (n < 1024) return `${n} B`
+              return `${(n / 1024).toFixed(2)} KB`
+            }
+
+            const formatDelta = (delta, basePct) => {
+              if (delta === 0) return '—'
+              const sign = delta > 0 ? '+' : ''
+              const pct = basePct === 0 ? 'new' : `${sign}${((delta / basePct) * 100).toFixed(2)}%`
+              const emoji = delta > 0 ? '🔴' : '🟢'
+              return `${emoji} ${sign}${formatBytes(delta)} (${pct})`
+            }
+
+            const baseByName = Object.fromEntries(base.map((p) => [p.name, p]))
+
+            const rows = pr.map((p) => {
+              const b = baseByName[p.name]
+              const baseSize = b ? b.size : 0
+              const delta = p.size - baseSize
+              return {
+                name: p.name,
+                base: formatBytes(baseSize),
+                pr: formatBytes(p.size),
+                delta: formatDelta(delta, baseSize),
+                changed: delta !== 0,
+              }
+            })
+
+            const totalDelta = rows.reduce((sum, r) => {
+              const prSize = pr.find((p) => p.name === r.name).size
+              const baseSize = (baseByName[r.name] || { size: 0 }).size
+              return sum + (prSize - baseSize)
+            }, 0)
+
+            const anyChange = rows.some((r) => r.changed)
+
+            const tableRows = rows.map((r) =>
+              `| ${r.name} | ${r.base} | ${r.pr} | ${r.delta} |`
+            ).join('\n')
+
+            const summary = anyChange
+              ? `**Total delta: ${formatBytes(Math.abs(totalDelta))}** ${totalDelta > 0 ? '🔴 increase' : '🟢 decrease'}`
+              : '_No bundle size changes._'
+
+            const body = [
+              '<!-- bundle-size-bot -->',
+              '### 📦 Bundle size',
+              '',
+              summary,
+              '',
+              '| Package | Base | This PR | Δ |',
+              '|---|---:|---:|---:|',
+              tableRows,
+              '',
+              '_Sizes are gzipped. Budgets are enforced separately by `size-limit` in CI._',
+            ].join('\n')
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            })
+
+            const existing = comments.find((c) => c.body && c.body.includes('<!-- bundle-size-bot -->'))
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              })
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              })
+            }
+
+  # ─────────────────────────────────────────────────────────────────
+  # Changeset preview — sticky comment showing projected version bumps
+  # Skips silently if no .changeset/*.md files are added in the PR.
+  # ─────────────────────────────────────────────────────────────────
+  changeset-preview:
+    name: Changeset preview
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Detect changesets in this PR
+        id: detect
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          set -euo pipefail
+          ADDED=$(git diff --name-only --diff-filter=A "origin/${BASE_REF}...HEAD" -- '.changeset/*.md' || true)
+          ADDED=$(echo "$ADDED" | grep -v -E '\.changeset/(README|config)\.(md|json)$' || true)
+          if [ -z "$ADDED" ]; then
+            echo "has_changesets=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_changesets=true" >> "$GITHUB_OUTPUT"
+            echo "Changesets in this PR:"
+            echo "$ADDED"
+          fi
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        if: steps.detect.outputs.has_changesets == 'true'
+
+      - name: Cache bun dependencies
+        if: steps.detect.outputs.has_changesets == 'true'
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: bun-${{ runner.os }}-
+
+      - name: Install
+        if: steps.detect.outputs.has_changesets == 'true'
+        run: bun install --frozen-lockfile
+
+      - name: Run changeset status
+        if: steps.detect.outputs.has_changesets == 'true'
+        run: bunx changeset status --output=/tmp/status.json
+
+      - name: Post preview comment
+        if: steps.detect.outputs.has_changesets == 'true'
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v8.0.0
+        with:
+          script: |
+            const fs = require('fs')
+            const status = JSON.parse(fs.readFileSync('/tmp/status.json', 'utf8'))
+
+            const releases = status.releases || []
+            if (releases.length === 0) {
+              console.log('No releases planned by the present changesets — skipping comment.')
+              return
+            }
+
+            const bumpRank = { patch: 0, minor: 1, major: 2 }
+            const overall = releases.reduce(
+              (acc, r) => (bumpRank[r.type] > bumpRank[acc] ? r.type : acc),
+              'patch',
+            )
+
+            const tableRows = releases
+              .map((r) => `| ${r.name} | ${r.oldVersion} | ${r.newVersion} |`)
+              .join('\n')
+
+            const changesetSummaries = (status.changesets || [])
+              .map((c) => `- ${c.summary.split('\n')[0]}`)
+              .join('\n')
+
+            const body = [
+              '<!-- changeset-preview-bot -->',
+              '### 🦋 Changeset preview',
+              '',
+              `If merged, this PR will produce a **${overall}** release across all 15 packages (fixed group):`,
+              '',
+              '| Package | From | To |',
+              '|---|---|---|',
+              tableRows,
+              '',
+              '**Changesets in this PR:**',
+              '',
+              changesetSummaries || '_(no summaries)_',
+            ].join('\n')
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            })
+
+            const existing = comments.find((c) => c.body && c.body.includes('<!-- changeset-preview-bot -->'))
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              })
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              })
+            }

--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -1,0 +1,66 @@
+name: Changeset
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: changeset-check-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: Changeset
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Verify changeset present (or bypass label)
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          HAS_SKIP_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'skip-changeset') }}
+        run: |
+          set -euo pipefail
+
+          # 1. PRs that don't touch packages/ never need a changeset.
+          PACKAGE_FILES=$(git diff --name-only "origin/${BASE_REF}...HEAD" -- 'packages/**' || true)
+          if [ -z "$PACKAGE_FILES" ]; then
+            echo "::notice::PR does not touch packages/ — changeset not required."
+            exit 0
+          fi
+
+          # 2. skip-changeset label bypasses the check.
+          if [ "$HAS_SKIP_LABEL" = "true" ]; then
+            echo "::notice::skip-changeset label present — bypassing the gate."
+            echo "Files touched in packages/:"
+            echo "$PACKAGE_FILES"
+            exit 0
+          fi
+
+          # 3. Otherwise, an added .changeset/*.md file is required.
+          ADDED_CHANGESETS=$(git diff --name-only --diff-filter=A "origin/${BASE_REF}...HEAD" -- '.changeset/*.md' || true)
+          # Filter out README.md and config files that don't count.
+          ADDED_CHANGESETS=$(echo "$ADDED_CHANGESETS" | grep -v -E '\.changeset/(README|config)\.(md|json)$' || true)
+
+          if [ -z "$ADDED_CHANGESETS" ]; then
+            echo "::error::This PR touches packages/ but no changeset is present."
+            echo ""
+            echo "To add one:"
+            echo "  bun changeset"
+            echo "  git add .changeset && git commit -m 'add changeset' && git push"
+            echo ""
+            echo "Or, if this PR doesn't ship to consumers (chore / CI / internal refactor),"
+            echo "add the 'skip-changeset' label to bypass."
+            exit 1
+          fi
+
+          echo "::notice::Changeset(s) found:"
+          echo "$ADDED_CHANGESETS"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,18 +69,9 @@ jobs:
           publish: bun run release
           title: 'chore: version packages'
           commit: 'chore: version packages'
+          createGithubReleases: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      # When releases are driven by hand-bumped versions (no .changeset/* files),
-      # the changesets action above is a no-op — but the package was still
-      # published earlier under the `next` tag by the prerelease job on the
-      # release/** branch. Promote it to `latest` here so `npm install`
-      # resolves to the freshly-merged version instead of stale code.
-      - name: Promote workspace packages to npm latest
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: bun run promote-latest
 
   # ── Prerelease (feature/release branches) ───────────────────────
   prerelease:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,12 +73,67 @@ packages/
 7. Commit with a clear message describing the change
 8. Open a pull request against `main`
 
+## Releases & Changesets
+
+Releases are driven by [Changesets](https://github.com/changesets/changesets). Every PR that changes user-facing behavior of any `@vitus-labs/*` package must include a changeset describing the change.
+
+### Adding a changeset
+
+```bash
+bun changeset
+```
+
+The interactive prompt asks you to pick:
+
+1. **Packages affected** — choose any one (the [fixed-package group](.changeset/config.json) makes them all bump together anyway).
+2. **Bump type**:
+   - `patch` — bug fixes, type-only refactors, performance work, dependency bumps.
+   - `minor` — new public API surface (new exports, new generic type parameters, new options, new methods).
+   - `major` — breaking changes (removed exports, signature changes, behavior changes that consumers must adapt to).
+3. **Summary** — one sentence in the present tense, written for a release-notes audience.
+
+The CLI creates `.changeset/<random-name>.md`. Commit it with your PR.
+
+> Because all 15 packages are in a fixed group, every bump moves all of them together. Pick the bump type for the **highest-impact** change in your PR.
+
+### When to skip a changeset
+
+Add the `skip-changeset` label to the PR if it:
+
+- Touches only `.github/`, `.vscode/`, `scripts/`, or root-level config — not `packages/`
+- Changes only this `CONTRIBUTING.md`, the root `README.md`, or other repo-level docs (not package READMEs)
+- Adds or fixes tests without changing the package surface
+
+CI's `Changeset` check fails any PR that touches `packages/**` without either a changeset or the `skip-changeset` label.
+
+### How a release happens (you don't run any of this)
+
+1. Your PR with a `.changeset/*.md` file merges to `main`.
+2. The next push to `main` triggers `release.yml` → `changesets/action` collects all unconsumed changesets and opens a `chore: version packages` PR.
+3. That PR shows: bumped versions in every `package.json`, generated `CHANGELOG.md` per package, deleted `.changeset/*.md` files.
+4. CI runs on it; once green, mark it auto-merge (or wait for a maintainer).
+5. Merging triggers another `release.yml` run that publishes to npm via OIDC trusted publishing (no secrets needed) and creates one GitHub Release per package with the changeset summaries as the body.
+
+### Prerelease channel
+
+Push to a branch matching `release/**` or `feature/**` to publish a snapshot version under the `next` dist-tag. Consumers can install:
+
+```bash
+npm install @vitus-labs/styler@next
+```
+
+Useful for testing a PR's effect on downstream apps before merging to `main`.
+
+### Manual fallback (rare)
+
+`scripts/promote-latest.mjs` and `bun run promote-latest` exist as a manual escape hatch in case dist-tags ever drift (e.g., a hand-bumped release where the prerelease branch published before the stable job ran). Run locally with `npm login` if needed — not wired into CI to keep the secret surface zero.
+
 ## Conventions
 
 - **TypeScript** — all source code is TypeScript
 - **Biome** — used for linting and formatting
-- **Jest** — used for testing with `@swc/jest` transformer
-- **styled-components** — CSS-in-JS styling engine
+- **Vitest** — used for testing (resolves `source` condition to TS source for fast workspace-wide tests)
+- **`@vitus-labs/styler`** — built-in CSS-in-JS engine; consumers can swap to Emotion or styled-components via the connector packages
 - **Workspace dependencies** — use `workspace:*` protocol for inter-package deps
 
 ## Commit Messages


### PR DESCRIPTION
## Summary

Wires up the full Changesets release path that's been configured but never load-bearing. After this lands, every PR declares its release impact via a `.changeset/*.md` file; CI gates on it; merging to `main` opens an auto-generated Version PR; merging that publishes via OIDC and creates GitHub Releases automatically. **No `NPM_TOKEN` needed anywhere** — OIDC trusted publishing covers `npm publish`.

This is **PR-1 of three** in the new release rollout. PR-2 refactors peer deps to caret ranges (so minor bumps stop escalating to major). PR-3 bootstraps 2.2.0 through the new flow with retroactive changesets for #198–#204.

## What's in this PR

### Workflows

**`changeset-check.yml`** — new PR gate.
- PRs touching `packages/**` must add a `.changeset/*.md` file or carry the `skip-changeset` label.
- Fails with an actionable error message + `bun changeset` instructions.
- Status check context: `Changeset` (will be added to `main` branch protection post-merge).

**`bundle-size.yml`** — two parallel jobs posting sticky PR comments.
- **Bundle size diff** — builds base + PR head, runs `bun run size --json` on both, posts a markdown table of per-package gzipped deltas with 🔴/🟢 emoji. Informational only; `size-limit` budget enforcement stays in `ci.yml`.
- **Changeset preview** — runs `bunx changeset status` if the PR adds a changeset and posts an "If merged, this PR will produce a {minor|major|patch} release across these packages" comment. Skips silently if no changeset is present.

**`release.yml`** — two changes to the stable job:
- Add `createGithubReleases: true` to the `changesets/action` step → each version bump produces 15 GitHub Release entries (one per fixed-group package), bodies populated from changeset summaries.
- **Remove** the post-publish `Promote workspace packages to npm latest` step (added by #186) — it needed `NPM_TOKEN` (OIDC scope is publish-only). With the new Changesets-driven flow, `changeset publish` on main lands directly on `latest` — promote-latest was only useful for the hand-bumped flow we're moving away from. The `scripts/promote-latest.mjs` script and `bun run promote-latest` entry stay in place as a manual escape hatch.

### Docs

**`.github/PULL_REQUEST_TEMPLATE.md`** — appends a "Release Impact" section with two checkboxes (added a changeset / labeled `skip-changeset`).

**`CONTRIBUTING.md`** — adds a comprehensive "Releases & Changesets" section: `bun changeset` interactive workflow, bump-type guide (patch/minor/major), when to use `skip-changeset`, the auto-publish flow end-to-end, the prerelease channel (`release/**` → `next` dist-tag), the manual fallback. Also fixes two stale lines in Conventions: Jest → Vitest, styled-components → `@vitus-labs/styler`.

## Out-of-band steps after this lands

1. Add `Changeset` to required status checks on `main` branch protection (additive — keeps existing 3 contexts).
2. Create the `skip-changeset` label.
3. **PR-2**: Refactor peer deps from exact-version to caret ranges (`"@vitus-labs/core": "2.1.0"` → `"^2.1.0"`) + update `scripts/sync-peer-deps.mjs` to maintain ranges. Without this, minor changesets escalate to major bumps via Changesets' (correct) semver enforcement on internal peer-dep range changes.
4. **PR-3**: Write 6 retroactive changesets for #198–#204 to cut 2.2.0 through the new flow as the first end-to-end smoke test.

## Test plan

- [x] All three workflow YAMLs parse cleanly (no tabs, valid structure)
- [x] `bun run size --json` schema verified (`[{name, size, sizeLimit, passed}]`)
- [x] `bunx changeset status --output=...` JSON schema verified (has `releases` and `changesets` arrays)
- [x] `bun run lint` clean
- [ ] After merge: PR-2 + PR-3 will smoke-test the entire flow end-to-end (PR template prompts, changeset gate, bundle-size comment, changeset preview, Version PR auto-open, OIDC publish, GitHub Releases creation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)