### PR TITLE
fix(ci): materialise base branch ref before `changeset status`

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -193,6 +193,17 @@ jobs:
         if: steps.detect.outputs.has_changesets == 'true'
         run: bun install --frozen-lockfile
 
+      # `changeset status` calls `git merge-base HEAD <baseBranch>` and
+      # needs the base branch as a *local* ref, not just `origin/<base>`.
+      # actions/checkout in PR mode only sets up the merge ref, so we have
+      # to materialise the base branch ourselves. `|| true` covers the
+      # case where the local branch already exists.
+      - name: Materialise base branch ref for changeset status
+        if: steps.detect.outputs.has_changesets == 'true'
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: git fetch origin "${BASE_REF}:${BASE_REF}" || true
+
       - name: Run changeset status
         if: steps.detect.outputs.has_changesets == 'true'
         run: bunx changeset status --output=/tmp/status.json


### PR DESCRIPTION
## Summary

The `Changeset preview` job in `.github/workflows/bundle-size.yml` (added in #205) failed on #206 with:

```
Failed to find where HEAD diverged from "main".
Does "main" exist and it's synced with remote?
```

**Root cause:** `bunx changeset status` calls `git merge-base HEAD main` internally and needs `main` as a *local* ref. `actions/checkout` in PR mode (default) checks out the PR's merge commit and only exposes the base branch as `origin/main`, not as a local `main`. The neighbouring **bundle-size** job in the same workflow was unaffected because it does its own explicit `git fetch origin <base>` + `git checkout origin/<base>` sequence — the changeset-preview job was missing the equivalent.

**Fix:** one extra step before `bunx changeset status`:

```yaml
- name: Materialise base branch ref for changeset status
  if: steps.detect.outputs.has_changesets == 'true'
  env:
    BASE_REF: ${{ github.event.pull_request.base.ref }}
  run: git fetch origin "${BASE_REF}:${BASE_REF}" || true
```

`|| true` keeps the step idempotent (handles the case where the local branch already exists).

## Notes

- `Changeset preview` is **informational only** — branch protection requires `Changeset` (the gate), not the preview comment. PR-2 (#206) can merge with this fix queued behind it. Fixing the workflow now keeps the release-flow surface clean.
- This PR doesn't touch `packages/**` so the `Changeset` gate passes without a changeset (and one isn't needed — pure CI plumbing).

## Test plan

- [x] CI runs on this PR will exercise the `Changeset preview` path (no changesets in this PR → silent skip; fine).
- [ ] After merge, re-run `Changeset preview` on #206 — should succeed and post the preview comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)