### PR TITLE
fix(ci): changeset gate accepts adds OR deletes (retire bot-detection bypass)

### DIFF
--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -23,24 +23,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Verify changeset present (or bypass label)
+      - name: Verify changeset activity (added or consumed)
         env:
           BASE_REF: ${{ github.event.pull_request.base.ref }}
           HAS_SKIP_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'skip-changeset') }}
-          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
-          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
           set -euo pipefail
-
-          # 0. Auto-bypass for the changesets/action-generated Version PR.
-          # That PR bumps every package.json (touches packages/**) but
-          # *deletes* changesets instead of adding new ones — so a literal
-          # reading of the gate fails it. The PR is signed by github-actions
-          # and titled "chore: version packages" — recognise both.
-          if [ "$PR_AUTHOR" = "github-actions[bot]" ] && [[ "$PR_TITLE" == "chore: version packages"* ]]; then
-            echo "::notice::Auto-generated Version PR — bypassing the gate."
-            exit 0
-          fi
 
           # 1. PRs that don't touch packages/ never need a changeset.
           PACKAGE_FILES=$(git diff --name-only "origin/${BASE_REF}...HEAD" -- 'packages/**' || true)
@@ -57,15 +45,21 @@ jobs:
             exit 0
           fi
 
-          # 3. Otherwise, an added .changeset/*.md file is required.
-          ADDED_CHANGESETS=$(git diff --name-only --diff-filter=A "origin/${BASE_REF}...HEAD" -- '.changeset/*.md' || true)
+          # 3. Either ADDING a changeset (regular feature/fix PR) or
+          # DELETING changesets (Version PR consuming them) satisfies the
+          # gate. The intent of the rule is "every package change has a
+          # changelog trail" — consuming a previously-added changeset
+          # honours that just as much as adding a new one. This frames
+          # the Version PR as a first-class workflow PR rather than a
+          # special case needing an author/title bypass.
+          CHANGESET_DIFF=$(git diff --name-only --diff-filter=AD "origin/${BASE_REF}...HEAD" -- '.changeset/*.md' || true)
           # Filter out README.md and config files that don't count.
-          ADDED_CHANGESETS=$(echo "$ADDED_CHANGESETS" | grep -v -E '\.changeset/(README|config)\.(md|json)$' || true)
+          CHANGESET_DIFF=$(echo "$CHANGESET_DIFF" | grep -v -E '\.changeset/(README|config)\.(md|json)$' || true)
 
-          if [ -z "$ADDED_CHANGESETS" ]; then
-            echo "::error::This PR touches packages/ but no changeset is present."
+          if [ -z "$CHANGESET_DIFF" ]; then
+            echo "::error::This PR touches packages/ but no changeset activity is present."
             echo ""
-            echo "To add one:"
+            echo "Add one with:"
             echo "  bun changeset"
             echo "  git add .changeset && git commit -m 'add changeset' && git push"
             echo ""
@@ -74,5 +68,5 @@ jobs:
             exit 1
           fi
 
-          echo "::notice::Changeset(s) found:"
-          echo "$ADDED_CHANGESETS"
+          echo "::notice::Changeset activity found:"
+          echo "$CHANGESET_DIFF"


### PR DESCRIPTION
## Why

When the Version PR consumes changesets, it *deletes* `.changeset/*.md` files instead of adding them. The original gate (#205) required an added file, so #211 added an author+title bypass to recognise the auto-generated Version PR and skip the check.

That bypass works but papers over a **flawed gate rule**. Reframed correctly: the gate's intent is "every package change has a changelog trail" — *consuming* a previously-added changeset honours that intent just as much as *adding* a new one.

## What changes

Replace `--diff-filter=A` (added only) with `--diff-filter=AD` (added or deleted):

```diff
- ADDED_CHANGESETS=$(git diff --name-only --diff-filter=A "origin/${BASE_REF}...HEAD" -- '.changeset/*.md' || true)
+ CHANGESET_DIFF=$(git diff --name-only --diff-filter=AD "origin/${BASE_REF}...HEAD" -- '.changeset/*.md' || true)
```

Remove the now-redundant **author+title bypass** for `github-actions[bot]`-authored Version PRs.

## Behavioural matrix

| PR shape | Old gate | New gate |
|---|---|---|
| Adds `.changeset/foo.md`, touches packages | ✅ pass | ✅ pass |
| **Version PR: deletes `.changeset/*.md`, touches packages** | ❌ → bypassed via author+title | ✅ pass legitimately |
| Touches packages, no changeset activity, no label | ❌ fail (with helpful msg) | ❌ fail (with helpful msg) |
| Touches packages, has `skip-changeset` label | ✅ pass | ✅ pass |
| Doesn't touch packages at all | ✅ pass | ✅ pass |

## Verification

`git diff --name-only --diff-filter=AD 084f1108^..084f1108 -- '.changeset/*.md'` (over the v2.2.0 Version PR merge) correctly returns all 7 consumed changesets — exactly what the new gate would accept.

## Why this is the last refactor

This is the **only** self-inflicted workaround in the release flow. Everything else we have is correct adaptation to npm/GitHub/hooks limitations:

- `scripts/rewrite-workspace-peers.mjs` (#217) — fills an npm gap, fundamental.
- Experimental Changesets flag (#208) — fixed-group + peer-dep semver requires it, fundamental.
- `core.hooksPath /dev/null` in CI (#219) — hooks shouldn't fire in CI, fundamental.
- Custom umbrella Release step (#211) — `createGithubReleases` was unreliable; replacing it with our own step is fundamental.
- `RELEASE_PAT` fallback (#211) — GitHub's bot-pushes-don't-trigger-CI model; not fixable without a PAT.

Retire just this one and stop. The architecture is sound.

🤖 Generated with [Claude Code](https://claude.com/claude-code)