### PR TITLE
chore(deps): bump CI actions to latest pinned versions

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -60,7 +60,7 @@ jobs:
         run: bun run size --json > /tmp/base.json
 
       - name: Diff and comment
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v8.0.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const fs = require('fs')
@@ -210,7 +210,7 @@ jobs:
 
       - name: Post preview comment
         if: steps.detect.outputs.has_changesets == 'true'
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v8.0.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const fs = require('fs')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Coverage report
         if: github.event_name == 'pull_request'
-        uses: davelosert/vitest-coverage-report-action@3c50566c523e04813df28de8f7c48dd97d663f1c # v2.11.2
+        uses: davelosert/vitest-coverage-report-action@02f3c2e641286b7fa308cd3e430783103ce6103b # v2.12.0
         with:
           json-summary-path: ./coverage/coverage-summary.json
           json-final-path: ./coverage/coverage-final.json

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -32,10 +32,10 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@c3f298df8c1fea2fefe20c785e6aa00f32df8260 # v4.35.3
+        uses: github/codeql-action/init@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
         with:
           languages: ${{ matrix.language }}
           queries: security-extended
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@c3f298df8c1fea2fefe20c785e6aa00f32df8260 # v4.35.3
+        uses: github/codeql-action/analyze@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,7 @@ jobs:
 
       - name: Create Release PR or Publish
         id: changesets
-        uses: changesets/action@6a0a831ff30acef54f2c6aa1cbbc1096b066edaf # v1.7.0
+        uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b # v1.8.0
         with:
           version: bun run version-packages
           publish: bun run release


### PR DESCRIPTION
## Summary

Bumps all GitHub Actions in [.github/workflows/](.github/workflows/) to their latest versions, SHA-pinned. Supersedes dependabot PRs #212, #213, #215 (those can be closed once this merges).

| Action | From | To |
|---|---|---|
| `actions/github-script` | v8.0.0 | v9.0.0 |
| `changesets/action` | v1.7.0 | v1.8.0 |
| `github/codeql-action` | v4.35.3 | v4.35.4 |
| `davelosert/vitest-coverage-report-action` | v2.11.2 | v2.12.0 |

Already on latest (no change): `actions/cache@v5.0.5`, `actions/checkout@v6.0.2`, `actions/setup-node@v6.4.0`, `oven-sh/setup-bun@v2.2.0`, `step-security/harden-runner@v2.19.1`.

## Notes on `actions/github-script` v9

v9 has documented breaking changes — but neither applies here:

- ❌ `require('@actions/github')` no longer works → we don't use it (grepped).
- ❌ `getOctokit` is now an injected parameter → we don't redeclare it.

Our scripts use the injected `github.rest.*` client and `context.*` — both unchanged.

## Test plan

- [ ] All CI jobs green on this PR (CodeQL, ci.yml, bundle-size preview).
- [ ] After merge, the next release PR exercises `changesets/action@v1.8.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)