### PR TITLE
chore: retroactive changesets for 2.2.0 (#198, #199, #200, #201, #202, #204)

### DIFF
--- a/.changeset/feat-core-cssengineresult.md
+++ b/.changeset/feat-core-cssengineresult.md
@@ -1,0 +1,5 @@
+---
+"@vitus-labs/core": minor
+---
+
+Add augmentable `CSSEngineResult` interface — `css()`'s return type now follows whichever engine `init()`'d via TypeScript module declaration merging, replacing the previous engine-agnostic `any`. Connector packages declare their concrete result shape; consumer code automatically gets the right type without core depending on any specific engine package.

--- a/.changeset/feat-elements-generic-props.md
+++ b/.changeset/feat-elements-generic-props.md
@@ -1,0 +1,5 @@
+---
+"@vitus-labs/elements": minor
+---
+
+Generic `Props<T>` on `Iterator` and `List` with discriminated branches — `T` is inferred at the JSX call site from the `data` array. Primitive arrays get `SimpleProps<T>` (`valueName` required), object arrays get `ObjectProps<T>` (`valueName` forbidden, `itemKey` typed against `keyof T`), no-data calls get `ChildrenProps`, and unparameterized callers fall back to the previous loose shape (`LooseProps`) for back-compat. Existing code keeps type-checking; new code gains stricter inference automatically.

--- a/.changeset/fix-mode-helpers-and-init-type.md
+++ b/.changeset/fix-mode-helpers-and-init-type.md
@@ -1,0 +1,6 @@
+---
+"@vitus-labs/rocketstyle": patch
+"@vitus-labs/rocketstories": patch
+---
+
+Two correctness fixes uncovered by the docs audit. Fix `isDark`/`isLight` swap in `getDefaultAttrs` mode helpers (`rocketstyle.tsx:532-533`) — runtime renders were correct via `useTheme`, but the static introspection path used by rocketstories fed `.attrs()` callbacks inverted helpers, so any story whose attrs branched on `helpers.isDark`/`helpers.isLight` showed wrong-mode-sensitive defaults. Tighten `IRocketStories.init` interface from a method (`() => {...}`) to a property literal — the runtime is an object literal, so `stories.init()` typechecked but threw `init is not a function` at runtime; now the type matches runtime. Includes regression tests for both.

--- a/.changeset/fix-rocketstories-bundle.md
+++ b/.changeset/fix-rocketstories-bundle.md
@@ -1,0 +1,5 @@
+---
+"@vitus-labs/rocketstories": patch
+---
+
+Bundle of 5 fixes for rocketstories: `.replaceComponent()` and `.config({ component })` now drop attrs on a real component swap (mirrors the rocketstyle fix); typo rename `cloneAndEhnance` → `cloneAndEnhance`; proper types for `RocketType.getStaticDimensions` and `getDefaultAttrs` (no more `any`); three `as any` casts in render paths replaced with honest typed casts; `@storybook/react` peer dep loosened from exact `10.3.6` to `^10.3.6`.

--- a/.changeset/fix-rocketstyle-component-swap.md
+++ b/.changeset/fix-rocketstyle-component-swap.md
@@ -1,0 +1,5 @@
+---
+"@vitus-labs/rocketstyle": patch
+---
+
+Fix component-swap leak in `.config({ component })`. When `cloneAndEnhance` swaps the underlying component, the prior `attrs`, `priorityAttrs`, `compose`, and `filterAttrs` chain values were silently carried forward — they were tailored to the previous component's prop shape and could leak invalid props onto the rendered output. Now those chain values reset on component change. Style-side state (themes, dimensions, statics, pseudo) is preserved. Same-component swaps remain a no-op for attrs.

--- a/.changeset/refactor-rocketstories-theme-isolation.md
+++ b/.changeset/refactor-rocketstories-theme-isolation.md
@@ -1,0 +1,5 @@
+---
+"@vitus-labs/rocketstories": patch
+---
+
+Snapshot the theme into per-`storyOf` Configuration at construction time so each builder is isolated from later `setTheme` mutations or competing `init({ theme })` calls in the same process. `RocketStoryHoc` and `renderDimension` now read theme from Configuration instead of the module-level singleton — fixes a latent bug where two `storyOf` instances with different themes would have the second one's theme corrupt the first's static introspection. Existing default `Theme` decorator path (singleton-based) keeps working for back-compat.


### PR DESCRIPTION
## Summary

Six changesets covering all merged PRs since v2.1.0 that ship to consumers (skips #203, which was DX/.vscode-only). Combined with the already-on-main `peer-deps-workspace-protocol` patch changeset from #208, this brings the suite to **2.2.0** (minor — driven by the two `feat()` PRs).

This is **PR-3 of three** — the bootstrap end-to-end test of the new Changesets-driven release flow set up in #205, #207, #208.

## Changesets in this PR

| File | Bump | Source |
|------|------|--------|
| `feat-core-cssengineresult.md` | minor | #198 — Augmentable `CSSEngineResult` interface |
| `feat-elements-generic-props.md` | minor | #199 — Generic `Props<T>` on Iterator/List |
| `fix-rocketstyle-component-swap.md` | patch | #200 — Reset chain values on `.config({ component })` swap |
| `fix-rocketstories-bundle.md` | patch | #201 — Bundle of 5 rocketstories fixes |
| `fix-mode-helpers-and-init-type.md` | patch | #202 — `isDark`/`isLight` swap + `IRocketStories.init` type |
| `refactor-rocketstories-theme-isolation.md` | patch | #204 — Per-`storyOf` theme snapshotting |

#203 (`.vscode` workspace hints) is skipped — DX-only, no package surface change.

## What happens when this merges

1. `release.yml` runs on `main` → `changesets/action` detects the existing Version PR (opened from #208's single changeset) and **updates it** to include all 7 changesets.
2. The Version PR's proposed bumps shift from `2.1.0 → 2.1.1` (patch) to `2.1.0 → 2.2.0` (minor).
3. CI runs on the Version PR; once green, you can merge it.
4. Merging the Version PR triggers `release.yml` again → `changeset publish` runs → publishes all 15 packages to npm via **OIDC trusted publishing** (no `NPM_TOKEN`) → `createGithubReleases: true` produces **15 GitHub Release** entries auto-populated from the changeset summaries.

## ⚠️ Ordering note

**Do not merge the open Version PR before this PR-3 lands.** Right now the Version PR proposes `2.1.0 → 2.1.1` (patch — just the workspace-protocol changeset from #208). Merging it before this adds its 6 changesets would publish 2.1.1, then 2.2.0 separately. Once this PR merges, the Version PR auto-updates to propose `2.1.0 → 2.2.0` in a single hop.

## Verified locally

I ran `bunx changeset status` on a throwaway branch with all 7 changesets present and confirmed:

- All 15 fixed-group packages bump at **minor**
- No major escalation (workspace:^ + experimental config flag from #208 working as designed)
- Examples bump at patch (don't publish — `private: true`)

I also ran `GITHUB_TOKEN=$(gh auth token) bun run version-packages` and inspected the generated CHANGELOG.md files — they read correctly, with proper PR/author backlinks via `@changesets/changelog-github`.

## Test plan

- [x] `bunx changeset status` previews all 15 → minor (verified locally)
- [x] `bun run version-packages` generates CHANGELOGs cleanly (verified locally on throwaway)
- [x] `Changeset` CI gate satisfied (this PR adds 6 `.changeset/*.md` files)
- [ ] After merge: Version PR updates with all 7 changesets (will verify by inspecting it before deciding whether to merge it)
- [ ] Version PR merge → 2.2.0 publishes to npm + 15 GitHub Releases auto-create (final smoke test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)