### PR TITLE
feat(rocketstyle): .attrs() keys become optional at JSX call site

### DIFF
--- a/.changeset/feat-rocketstyle-attrs-optional-defaults.md
+++ b/.changeset/feat-rocketstyle-attrs-optional-defaults.md
@@ -1,0 +1,27 @@
+---
+'@vitus-labs/rocketstyle': minor
+---
+
+`.attrs({ x: defaultValue })` now makes `x` optional at the JSX call site.
+
+Semantically, `.attrs()` provides a runtime default — so the consumer shouldn't be required to pass that prop. The previous types didn't reflect that: keys passed to `.attrs()` stayed required at the call site (especially when they overlapped with the wrapped component's required props, e.g. `component` on `List`).
+
+Two changes:
+
+- **DFP widening**: `IRocketStyleComponent`'s `DFP` now strips OA keys that EA defaults and re-adds them as `Partial`, and feeds `Partial<EA>` into the merge — every `.attrs()`-provided key becomes optional at the call site.
+- **`.attrs()` inference**: previously the object-form `.attrs({ … })` didn't update EA without an explicit `<P>` annotation (the param type `Partial<MergeTypes<[DFP, P]>>` defeated P inference). The new signature uses `P & Partial<NoInfer<DFP>>`, letting TS infer P from the param's keys while still accepting extra DFP defaults.
+
+Result on wrappers like:
+
+```ts
+const CardList = rocketstyle()({ component: List, name: 'CardList' })
+  .attrs({ component: Card, rootElement: false })
+```
+
+- `<CardList data={users} itemKey="id" />` — compiles (component default from .attrs).
+- `<CardList data={users} component={OtherCard} itemKey="id" />` — still compiles (override).
+- `<CardList data={users} valueName="x" />` — still rejected (per-mode narrowing from #222 preserved).
+
+**Behavior change to be aware of**: `.attrs<{ isRequired: boolean }>({ isRequired: true })` no longer requires `isRequired` at the JSX call site (it has a default). This is consistent with what `.attrs` means, but if anyone was relying on `.attrs()` keys being required JSX props, that no longer holds.
+
+Callback-form `.attrs((props) => …)` does not infer P; pass it explicitly (`.attrs<P>((props) => …)`) if you want callback-set defaults to widen the type surface.

--- a/packages/rocketstyle/src/__tests__/attrs-widening.test-d.tsx
+++ b/packages/rocketstyle/src/__tests__/attrs-widening.test-d.tsx
@@ -1,0 +1,57 @@
+/**
+ * `.attrs({ x: defaultValue })` provides a runtime default for `x` — so at
+ * the JSX call site, `x` is optional, not required. This test pins that
+ * widening for both:
+ *
+ *   - keys that exist on the wrapped component (OA-overlapping):
+ *     `.attrs({ component: Card })` makes `component` optional even though
+ *     `ObjectProps['component']` is required.
+ *   - keys that are new (EA-only): `.attrs<{ tone: string }>({ tone: 'a' })`
+ *     makes `tone` optional at the call site.
+ */
+import { List } from '@vitus-labs/elements'
+import rocketstyle from '~/init'
+
+type User = { id: number; name: string }
+
+declare const users: User[]
+declare const Card: (p: User) => React.ReactNode
+
+// ─── OA-overlapping key: `component` ────────────────────────────────
+// List's ObjectProps requires `component`. After `.attrs({ component })`,
+// the consumer can omit it — the default fills in.
+const CardList = rocketstyle()({ component: List, name: 'CardList' })
+  .theme(() => ({ rootSize: 16 }))
+  .attrs({ component: Card, rootElement: false })
+
+// Compiles WITHOUT passing `component={Card}` — default kicks in.
+const _omitted = <CardList data={users} itemKey="id" />
+
+// Still accepts an explicit override.
+const _override = <CardList data={users} component={Card} itemKey="id" />
+
+// ─── EA-only key: net-new attr ──────────────────────────────────────
+const Sized = rocketstyle()({ component: List, name: 'Sized' })
+  .theme(() => ({ rootSize: 16 }))
+  .attrs<{ tone: 'a' | 'b' }>({ tone: 'a' })
+
+// `tone` was passed to `.attrs()` as required-typed P — but on the wrapper
+// it's now optional because it has a default.
+const _toneOmitted = <Sized data={users} component={Card} itemKey="id" />
+const _toneSet = <Sized data={users} component={Card} itemKey="id" tone="b" />
+
+// ─── Per-mode discrimination from PR #222 must still fire ───────────
+const _badValueName = (
+  // @ts-expect-error — valueName forbidden on object arrays (Object branch)
+  <CardList data={users} valueName="text" />
+)
+
+declare const strings: string[]
+const _modeMix = (
+  // @ts-expect-error — children mode rejects `data`
+  <CardList data={strings}>
+    <span>x</span>
+  </CardList>
+)
+
+export { _badValueName, _modeMix, _omitted, _override, _toneOmitted, _toneSet }

--- a/packages/rocketstyle/src/types/rocketstyle.ts
+++ b/packages/rocketstyle/src/types/rocketstyle.ts
@@ -92,19 +92,29 @@ export interface IRocketStyleComponent<
   // `OA extends infer O` distributes over OA's union branches so a wrapper
   // around an overloaded component (`ExtractProps<typeof List>` is a
   // 3-branch union after the new ExtractProps) yields a discriminated DFP
-  // union — one MergeTypes per branch.
+  // union — one branch per overload.
   //
-  // Critically: OA is intersected raw, NOT fed through MergeTypes. The
-  // wrapped component's prop type (e.g. `ObjectProps<O>`) uses `valueName?:
-  // never` as the discrimination mechanism (#199); MergeTypes' inner
-  // `ExtractNullableKeys` strips keys whose type is `never | undefined`,
-  // which would erase that discrimination and let `<StyledList
-  // data={users} valueName="x" />` compile against the object branch.
-  // Keeping OA outside MergeTypes preserves all `?: never` markers from
-  // each overload branch, so per-mode rejection fires at the JSX call
-  // site of the wrapper just like it does on the direct component.
+  // OA-overlapping EA keys (e.g. `.attrs({ tag: 'button' })` on a wrapper
+  // whose OA has `tag: HTMLTags`) are stripped from OA and re-added as
+  // `Partial<Pick<O, …>>` — taking O's WIDER type, not EA's narrow
+  // literal. The runtime default is `'button'`; the JSX call site still
+  // accepts any `HTMLTags` value (so `<Btn tag="a" />` is valid).
+  // `Partial<Omit<EA, keyof O>>` handles net-new EA-only keys (no OA
+  // conflict) and marks them optional too — every `.attrs()` value is
+  // semantically a default, never required of the consumer.
+  //
+  // OA is intersected raw, NOT fed through MergeTypes — `?: never`
+  // markers from overload branches (PR #222) must survive discrimination.
   DFP = OA extends infer O
-    ? O & MergeTypes<[EA, DefaultProps, ExtractDimensionProps<D, DKP, UB>]>
+    ? Omit<O, keyof EA & keyof O> &
+        Partial<Pick<O, keyof EA & keyof O>> &
+        MergeTypes<
+          [
+            Partial<Omit<EA, keyof O>>,
+            DefaultProps,
+            ExtractDimensionProps<D, DKP, UB>,
+          ]
+        >
     : never,
 > {
   (props: DFP & { ref?: any }): ReactNode
@@ -210,10 +220,22 @@ export interface IRocketStyleComponent<
    *  }))
    *  ```
    */
-  attrs: <P extends TObj | unknown = unknown>(
-    param: P extends TObj
-      ? Partial<MergeTypes<[DFP, P]>> | AttrsCb<MergeTypes<[DFP, P]>, Theme<T>>
-      : Partial<DFP> | AttrsCb<DFP, Theme<T>>,
+  attrs: <P extends TObj = {}>(
+    // Object form: TS infers P from the param's keys. `NoInfer<DFP>`
+    // prevents DFP from contributing to P inference, so keys that exist on
+    // both P and DFP (e.g. `component` when wrapping `List`) get attributed
+    // to P — which makes them optional at the JSX call site (via DFP
+    // widening on EA keys). Extra DFP defaults that aren't in P come
+    // through the `Partial<NoInfer<DFP>>` part, preserving the existing
+    // ability to set defaults for any current prop without typing them
+    // into P explicitly.
+    //
+    // Callback form: P is inferred from the explicit type annotation only
+    // (no inference from callback return), so wrapped-component widening
+    // requires `.attrs<P>((props) => …)` for callbacks.
+    param:
+      | (P & Partial<NoInfer<DFP>>)
+      | AttrsCb<MergeTypes<[DFP, P]>, Theme<T>>,
     config?: Partial<{
       /**
        * priority props will be resolved first and overwritten by normal `attrs`
@@ -223,13 +245,9 @@ export interface IRocketStyleComponent<
       /**
        * filter props will be omitted when passing to final component
        */
-      filter: P extends TObj
-        ? Partial<keyof MergeTypes<[EA, P]>>[]
-        : Partial<keyof EA>[]
+      filter: (keyof MergeTypes<[EA, P]>)[]
     }>,
-  ) => P extends TObj
-    ? RocketStyleComponent<OA, MergeTypes<[EA, P]>, T, CSS, S, HOC, D, UB, DKP>
-    : RocketStyleComponent<OA, EA, T, CSS, S, HOC, D, UB, DKP>
+  ) => RocketStyleComponent<OA, MergeTypes<[EA, P]>, T, CSS, S, HOC, D, UB, DKP>
 
   // THEME chaining method
   // --------------------------------------------------------


### PR DESCRIPTION
## Summary

`.attrs({ x: defaultValue })` provides a runtime default for `x` — so at the JSX call site, the consumer shouldn't be required to pass it. Previously the types kept those keys required, which was especially painful when the key overlapped with a required prop of the wrapped component (e.g. `component` on `List`), forcing consumer-side `Omit + cast` workarounds.

Two changes:

- **DFP widening** ([rocketstyle.ts:105-122](packages/rocketstyle/src/types/rocketstyle.ts#L105-L122))
  - Strip EA-overlapping keys from OA and re-add them as `Partial<Pick<O, …>>` — taking O's WIDER type, not EA's narrow literal. This means `.attrs({ tag: 'button' })` on a `tag: HTMLTags` wrapper makes the JSX call site accept any `HTMLTags`, not just `'button'`.
  - `Partial<Omit<EA, keyof O>>` handles net-new EA-only keys (no OA conflict) and makes them optional too.

- **`.attrs()` inference** ([rocketstyle.ts:226-244](packages/rocketstyle/src/types/rocketstyle.ts#L226-L244))
  - Previously the object-form `.attrs({ … })` couldn't infer P into EA without an explicit `<P>` annotation — the param type `Partial<MergeTypes<[DFP, P]>>` was unsolvable for P. The new signature uses `P & Partial<NoInfer<DFP>>`, letting TS infer P from the param's keys while still accepting extra DFP defaults.

## Result on consumer wrappers

```ts
const CardList = rocketstyle()({ component: List, name: 'CardList' })
  .attrs({ component: Card, rootElement: false })

<CardList data={users} itemKey="id" />                  // ✓ compiles
<CardList data={users} component={Other} itemKey="id" /> // ✓ override
<CardList data={users} valueName="x" />                  // ✗ per-mode narrowing preserved
```

No more `Omit + cast` workaround needed.

## Behavior change

`.attrs<{ x: T }>({ x: v })` no longer requires `x` at the JSX call site (it has a default). This is consistent with `.attrs` semantics, but is a behavior shift if anyone relied on the previous required-ness.

Callback form `.attrs((props) => …)` still doesn't infer P — pass `<P>` explicitly for callback-set defaults to widen the type surface.

## Test plan

- [x] `bun run typecheck` — all 15 packages clean (after rebuild so DTS picks up new types).
- [x] `bun run test` — 2668 tests pass.
- [x] `bun run lint` — clean.
- [x] `bun run pkgs:build` — all 15 packages build.
- [x] New `attrs-widening.test-d.tsx` pins: OA-overlapping widening, EA-only widening, and that per-mode narrowing from #222 still fires on wrapper `@ts-expect-error` cases.
- [ ] Verify in bokisch.com after publish: `.attrs({ component: Card })` works without the `Omit + cast` workaround.

🤖 Generated with [Claude Code](https://claude.com/claude-code)