### PR TITLE
fix(elements): add LooseList + LooseIterator aliases for HOC wrapping

### DIFF
--- a/.changeset/fix-list-iterator-loose-export.md
+++ b/.changeset/fix-list-iterator-loose-export.md
@@ -1,0 +1,24 @@
+---
+"@vitus-labs/elements": patch
+---
+
+Add `LooseList` named export (and internal `LooseIterator` helper) — a loose-typed alias over the same runtime component, designed for use with HOC machinery like rocketstyle that wraps a component and reads `ExtractProps<typeof Component>` to derive the wrapper's prop surface.
+
+**Why:** the strict overloaded `ListComponent` / `IteratorComponent` interfaces introduced in 2.2.0 (PR #199) give direct JSX callers per-mode narrowing (`<List data={users} valueName="x" />` rejected for object arrays, etc.), but `ExtractProps<typeof List>` resolves overloaded interfaces via the LAST overload — which is `ChildrenProps & ListExtras & RefExtra`, requiring `children`. That broke a 2.1.0 pattern where consumers wrapped `List` with rocketstyle and got a loose iterator surface.
+
+**Why a separate export instead of fixing the default:** a single callable can't be both strict-per-T at call sites and loose for `infer P` reflection. Loose fallbacks (overload-last or generic-with-default) bleed into call-site resolution and defeat the narrowing.
+
+**Usage:**
+
+```ts
+import List, { LooseList } from '@vitus-labs/elements'
+
+// Direct use — keeps full narrowing
+<List data={users} valueName="x" />          // ❌ correctly rejected
+
+// HOC wrapping — uses the loose alias
+const StyledList = rocketstyle()({ component: LooseList })
+<StyledList data={[...]} />                  // ✅ works
+```
+
+Same runtime component under both names — no breaking change to existing imports.

--- a/packages/elements/src/List/component.tsx
+++ b/packages/elements/src/List/component.tsx
@@ -117,3 +117,37 @@ export interface ListComponent {
 }
 
 export default Component as unknown as ListComponent
+
+// ---------------------------------------------------------------------------
+// Loose-typed alias for HOC composition (rocketstyle wrapping etc.)
+//
+// `ListComponent`'s strict overloads give direct JSX callers per-mode
+// narrowing — but `ExtractProps<typeof List>` (used by rocketstyle and other
+// HOC machinery to derive the wrapper's prop surface) resolves overloaded
+// interfaces via the *last* signature, which is `IteratorChildrenProps &
+// ListExtras & RefExtra` — much narrower than 2.1.0's loose surface and
+// requires `children`.
+//
+// The fundamental TS constraint: a single callable can't be both
+// strict-per-T at call sites AND loose for `infer P` reflection. Loose
+// fallbacks at the call site (overload-last or generic-with-default) bleed
+// into call-site resolution and defeat the narrowing.
+//
+// Solution: export the same runtime under two type identities. Direct
+// consumers use the default `List` for full narrowing; HOC consumers use
+// `LooseList` for the loose, wrappable surface.
+//
+//   import List from '@vitus-labs/elements'
+//   <List data={users} valueName="x" />              // ❌ correctly narrowed
+//
+//   import { LooseList } from '@vitus-labs/elements'
+//   const Styled = rocketstyle()({ component: LooseList })
+//   <Styled data={users} />                          // ✅ wrappable
+//
+export const LooseList = Component as unknown as ((
+  props: IteratorLooseProps & ListExtras & RefExtra,
+) => ReactNode) & {
+  displayName?: string
+  pkgName?: string
+  VITUS_LABS__COMPONENT?: string
+}

--- a/packages/elements/src/List/index.ts
+++ b/packages/elements/src/List/index.ts
@@ -1,6 +1,7 @@
 import type { Props } from './component'
-import component from './component'
+import component, { LooseList } from './component'
 
 export type { Props }
+export { LooseList }
 
 export default component

--- a/packages/elements/src/__tests__/List.loose.test-d.ts
+++ b/packages/elements/src/__tests__/List.loose.test-d.ts
@@ -1,0 +1,60 @@
+/**
+ * Type-level smoke tests for the dual-export pattern that lets List/Iterator
+ * be:
+ *  1. Strict-narrowing at direct JSX call sites (the #199 design).
+ *  2. Wrappable by HOC machinery like rocketstyle (the 2.1.0 back-compat).
+ *
+ * The two requirements can't coexist in one callable — TS's call-site
+ * overload resolution and `infer P` extraction both read from the same
+ * callable signature, so a loose fallback that satisfies (2) bleeds into (1)
+ * and defeats the narrowing. Solving it requires two type identities over
+ * the same runtime component: `List` (strict) and `LooseList` (loose). This
+ * file pins the contract for both.
+ */
+import type { ComponentType } from 'react'
+import { expectTypeOf } from 'vitest'
+import type { LooseProps as IteratorLooseProps } from '~/helpers/Iterator'
+import type ListDefault from '~/List'
+import type { LooseList } from '~/List'
+
+// rocketstyle's ExtractProps (verbatim from packages/rocketstyle/src/types/utils.ts)
+type ExtractProps<TComponentOrTProps> =
+  TComponentOrTProps extends ComponentType<infer TProps>
+    ? TProps
+    : TComponentOrTProps
+
+// ---------------------------------------------------------------------------
+// Direct surface (`List`) — strict narrowing preserved
+// ---------------------------------------------------------------------------
+
+// The strict default extracts to the last (narrowest) overload — that's the
+// existing behaviour we're explicitly NOT changing. The Iterator.jsx-inference
+// test-d file pins the call-site narrowing (`<List data={users}
+// valueName="x" />` rejected, etc.); this assertion just records that the
+// default extraction is still narrow, so callers know they need `LooseList`
+// for HOC composition.
+type DirectExtract = ExtractProps<typeof ListDefault>
+
+// `LooseProps` (everything optional) is NOT assignable to `DirectExtract`
+// because the narrowest overload requires `children`. If this assertion
+// flips, something widened the default surface — likely accidental.
+type DirectIsLoose = IteratorLooseProps extends DirectExtract ? true : false
+expectTypeOf<DirectIsLoose>().toEqualTypeOf<false>()
+
+// ---------------------------------------------------------------------------
+// Loose surface (`LooseList`) — wrappable
+// ---------------------------------------------------------------------------
+
+type LooseExtract = ExtractProps<typeof LooseList>
+
+// 1. `LooseProps` is assignable to `LooseExtract` (LooseList accepts loose
+//    props — the wrapping back-compat path).
+const _looseAccepted: LooseExtract = {} as IteratorLooseProps
+void _looseAccepted
+
+// 2. `LooseExtract` is assignable to `LooseProps` (LooseList's surface
+//    doesn't add hidden required fields beyond the loose set + Element +
+//    ref slot).
+declare const looseValue: LooseExtract
+const _: IteratorLooseProps = looseValue
+void _

--- a/packages/elements/src/__tests__/LooseList.rocketstyle.test-d.tsx
+++ b/packages/elements/src/__tests__/LooseList.rocketstyle.test-d.tsx
@@ -1,0 +1,54 @@
+/**
+ * Integration check: `LooseList` actually composes with rocketstyle.
+ *
+ * The escape-hatch export is only useful if `rocketstyle()({ component:
+ * LooseList })` actually produces a wrapper whose typed JSX surface
+ * accepts iterator props. This file fails `bun run typecheck` if that
+ * round-trip breaks.
+ */
+import rocketstyle from '@vitus-labs/rocketstyle'
+import List, { LooseList } from '~/List'
+
+type User = { id: number; name: string }
+
+declare const users: User[]
+declare const Card: (p: User) => React.ReactNode
+
+// ---------------------------------------------------------------------------
+// LooseList wraps cleanly — iterator surface preserved at the JSX call site
+// ---------------------------------------------------------------------------
+
+const StyledList = rocketstyle()({
+  component: LooseList,
+  name: 'StyledList',
+}).theme(() => ({ rootSize: 16 }))
+
+// Object array — must compile
+const _objArray = <StyledList data={users} component={Card} itemKey="id" />
+
+// String array — must compile
+declare const strings: string[]
+declare const Item: (p: { children: string }) => React.ReactNode
+const _strArray = (
+  <StyledList data={strings} component={Item} valueName="children" />
+)
+
+// itemProps callback — works (loose surface accepts any callback)
+const _withItemProps = (
+  <StyledList
+    data={users}
+    component={Card}
+    itemKey="id"
+    itemProps={(item) => ({ 'data-id': (item as User).id })}
+  />
+)
+
+// ---------------------------------------------------------------------------
+// Strict default `List` STILL rejects misuse — #199 narrowing intact
+// ---------------------------------------------------------------------------
+
+// MUST FAIL: object arrays forbid valueName
+// @ts-expect-error — valueName forbidden on object arrays
+const _strictFails = <List data={users} valueName="text" component={Card} />
+
+export { _objArray, _strArray, _strictFails, _withItemProps }

--- a/packages/elements/src/helpers/Iterator/component.tsx
+++ b/packages/elements/src/helpers/Iterator/component.tsx
@@ -19,6 +19,7 @@ import type {
   ChildrenProps,
   ElementType,
   ExtendedProps,
+  LooseProps,
   ObjectProps,
   ObjectValue,
   Props,
@@ -297,6 +298,35 @@ export interface IteratorComponent {
 const Iterator = Object.assign(memo(Component), {
   isIterator: true as const,
   RESERVED_PROPS,
-}) as unknown as IteratorComponent
+})
 
-export default Iterator
+export default Iterator as unknown as IteratorComponent
+
+// ---------------------------------------------------------------------------
+// Loose-typed alias for HOC composition (rocketstyle wrapping etc.)
+//
+// `IteratorComponent`'s strict overloads give direct JSX callers per-mode
+// narrowing — but `ExtractProps<typeof Iterator>` (used by rocketstyle and
+// other HOC machinery) resolves overloaded interfaces via the *last*
+// signature, which is `ChildrenProps` — much narrower than 2.1.0's loose
+// surface and requires `children`.
+//
+// A single callable can't be both strict-per-T at call sites AND loose for
+// `infer P` reflection. The dual export pattern lets direct consumers keep
+// full narrowing while HOC consumers get a wrappable surface. See
+// `LooseList` for the same pattern in the List package.
+//
+//   import Iterator from '~/helpers/Iterator'
+//   <Iterator data={users} valueName="x" />          // ❌ correctly narrowed
+//
+//   import { LooseIterator } from '~/helpers/Iterator'
+//   const Wrapped = rocketstyle()({ component: LooseIterator })
+//   <Wrapped data={users} />                         // ✅ wrappable
+//
+export const LooseIterator = Iterator as unknown as ((
+  props: LooseProps,
+) => ReactNode) & {
+  isIterator: true
+  RESERVED_PROPS: typeof RESERVED_PROPS
+  displayName?: string
+}

--- a/packages/elements/src/helpers/Iterator/index.ts
+++ b/packages/elements/src/helpers/Iterator/index.ts
@@ -1,4 +1,4 @@
-import component from './component'
+import component, { LooseIterator } from './component'
 import type {
   ChildrenProps,
   ElementType,
@@ -24,5 +24,7 @@ export type {
   SimpleProps,
   SimpleValue,
 }
+
+export { LooseIterator }
 
 export default component

--- a/packages/elements/src/index.ts
+++ b/packages/elements/src/index.ts
@@ -9,7 +9,7 @@ import type {
   PropsCallback,
 } from '~/helpers/Iterator'
 import type { Props as ListProps } from '~/List'
-import List from '~/List'
+import List, { LooseList } from '~/List'
 import type { Props as OverlayProps, UseOverlayProps } from '~/Overlay'
 import Overlay, { OverlayProvider, useOverlay } from '~/Overlay'
 import type { Props as PortalProps } from '~/Portal'
@@ -61,6 +61,7 @@ export type {
 export {
   Element,
   List,
+  LooseList,
   Overlay,
   OverlayProvider,
   Portal,


### PR DESCRIPTION
## Problem

The strict overloaded `ListComponent` / `IteratorComponent` interfaces introduced in 2.2.0 (PR #199) give direct JSX callers per-mode narrowing — `<List data={users} valueName="x" />` correctly rejected, `itemProps={(user) => …}` callbacks narrow to `User`, etc.

But `ExtractProps<typeof List>` resolves overloaded interfaces via the **last** overload — `ChildrenProps & ListExtras & RefExtra` — which requires `children`. That broke a 2.1.0 pattern where consumers did `rocketstyle()({ component: List })` and got a loose iterator surface to work against. Reported by a consumer.

## Why this needs a separate export rather than "fix the default"

A single callable type can't be both strict-per-T at call sites **and** loose for `infer P` reflection — TypeScript reads both from the same signature. I prototyped both alternatives:

1. **Add a loose-fallback overload as the last signature** → call-site overload resolution picks the loose one whenever the narrow overloads miss; ALL 5 `@ts-expect-error` narrowing checks from #199 broke.
2. **Collapse to a single generic with `T = unknown` default** → callback args (e.g. `itemProps={(user) => …}`) widened to the loose union instead of narrowing to `User`.

Both confirmed there's no single-callable design that achieves both goals. The dual export is the standard escape hatch.

## What ships

- `packages/elements/src/List/component.tsx` — adds `LooseList` named export (same runtime as `List`, typed as a single callable accepting `LooseProps & ListExtras & RefExtra`).
- `packages/elements/src/helpers/Iterator/component.tsx` — adds `LooseIterator` named export with the same pattern.
- Re-exported from `List/index.ts`, `helpers/Iterator/index.ts`, and (`LooseList` only — `LooseIterator` stays an internal helper) `packages/elements/src/index.ts`.
- `packages/elements/src/__tests__/List.loose.test-d.ts` — type-level test pinning both contracts: strict default doesn't accept `LooseProps`, loose alias does.

## Usage

```ts
import List, { LooseList } from '@vitus-labs/elements'

// Direct use — keeps full narrowing
<List data={users} valueName="x" />            // ❌ correctly rejected

// HOC wrapping — uses the loose alias
const StyledList = rocketstyle()({ component: LooseList })
<StyledList data={[…]} />                       // ✅ works
```

## Verified

- New type-level test `List.loose.test-d.ts` pins both surfaces
- Existing `Iterator.jsx-inference.test-d.tsx` (all 5 `@ts-expect-error` checks from #199) still fires — narrowing on the default export unaffected
- Pipeline: **2668 tests pass**, lint clean, typecheck clean across all 15 packages, build clean
- `Changeset` CI gate satisfied (`.changeset/fix-list-iterator-loose-export.md` added)

## Trade-off and alternatives considered

| Option | Strict narrowing (#199) | Loose wrapping (2.1.0) |
|---|---|---|
| Current 2.2.x | ✅ yes | ❌ broken |
| Revert #199 entirely | ❌ lost | ✅ restored |
| Loose-fallback overload | ❌ broken | ✅ yes |
| Single generic w/ default | ❌ broken | ✅ yes |
| **Dual export (this PR)** | **✅ kept** | **✅ restored (opt-in)** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)