### PR TITLE
chore(release): polish — auto-skip Version PR, umbrella Release step, optional RELEASE_PAT

### DIFF
--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -27,8 +27,20 @@ jobs:
         env:
           BASE_REF: ${{ github.event.pull_request.base.ref }}
           HAS_SKIP_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'skip-changeset') }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
           set -euo pipefail
+
+          # 0. Auto-bypass for the changesets/action-generated Version PR.
+          # That PR bumps every package.json (touches packages/**) but
+          # *deletes* changesets instead of adding new ones — so a literal
+          # reading of the gate fails it. The PR is signed by github-actions
+          # and titled "chore: version packages" — recognise both.
+          if [ "$PR_AUTHOR" = "github-actions[bot]" ] && [[ "$PR_TITLE" == "chore: version packages"* ]]; then
+            echo "::notice::Auto-generated Version PR — bypassing the gate."
+            exit 0
+          fi
 
           # 1. PRs that don't touch packages/ never need a changeset.
           PACKAGE_FILES=$(git diff --name-only "origin/${BASE_REF}...HEAD" -- 'packages/**' || true)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,9 +69,63 @@ jobs:
           publish: bun run release
           title: 'chore: version packages'
           commit: 'chore: version packages'
-          createGithubReleases: true
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Prefer a fine-grained PAT (`RELEASE_PAT`) when present so
+          # commits the action pushes to the Version PR's branch trigger
+          # downstream workflows (CI on the Version PR). Falls back to
+          # the default token, which works for everything except trigger
+          # propagation. See CONTRIBUTING.md → Releases → Setup.
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
+
+      # The changesets/action's built-in `createGithubReleases: true`
+      # iterates per-package and was observed hanging mid-run on the 2.2.0
+      # release after npm publish had already succeeded. Replaced with a
+      # single umbrella Release for the suite — matches how other fixed-
+      # group monorepos (React, Apollo, Babel) ship.
+      - name: Create umbrella GitHub Release
+        if: steps.changesets.outputs.published == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          VERSION=$(node -p "require('./packages/core/package.json').version")
+          TAG="v${VERSION}"
+
+          # Idempotent tag: skip if it already exists (e.g. retried run).
+          if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
+            echo "::notice::Tag ${TAG} already exists — skipping tag step."
+          else
+            git tag "${TAG}"
+            git push origin "${TAG}"
+          fi
+
+          # Build a markdown list of every published package@version from
+          # the action's structured output.
+          PACKAGES=$(echo '${{ steps.changesets.outputs.publishedPackages }}' \
+            | jq -r '[.[] | "- `\(.name)@\(.version)`"] | join("\n")')
+
+          BODY=$(cat <<EOF
+          All packages in the \`@vitus-labs/*\` suite at **${VERSION}**.
+
+          ## Published
+
+          ${PACKAGES}
+
+          ## Per-package detail
+
+          See each \`packages/*/CHANGELOG.md\` for the package-specific entry generated from the changesets that bumped it.
+          EOF
+          )
+
+          # Create the Release. `--verify-tag` ensures we point at a real
+          # ref. Idempotent via `|| true` if a Release already exists for
+          # this tag (manual retry scenario).
+          gh release create "${TAG}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --title "${TAG}" \
+            --notes "${BODY}" \
+            --verify-tag \
+            || echo "::warning::Release for ${TAG} already exists — skipping creation."
 
   # ── Prerelease (feature/release branches) ───────────────────────
   prerelease:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,7 +112,24 @@ CI's `Changeset` check fails any PR that touches `packages/**` without either a 
 2. The next push to `main` triggers `release.yml` → `changesets/action` collects all unconsumed changesets and opens a `chore: version packages` PR.
 3. That PR shows: bumped versions in every `package.json`, generated `CHANGELOG.md` per package, deleted `.changeset/*.md` files.
 4. CI runs on it; once green, mark it auto-merge (or wait for a maintainer).
-5. Merging triggers another `release.yml` run that publishes to npm via OIDC trusted publishing (no secrets needed) and creates one GitHub Release per package with the changeset summaries as the body.
+5. Merging triggers another `release.yml` run that publishes to npm via OIDC trusted publishing (no secrets needed) and creates a single umbrella `vX.Y.Z` GitHub Release for the suite. Per-package detail lives in each `packages/*/CHANGELOG.md`.
+
+### Setup (optional): `RELEASE_PAT` for self-triggering Version PRs
+
+By default, GitHub Actions workflows triggered by pushes from `GITHUB_TOKEN` (which `changesets/action` uses) **do not trigger downstream workflows** — a security feature to prevent infinite-loop scenarios. Without a workaround, Version PRs land with empty CI checks and require a manual close+reopen to start them.
+
+To make Version PRs self-trigger CI, create a fine-grained Personal Access Token and store it as a `RELEASE_PAT` repository secret:
+
+1. **Create the PAT**: github.com/settings/personal-access-tokens → *Generate new token (Fine-grained)*
+   - Resource owner: `vitus-labs`
+   - Repository access: only `vitus-labs/ui-system`
+   - Permissions: Repository → Contents = read+write, Pull requests = read+write, Workflows = read+write
+   - Expiration: long-lived or rotation-based per your security policy
+2. **Add as secret**: repo → Settings → Secrets and variables → Actions → *New repository secret*
+   - Name: `RELEASE_PAT`
+   - Value: (paste the token)
+
+`release.yml` falls back to the default `GITHUB_TOKEN` when `RELEASE_PAT` is unset, so this is genuinely optional — without it, releases still work, you just close+reopen the Version PR once to kick CI.
 
 ### Prerelease channel
 


### PR DESCRIPTION
## Summary

Three fixes for friction points hit during the 2.2.0 bootstrap, so the next release runs hands-off. Each fix is small and independent.

## 1. `changeset-check.yml` — auto-skip Version PRs

The `Changeset` gate failed on the auto-generated Version PR (#209) because it bumps every `package.json` (touches `packages/**`) but *deletes* changesets instead of adding new ones. We unblocked 2.2.0 by manually adding the `skip-changeset` label.

**Fix**: a step-0 in the gate that exits 0 when `pull_request.user.login == 'github-actions[bot]'` AND title starts with `chore: version packages`. Future Version PRs satisfy the required check on their first run — no label needed.

## 2. `release.yml` — drop `createGithubReleases`, add umbrella step

`changesets/action`'s built-in `createGithubReleases: true` hung **after** npm publish had already succeeded, producing zero git tags and zero Releases for 13+ minutes before we cancelled. We worked around it manually by creating a single `v2.2.0` umbrella Release.

**Fix**: replace the built-in flag with a dedicated step that:

- Reads the new version from `packages/core/package.json`.
- Creates and pushes a single `v${VERSION}` git tag (idempotent — skips if it already exists).
- Builds a markdown body listing every published `@scope/name@version` from the action's `publishedPackages` output, plus a pointer to per-package `CHANGELOG.md` for granular detail.
- Calls `gh release create` (idempotent — warns and continues if a Release already exists).

Matches how other fixed-group monorepos (React, Apollo, Babel) ship — single suite-wide Release rather than 15 per-package Releases.

## 3. `release.yml` — optional `RELEASE_PAT` fallback

GitHub intentionally doesn't trigger downstream workflows on pushes from `GITHUB_TOKEN`, so `changesets/action`'s commits to the Version PR's branch never started CI. We had to close+reopen #209 manually to kick checks.

**Fix**: prefer `secrets.RELEASE_PAT` when present, fall back to `secrets.GITHUB_TOKEN`. Without the PAT the flow works exactly as today; with it, Version PRs self-trigger CI on every commit.

### Setup after merge (one-time, optional)

To enable self-triggering Version PRs:

1. **Create a fine-grained PAT** at github.com/settings/personal-access-tokens
   - Resource owner: `vitus-labs`
   - Repository access: only `vitus-labs/ui-system`
   - Permissions: Contents = read+write, Pull requests = read+write, Workflows = read+write
2. **Add as repo secret** Settings → Secrets and variables → Actions → New repository secret
   - Name: `RELEASE_PAT`
   - Value: (paste the token)

Releases work without it — without it you just close+reopen the Version PR once to kick CI.

## Docs

`CONTRIBUTING.md`:

- Updated "How a release happens" to reflect the umbrella Release pattern (was "one GitHub Release per package").
- Added "Setup (optional): `RELEASE_PAT`" subsection with PAT scope + step-by-step instructions.

## Test plan

- [x] All 5 workflow YAMLs parse cleanly (verified manually — no tabs, valid structure)
- [x] Heredoc rendering simulated locally with sample `publishedPackages` JSON — produces expected markdown
- [x] `bun run lint` clean
- [x] `Changeset` CI gate satisfied (this PR doesn't touch `packages/**`, so the gate exits 0 on the "no packages touched" branch)
- [ ] After merge: next release naturally validates all three fixes end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)