### PR TITLE
fix(ci): disable local pre-push hooks in release.yml jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,20 @@ jobs:
 
       - run: bun install --frozen-lockfile
 
+      # `bun install` runs the root `prepare` script which sets
+      # core.hooksPath to .githooks — that hook chains lint+typecheck
+      # before every `git push`. In CI it fires when `changesets/action`
+      # pushes the Version PR commit / publish tags, which made the
+      # action spend minutes re-running typecheck and eventually SIGTERM
+      # itself (observed on the 2.2.1 publish — npm publish succeeded but
+      # the GitHub Release step was killed before it could run).
+      #
+      # The workflow already validates lint/build/typecheck/test in
+      # explicit steps below, so suppressing the hook here removes pure
+      # redundancy — not safety.
+      - name: Disable local git hooks for the publish flow
+        run: git config core.hooksPath /dev/null
+
       - name: Lint & Format
         run: bun run lint
 
@@ -157,6 +171,12 @@ jobs:
           restore-keys: bun-${{ runner.os }}-
 
       - run: bun install --frozen-lockfile
+
+      # Same reason as the stable job — the local pre-push hook would
+      # re-run typecheck on every push by `changeset publish` and could
+      # cancel the action mid-publish.
+      - name: Disable local git hooks for the publish flow
+        run: git config core.hooksPath /dev/null
 
       - name: Build all packages
         run: bun run pkgs:build


### PR DESCRIPTION
## The bug

The 2.2.1 publish run reported `failure` and the umbrella `v2.2.1` GitHub Release wasn't auto-created (I created it manually). npm publish itself completed cleanly — verified `^2.2.1` peerDeps on registry.

**Root cause**: `bun install` runs the root `prepare` script which sets `core.hooksPath` to `.githooks`. `.githooks/pre-push` chains `bun run lint && bun run typecheck` before every `git push`. In CI that fires whenever `changesets/action` pushes a Version PR commit / publish tag.

Log shows ~7 parallel `pre-push: running typecheck...` invocations in 2.5 minutes before:

```
##[error]The operation was canceled.
```

Each typecheck across all 15 packages takes ~15s, so several parallel firings starve the CI runner and the action gets a SIGTERM.

## Fix

Add a single step after `bun install` (in **both** the stable and prerelease jobs) that unsets the hooks path for the duration of the run:

```yaml
- name: Disable local git hooks for the publish flow
  run: git config core.hooksPath /dev/null
```

The workflow already runs `bun run lint` and `bun run typecheck` as explicit named steps before the publish step, so suppressing the local hook in CI removes pure redundancy — not safety. Developers' machines and the PR `CI` workflow are unaffected (those don't go through `release.yml`).

## What was rescued manually

- 2.2.1 npm publishes are correct (verified `^2.2.1` semver in peerDeps)
- `v2.2.1` git tag created at the version-packages merge commit
- `v2.2.1` GitHub Release created with appropriate notes pointing 2.2.0 users to the upgrade

## What still needs doing (out of band)

Deprecate `@vitus-labs/*@2.2.0` on npm with a pointer to 2.2.1 — requires npm auth (OIDC isn't enough; deprecate needs an automation token or `npm login`). Suggested commands:

```bash
for pkg in attrs connector-emotion connector-native connector-styled-components \
           connector-styler coolgrid core elements hooks kinetic kinetic-presets \
           rocketstories rocketstyle styler unistyle; do
  npm deprecate "@vitus-labs/${pkg}@2.2.0" \
    "Broken peerDependencies (workspace:^ shipped literally; Bun refuses to install). Use 2.2.1 or later."
done
```

## Test plan

- [x] YAML clean (no tabs)
- [x] Diff only touches release.yml (lint scope = packages/*/src/, untouched)
- [ ] After merge: next release flow runs end-to-end without the typecheck-hook storm

🤖 Generated with [Claude Code](https://claude.com/claude-code)