### PR TITLE
feat(rocketstyle): preserve overload narrowing through wrapping

### DIFF
--- a/.changeset/fix-rocketstyle-overload-narrowing.md
+++ b/.changeset/fix-rocketstyle-overload-narrowing.md
@@ -1,0 +1,22 @@
+---
+'@vitus-labs/rocketstyle': minor
+---
+
+Preserve per-mode narrowing on overloaded components through `rocketstyle()` wrapping.
+
+PR #199 made `Iterator` and `List` overloaded interfaces so direct call sites get strict per-mode discrimination (e.g. `<List data={users} valueName="x" />` is rejected because `valueName?: never` on the object-array branch). Wrapping with `rocketstyle()({ component: List })` lost that — `ExtractProps<C>` picked the last overload, so the wrapper exposed only `ChildrenProps` and every iterator-style call errored.
+
+The fix is two-layered:
+
+- `ExtractProps` now pattern-matches against 1–4 callable overloads and returns the union of every overload's first-param type. Single-callable and plain-object inputs fall through to the previous behaviour unchanged.
+- `IRocketStyleComponent`'s `DFP` distributes over `OA`'s union branches and intersects each branch raw (not via `MergeTypes`), so `valueName?: never` markers survive — `MergeTypes`' `ExtractNullableKeys` would otherwise strip them.
+
+Result on wrapped components like `rocketstyle()({ component: List })`:
+
+- `<StyledList data={users} component={Card} />` — compiles (object-array branch).
+- `<StyledList data={users} valueName="x" component={Card} />` — rejected.
+- `<StyledList data={strings} component={Item} valueName="x" />` — compiles (string-array branch).
+- `<StyledList>{children}</StyledList>` — compiles (children branch).
+- `<StyledList data={strings}>{children}</StyledList>` — rejected (mode mixing).
+
+Trade-off: per-`T` narrowing inside `itemProps` / `wrapProps` callbacks is lost through the wrap (the callback's `item` argument is the constraint's upper bound, not the consumer's concrete `T`). Direct `<List data={users} itemProps={(u) => …} />` keeps full per-`T` narrowing. Wrapped consumers who need the concrete type in callbacks can annotate explicitly: `itemProps={(item: User) => …}`.

--- a/packages/rocketstyle/src/__tests__/ExtractProps.test-d.ts
+++ b/packages/rocketstyle/src/__tests__/ExtractProps.test-d.ts
@@ -1,0 +1,71 @@
+/**
+ * Type-level pin for `ExtractProps`. Tracks the contract:
+ *
+ *  - Components with N (≤4) callable overloads → union of all overload props.
+ *  - Components with a single signature → that signature's props (today's
+ *    behaviour, unchanged).
+ *  - Plain object types → returned as-is (today's behaviour, unchanged).
+ *
+ * The contract matters because `RocketStyleComponent`'s `OA` generic is
+ * `ExtractProps<C>` (rocketComponent.ts:14) — if this widens or narrows
+ * unexpectedly, every wrapped component's JSX surface shifts.
+ */
+import type { ReactNode } from 'react'
+import { expectTypeOf } from 'vitest'
+import type { ExtractProps } from '~/types/utils'
+
+// ─── Single-signature component (today's behaviour) ──────────────────
+type Simple = (props: { foo: string }) => ReactNode
+
+expectTypeOf<ExtractProps<Simple>>().toEqualTypeOf<{ foo: string }>()
+
+// ─── Plain object (passes through) ───────────────────────────────────
+type PlainObj = { bar: number }
+
+expectTypeOf<ExtractProps<PlainObj>>().toEqualTypeOf<PlainObj>()
+
+// ─── 2-overload component ────────────────────────────────────────────
+interface TwoOverload {
+  (props: { mode: 'a'; data: string }): ReactNode
+  (props: { mode: 'b'; data: number }): ReactNode
+}
+
+type TwoExtracted = ExtractProps<TwoOverload>
+// Union — both overload param types accessible.
+expectTypeOf<{ mode: 'a'; data: string }>().toMatchTypeOf<TwoExtracted>()
+expectTypeOf<{ mode: 'b'; data: number }>().toMatchTypeOf<TwoExtracted>()
+
+// ─── 3-overload component (Iterator / List shape) ────────────────────
+interface ThreeOverload {
+  <T extends string | number>(props: { mode: 'simple'; data: T[] }): ReactNode
+  <T extends object>(props: { mode: 'object'; data: T[] }): ReactNode
+  (props: { mode: 'children'; children: ReactNode }): ReactNode
+}
+
+type ThreeExtracted = ExtractProps<ThreeOverload>
+// All three branches must be assignable into the extracted union.
+expectTypeOf<{
+  mode: 'simple'
+  data: (string | number)[]
+}>().toMatchTypeOf<ThreeExtracted>()
+expectTypeOf<{
+  mode: 'object'
+  data: object[]
+}>().toMatchTypeOf<ThreeExtracted>()
+expectTypeOf<{
+  mode: 'children'
+  children: ReactNode
+}>().toMatchTypeOf<ThreeExtracted>()
+
+// ─── Mixed: overloads + static properties (List's actual shape) ──────
+interface OverloadedWithStatics {
+  (props: { kind: 'a' }): ReactNode
+  (props: { kind: 'b' }): ReactNode
+  displayName?: string
+  isMarker: true
+}
+
+type MixedExtracted = ExtractProps<OverloadedWithStatics>
+// Statics don't show up — only the call signatures' params.
+expectTypeOf<{ kind: 'a' }>().toMatchTypeOf<MixedExtracted>()
+expectTypeOf<{ kind: 'b' }>().toMatchTypeOf<MixedExtracted>()

--- a/packages/rocketstyle/src/__tests__/wrap-iterator.test-d.tsx
+++ b/packages/rocketstyle/src/__tests__/wrap-iterator.test-d.tsx
@@ -1,0 +1,67 @@
+/**
+ * Integration: does `rocketstyle()({ component: List })` produce a wrapper
+ * whose JSX call site preserves the per-mode narrowing #199 introduced on
+ * direct `<List>` usage?
+ *
+ * `bun run typecheck` fails if narrowing-through-wrap regresses:
+ *   - `valueName` on object arrays — must be rejected on the wrapper.
+ *   - `data` + `children` mode-mixing — must be rejected.
+ *   - Object-array mode with the right shape — must compile.
+ *   - String-array mode with `valueName` — must compile.
+ *   - Children-only mode — must compile.
+ *
+ * Note on per-T narrowing inside the wrapped surface: `keyof ObjectValue`
+ * widens to `string | number | symbol` (ObjectValue includes
+ * `Record<string, unknown>`), so `itemKey="anything"` is accepted on the
+ * wrapper — that's a documented trade-off of going through ExtractProps
+ * (the wrapped T substitutes its upper bound). Direct `<List …>` calls
+ * keep per-T narrowing.
+ */
+import { List } from '@vitus-labs/elements'
+import rocketstyle from '~/init'
+
+type User = { id: number; name: string }
+
+declare const users: User[]
+declare const strings: string[]
+declare const Card: (p: User) => React.ReactNode
+declare const Item: (p: { children: string }) => React.ReactNode
+
+// ─── Wrap List with rocketstyle (no manual type annotations) ────────
+const StyledList = rocketstyle()({
+  component: List,
+  name: 'StyledList',
+}).theme(() => ({ rootSize: 16 }))
+
+// ─── Compile: legal calls through the wrapper ────────────────────────
+
+// Object array mode
+const _obj = <StyledList data={users} component={Card} itemKey="id" />
+
+// String array mode
+const _str = <StyledList data={strings} component={Item} valueName="children" />
+
+// Children mode
+const _children = (
+  <StyledList>
+    <span>x</span>
+  </StyledList>
+)
+
+// ─── Fail: illegal calls must be rejected by the narrowing ───────────
+
+// MUST FAIL: valueName forbidden on object arrays
+const _badValueName = (
+  // @ts-expect-error — valueName forbidden on object arrays (Object branch)
+  <StyledList data={users} valueName="text" component={Card} />
+)
+
+// MUST FAIL: Children mode forbids `data`
+const _modeMix = (
+  // @ts-expect-error — children mode rejects `data`
+  <StyledList data={strings}>
+    <span>x</span>
+  </StyledList>
+)
+
+export { _badValueName, _children, _modeMix, _obj, _str }

--- a/packages/rocketstyle/src/types/rocketstyle.ts
+++ b/packages/rocketstyle/src/types/rocketstyle.ts
@@ -88,7 +88,24 @@ export interface IRocketStyleComponent<
   // dimension key props
   DKP extends TDKP = TDKP,
   // calculated final props
-  DFP = MergeTypes<[OA, EA, DefaultProps, ExtractDimensionProps<D, DKP, UB>]>,
+  //
+  // `OA extends infer O` distributes over OA's union branches so a wrapper
+  // around an overloaded component (`ExtractProps<typeof List>` is a
+  // 3-branch union after the new ExtractProps) yields a discriminated DFP
+  // union — one MergeTypes per branch.
+  //
+  // Critically: OA is intersected raw, NOT fed through MergeTypes. The
+  // wrapped component's prop type (e.g. `ObjectProps<O>`) uses `valueName?:
+  // never` as the discrimination mechanism (#199); MergeTypes' inner
+  // `ExtractNullableKeys` strips keys whose type is `never | undefined`,
+  // which would erase that discrimination and let `<StyledList
+  // data={users} valueName="x" />` compile against the object branch.
+  // Keeping OA outside MergeTypes preserves all `?: never` markers from
+  // each overload branch, so per-mode rejection fires at the JSX call
+  // site of the wrapper just like it does on the direct component.
+  DFP = OA extends infer O
+    ? O & MergeTypes<[EA, DefaultProps, ExtractDimensionProps<D, DKP, UB>]>
+    : never,
 > {
   (props: DFP & { ref?: any }): ReactNode
   // CONFIG chaining method

--- a/packages/rocketstyle/src/types/utils.ts
+++ b/packages/rocketstyle/src/types/utils.ts
@@ -56,7 +56,42 @@ export type MergeTypes<A extends readonly [...any]> = ExtractNullableKeys<
 >
 
 // ─── ExtractProps ─────────────────────────────────────────────
-export type ExtractProps<TComponentOrTProps> =
-  TComponentOrTProps extends ComponentType<infer TProps>
-    ? TProps
-    : TComponentOrTProps
+// Extracts the prop type from a component-or-type input. For components
+// with multiple call overloads (e.g. `Iterator` / `List` from
+// `@vitus-labs/elements` after PR #199), the union of every overload's
+// first-param type is returned so the wrapper's JSX call site can match
+// any of them — preserving the per-mode narrowing that #199 introduced
+// (e.g. `valueName` forbidden on object arrays) instead of collapsing
+// to the last overload alone.
+//
+// Inference order: 4-overload, 3-overload, 2-overload, single-callable
+// fallback (ComponentType<TProps>). The fallback path matches today's
+// behaviour for non-overloaded components — no behaviour change there.
+// Trade-off: generic type parameters in overloads are substituted with
+// their upper bound (so `<T extends ObjectValue>(props: ObjectProps<T>)`
+// extracts as `ObjectProps<ObjectValue>`, not `ObjectProps<T>` — TS
+// can't re-export the generic). Direct call sites against the original
+// component keep per-T narrowing intact; only the wrapped surface loses
+// it inside `itemProps` callbacks. Acceptable trade-off because per-mode
+// rejection (the actually-load-bearing part of #199) still fires.
+export type ExtractProps<TComponentOrTProps> = TComponentOrTProps extends {
+  (props: infer P1, ...args: any): any
+  (props: infer P2, ...args: any): any
+  (props: infer P3, ...args: any): any
+  (props: infer P4, ...args: any): any
+}
+  ? P1 | P2 | P3 | P4
+  : TComponentOrTProps extends {
+        (props: infer P1, ...args: any): any
+        (props: infer P2, ...args: any): any
+        (props: infer P3, ...args: any): any
+      }
+    ? P1 | P2 | P3
+    : TComponentOrTProps extends {
+          (props: infer P1, ...args: any): any
+          (props: infer P2, ...args: any): any
+        }
+      ? P1 | P2
+      : TComponentOrTProps extends ComponentType<infer TProps>
+        ? TProps
+        : TComponentOrTProps


### PR DESCRIPTION
## Summary

PR #199 made `Iterator`/`List` overloaded interfaces so direct `<List>` call sites get strict per-mode discrimination (e.g. `<List data={users} valueName="x" />` is rejected because `valueName?: never` on the object branch). Wrapping with `rocketstyle()({ component: List })` lost that — `ExtractProps<C>` picked only the **last** overload (`ChildrenProps`), so every iterator-style call on the wrapper errored asking for `children`.

This restores #199's per-mode narrowing on the wrapper without consumer-side type annotations, using a two-layer fix:

- **`ExtractProps`** (`packages/rocketstyle/src/types/utils.ts`) — pattern-matches against 1–4 callable overloads and unions every overload's first-param type. Single-callable and plain-object inputs fall through to today's behaviour unchanged.
- **`IRocketStyleComponent.DFP`** (`packages/rocketstyle/src/types/rocketstyle.ts`) — distributes over `OA`'s union branches and intersects each branch **raw** (not via `MergeTypes`). The intersection matters because `MergeTypes`' `ExtractNullableKeys` strips keys whose type is `never | undefined`, which would erase the `valueName?: never` discriminator on the object branch and let illegal calls compile.

Result on `rocketstyle()({ component: List })`:

| Call | Result |
|---|---|
| `<StyledList data={users} component={Card} itemKey="id" />` | ✅ compiles (object) |
| `<StyledList data={strings} component={Item} valueName="x" />` | ✅ compiles (simple) |
| `<StyledList>{children}</StyledList>` | ✅ compiles (children) |
| `<StyledList data={users} valueName="x" component={Card} />` | ✅ rejected |
| `<StyledList data={strings}>{children}</StyledList>` | ✅ rejected |

### Trade-off

Per-`T` narrowing inside `itemProps`/`wrapProps` callbacks is lost through the wrap — the callback's `item` argument is the constraint's upper bound (`ObjectValue`), not the consumer's concrete `T` (`User`). Direct `<List data={users} itemProps={(u) => …} />` keeps full per-`T` narrowing. Wrapped consumers who need the concrete type in callbacks annotate explicitly: `itemProps={(item: User) => …}`.

This is a fundamental TS limitation: `infer P` on a generic overload substitutes the type parameter with its upper bound; there's no syntax to capture both the param type AND its generic for re-export.

## Test plan

- [x] `bun run typecheck` — all 15 packages clean
- [x] `bun run test` — 2668 tests pass
- [x] `bun run lint` — clean
- [x] `bun run pkgs:build` — all 15 packages build
- [x] New `ExtractProps.test-d.ts` — pins union behaviour for 1/2/3-overload components, plain objects, mixed overload+statics
- [x] New `wrap-iterator.test-d.tsx` — integration: legal calls compile, illegal calls trigger `@ts-expect-error` on the wrapper's JSX call site
- [x] Existing `Iterator.jsx-inference.test-d.tsx` still passes — direct-call narrowing untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)