### PR TITLE
fix(elements): add LooseProps fallback overload to Iterator + List

### DIFF
--- a/.changeset/fix-elements-iterator-list-loose-overload.md
+++ b/.changeset/fix-elements-iterator-list-loose-overload.md
@@ -1,0 +1,33 @@
+---
+'@vitus-labs/elements': minor
+---
+
+Add a `LooseProps` fallback overload to `IteratorComponent` and `ListComponent`.
+
+**What changed**
+
+Iterator and List previously declared three call signatures (Simple, Object, Children). After 2.5.0 fixed the iterator-prop types for forwarding, one residual remained: `(typeof Wrapper)['$$types']['data']` — derived via rocketstyle's 4-overload-aware `ExtractProps` — is a wide union of every overload's `data`. Passing it back into `<List data={…}>` had no overload to bind to:
+
+- Simple wants `SimpleValue[]` — union too wide.
+- Object wants `ObjectValue[]` — union too wide.
+- Children doesn't take `data` and requires `children` — fails.
+
+A fourth `(props: LooseProps & extras) => ReactNode` overload gives the wide union a binding home. The narrow overloads still drive per-mode T-inference for direct callers; the loose fallback only matches when nothing narrower does.
+
+**Result**
+
+```ts
+type Props = { list?: (typeof MyList)['$$types']['data'] }
+const Component = ({ list }: Props) => <List data={list} component={Item} />
+//                                            ^^^^^^^^^^
+// Pre-fix: no overload matches the wide union.
+// Post-fix: binds to LooseProps overload, compiles cleanly.
+```
+
+**Trade-off**
+
+Heterogeneous arrays like `(string | User)[]` now compile (was rejected). Runtime handles per-item dispatch — the type-side fallback exists so forwarding round-trips work. If you want to reject mixed arrays, narrow your `data` type before passing it.
+
+**Why Option B (overload addition) over Option A (`children?` on ChildrenProps)**
+
+Option A would have made `<List />` (no data, no component, no children) type-allowed — that's a meaningful loss of "you must do something" enforcement. The added overload preserves Children's `children: ReactNode` requirement and only widens for legitimately-wide inputs.

--- a/packages/elements/src/List/component.tsx
+++ b/packages/elements/src/List/component.tsx
@@ -102,8 +102,10 @@ Component.VITUS_LABS__COMPONENT = name
 type RefExtra = { ref?: Ref<any> }
 
 export interface ListComponent {
-  // T inferred from `data` — strict per-mode constraints, no loose fallback.
-  // See Iterator's IteratorComponent for the same rationale.
+  // T inferred from `data`. Order: SimpleProps, ObjectProps, ChildrenProps,
+  // then a LooseProps fallback for forwarding patterns where derived
+  // `$$types['data']` is a wide union that doesn't bind to any narrow
+  // overload. See Iterator's IteratorComponent for the same rationale.
   <T extends SimpleValue>(
     props: IteratorSimpleProps<T> & ListExtras & RefExtra,
   ): ReactNode
@@ -111,6 +113,7 @@ export interface ListComponent {
     props: IteratorObjectProps<T> & ListExtras & RefExtra,
   ): ReactNode
   (props: IteratorChildrenProps & ListExtras & RefExtra): ReactNode
+  (props: IteratorLooseProps & ListExtras & RefExtra): ReactNode
   displayName?: string
   pkgName?: string
   VITUS_LABS__COMPONENT?: string

--- a/packages/elements/src/__tests__/Iterator.jsx-inference.test-d.tsx
+++ b/packages/elements/src/__tests__/Iterator.jsx-inference.test-d.tsx
@@ -162,14 +162,13 @@ const SizedButton = rocketstyle({
 />
 
 // ----------------------------------------------------------------------
-// Heterogeneous arrays — mixed string|object still rejected by all
-// overloads (`T extends SimpleValue | ObjectValue` doesn't accept a
-// union of the two simultaneously).
+// Heterogeneous arrays — mixed string|object now bind to the LooseProps
+// fallback overload (was rejected by Simple/Object overloads alone). The
+// runtime handles per-item dispatch; type-side, the fallback exists so
+// derived `$$types['data']` round-trips back into JSX cleanly.
 // ----------------------------------------------------------------------
 
 const mixed: (string | User)[] = ['a', { id: 1, name: 'one' }]
-// MUST FAIL: heterogeneous array doesn't match any single branch
-// @ts-expect-error — mixed-type arrays must be normalized before iteration
 ;<Iterator data={mixed} component={Item} />
 
 // ----------------------------------------------------------------------

--- a/packages/elements/src/helpers/Iterator/component.tsx
+++ b/packages/elements/src/helpers/Iterator/component.tsx
@@ -19,6 +19,7 @@ import type {
   ChildrenProps,
   ElementType,
   ExtendedProps,
+  LooseProps,
   ObjectProps,
   ObjectValue,
   Props,
@@ -280,15 +281,21 @@ const Component: FC<Props> = ({
 // ---------------------------------------------------------------------------
 export interface IteratorComponent {
   // T is inferred from the `data` prop at the JSX site — no explicit
-  // generic argument needed. The order matters: SimpleProps first (matches
-  // `data: SimpleValue[]`), then ObjectProps (object[]), then ChildrenProps.
-  // The narrow overloads enforce per-mode constraints (valueName required
-  // for primitive arrays, forbidden for object arrays, etc.) — there is
-  // intentionally no loose fallback overload, so calls that don't match
-  // any branch produce a real type error.
+  // generic argument needed. Order matters: SimpleProps first (matches
+  // `data: SimpleValue[]`), then ObjectProps (object[]), then ChildrenProps,
+  // then a LooseProps fallback.
+  //
+  // The narrow overloads (Simple/Object/Children) drive per-mode T
+  // inference and stricter compile-time errors for direct callers. The
+  // LooseProps fallback exists for forwarding patterns where
+  // `Partial<(typeof Wrapper)['$$types']>` is spread back into the JSX
+  // site — without a loose binding home, the wide union from
+  // overload-distribution (rocketstyle's ExtractProps) couldn't bind to
+  // any narrow overload.
   <T extends SimpleValue>(props: SimpleProps<T>): ReactNode
   <T extends ObjectValue>(props: ObjectProps<T>): ReactNode
   (props: ChildrenProps): ReactNode
+  (props: LooseProps): ReactNode
   isIterator: true
   RESERVED_PROPS: typeof RESERVED_PROPS
   displayName?: string


### PR DESCRIPTION
## Summary

Resolves the 2.5.0 residual the user reported: `(typeof Wrapper)['$$types']['data']` is a wide union and had no overload to bind to when passed back into JSX. Recommended **Option B** from the report — add a 4th `LooseProps` overload — over Option A (`children?` on ChildrenProps), which would have weakened the children-required guarantee for empty `<List />` calls.

## Change

```ts
export interface IteratorComponent {
  <T extends SimpleValue>(props: SimpleProps<T>): ReactNode
  <T extends ObjectValue>(props: ObjectProps<T>): ReactNode
  (props: ChildrenProps): ReactNode
  (props: LooseProps): ReactNode  // ← added
  …
}

export interface ListComponent {
  <T extends SimpleValue>(props: IteratorSimpleProps<T> & ListExtras & RefExtra): ReactNode
  <T extends ObjectValue>(props: IteratorObjectProps<T> & ListExtras & RefExtra): ReactNode
  (props: IteratorChildrenProps & ListExtras & RefExtra): ReactNode
  (props: IteratorLooseProps & ListExtras & RefExtra): ReactNode  // ← added
  …
}
```

## Composition with rocketstyle

`ExtractProps` in rocketstyle (PR #222) already handles up to 4 overloads — it captures all four and unions them. So `$$types` includes LooseProps as one branch, alongside the narrow Simple/Object/Children branches. When derived `$$types['data']` is forwarded back, TS tries each overload in order: narrow ones fail (wide union), the LooseProps overload binds. Direct narrow calls (`<List data={users} component={Card} />`) still bind to the Object overload — narrow always tried first.

## Verified

bokisch.com end-to-end with the exact failing pattern from the residual report:

```tsx
import { List } from '@vitus-labs/elements'
import { list } from '~/components/core'

type Props = { list?: (typeof list)['\$\$types']['data'] }
const _Component = ({ list: items }: Props) => (
  <List data={items} component=\"span\" />
)
```

Pre-fix: 'No overload matches'. Post-fix: compiles. Full bokisch.com `tsc --noEmit` exit 0.

Pipeline:
- [x] `bun run typecheck` — all 15 packages clean.
- [x] `bun run test` — 2668 tests pass.
- [x] `bun run lint` — clean.
- [x] `bun run pkgs:build` — all 15 packages build.

## Trade-off (documented in changeset)

Heterogeneous arrays like `(string | User)[]` now compile (was previously rejected — the `@ts-expect-error` directive in \`Iterator.jsx-inference.test-d.tsx\` for mixed-arrays became unused and was removed). Runtime handles per-item dispatch. If a caller wants to reject mixed arrays, narrow the `data` type before passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)