### PR TITLE
chore(styler): add tracked CSS-in-JS perf benchmark suite

### DIFF
--- a/.changeset/chore-styler-bench-suite.md
+++ b/.changeset/chore-styler-bench-suite.md
@@ -1,0 +1,9 @@
+---
+'@vitus-labs/styler': patch
+---
+
+Add a tracked CSS-in-JS perf benchmark at `packages/styler/benchmarks/`. Run with `bun run bench` from the styler package. Compares `@vitus-labs/styler` against `styled-components` 6 and `@emotion/styled` 11 on six scenarios: SSR (static / dynamic / themed) + CSR (mount / update / many distinct components).
+
+Documents the runtime perf landscape and serves as a regression check — a >10% drop on any styler row vs `results.md` should be investigated before merging.
+
+No runtime change; this only adds bench infra + devDependencies (`jsdom`, `tinybench`) to styler.

--- a/bun.lock
+++ b/bun.lock
@@ -36,7 +36,7 @@
     },
     "examples/nextjs-emotion": {
       "name": "@vitus-labs/example-nextjs-emotion",
-      "version": "0.0.0",
+      "version": "0.0.5",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
@@ -58,7 +58,7 @@
     },
     "examples/nextjs-styled-components": {
       "name": "@vitus-labs/example-nextjs-styled-components",
-      "version": "0.0.0",
+      "version": "0.0.5",
       "dependencies": {
         "@vitus-labs/connector-styled-components": "workspace:*",
         "@vitus-labs/coolgrid": "workspace:*",
@@ -79,7 +79,7 @@
     },
     "examples/nextjs-styler": {
       "name": "@vitus-labs/example-nextjs-styler",
-      "version": "0.0.0",
+      "version": "0.0.5",
       "dependencies": {
         "@vitus-labs/connector-styler": "workspace:*",
         "@vitus-labs/coolgrid": "workspace:*",
@@ -100,7 +100,7 @@
     },
     "examples/vite-emotion": {
       "name": "@vitus-labs/example-vite-emotion",
-      "version": "0.0.0",
+      "version": "0.0.5",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
@@ -123,7 +123,7 @@
     },
     "examples/vite-kinetic": {
       "name": "@vitus-labs/example-vite-kinetic",
-      "version": "0.0.0",
+      "version": "0.0.5",
       "dependencies": {
         "@vitus-labs/hooks": "workspace:*",
         "@vitus-labs/kinetic": "workspace:*",
@@ -142,7 +142,7 @@
     },
     "examples/vite-styled-components": {
       "name": "@vitus-labs/example-vite-styled-components",
-      "version": "0.0.0",
+      "version": "0.0.5",
       "dependencies": {
         "@vitus-labs/connector-styled-components": "workspace:*",
         "@vitus-labs/coolgrid": "workspace:*",
@@ -164,7 +164,7 @@
     },
     "examples/vite-styler": {
       "name": "@vitus-labs/example-vite-styler",
-      "version": "0.0.0",
+      "version": "0.0.5",
       "dependencies": {
         "@vitus-labs/connector-styler": "workspace:*",
         "@vitus-labs/coolgrid": "workspace:*",
@@ -186,7 +186,7 @@
     },
     "packages/attrs": {
       "name": "@vitus-labs/attrs",
-      "version": "2.1.0",
+      "version": "2.5.0",
       "devDependencies": {
         "@vitus-labs/core": "workspace:*",
         "@vitus-labs/elements": "workspace:*",
@@ -195,13 +195,13 @@
         "@vitus-labs/tools-typescript": "2.3.0",
       },
       "peerDependencies": {
-        "@vitus-labs/core": "2.1.0",
+        "@vitus-labs/core": "workspace:^",
         "react": ">= 19",
       },
     },
     "packages/connector-emotion": {
       "name": "@vitus-labs/connector-emotion",
-      "version": "2.1.0",
+      "version": "2.5.0",
       "devDependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
@@ -216,21 +216,21 @@
     },
     "packages/connector-native": {
       "name": "@vitus-labs/connector-native",
-      "version": "2.1.0",
+      "version": "2.5.0",
       "devDependencies": {
         "@vitus-labs/core": "workspace:*",
         "@vitus-labs/tools-rolldown": "2.3.0",
         "@vitus-labs/tools-typescript": "2.3.0",
       },
       "peerDependencies": {
-        "@vitus-labs/core": "2.1.0",
+        "@vitus-labs/core": "workspace:^",
         "react": ">= 19",
         "react-native": ">= 0.76",
       },
     },
     "packages/connector-styled-components": {
       "name": "@vitus-labs/connector-styled-components",
-      "version": "2.1.0",
+      "version": "2.5.0",
       "devDependencies": {
         "@vitus-labs/core": "workspace:*",
         "@vitus-labs/tools-rolldown": "2.3.0",
@@ -238,14 +238,14 @@
         "styled-components": "^6.3.11",
       },
       "peerDependencies": {
-        "@vitus-labs/core": "2.1.0",
+        "@vitus-labs/core": "workspace:^",
         "react": ">= 19",
         "styled-components": ">= 6",
       },
     },
     "packages/connector-styler": {
       "name": "@vitus-labs/connector-styler",
-      "version": "2.1.0",
+      "version": "2.5.0",
       "devDependencies": {
         "@vitus-labs/core": "workspace:*",
         "@vitus-labs/styler": "workspace:*",
@@ -253,14 +253,14 @@
         "@vitus-labs/tools-typescript": "2.3.0",
       },
       "peerDependencies": {
-        "@vitus-labs/core": "2.1.0",
-        "@vitus-labs/styler": "2.1.0",
+        "@vitus-labs/core": "workspace:^",
+        "@vitus-labs/styler": "workspace:^",
         "react": ">= 19",
       },
     },
     "packages/coolgrid": {
       "name": "@vitus-labs/coolgrid",
-      "version": "2.1.0",
+      "version": "2.5.0",
       "devDependencies": {
         "@vitus-labs/core": "workspace:*",
         "@vitus-labs/tools-rolldown": "2.3.0",
@@ -270,8 +270,8 @@
         "react-native": ">=0.84.1",
       },
       "peerDependencies": {
-        "@vitus-labs/core": "2.1.0",
-        "@vitus-labs/unistyle": "2.1.0",
+        "@vitus-labs/core": "workspace:^",
+        "@vitus-labs/unistyle": "workspace:^",
         "react": ">= 19",
         "react-native": ">= 0.76",
       },
@@ -281,7 +281,7 @@
     },
     "packages/core": {
       "name": "@vitus-labs/core",
-      "version": "2.1.0",
+      "version": "2.5.0",
       "dependencies": {
         "react-is": "^19.2.4",
       },
@@ -295,7 +295,7 @@
     },
     "packages/elements": {
       "name": "@vitus-labs/elements",
-      "version": "2.1.0",
+      "version": "2.5.0",
       "dependencies": {
         "react-is": "^19.2.4",
       },
@@ -308,8 +308,8 @@
         "@vitus-labs/unistyle": "workspace:*",
       },
       "peerDependencies": {
-        "@vitus-labs/core": "2.1.0",
-        "@vitus-labs/unistyle": "2.1.0",
+        "@vitus-labs/core": "workspace:^",
+        "@vitus-labs/unistyle": "workspace:^",
         "react": ">= 19",
         "react-dom": ">= 19",
         "react-native": ">= 0.76",
@@ -321,7 +321,7 @@
     },
     "packages/hooks": {
       "name": "@vitus-labs/hooks",
-      "version": "2.1.0",
+      "version": "2.5.0",
       "devDependencies": {
         "@vitus-labs/core": "workspace:*",
         "@vitus-labs/tools-rolldown": "2.3.0",
@@ -330,7 +330,7 @@
         "react-native": ">=0.84.1",
       },
       "peerDependencies": {
-        "@vitus-labs/core": "2.1.0",
+        "@vitus-labs/core": "workspace:^",
         "react": ">= 19",
         "react-native": ">= 0.76",
       },
@@ -340,7 +340,7 @@
     },
     "packages/kinetic": {
       "name": "@vitus-labs/kinetic",
-      "version": "2.1.0",
+      "version": "2.5.0",
       "devDependencies": {
         "@vitus-labs/hooks": "workspace:*",
         "@vitus-labs/tools-rolldown": "2.3.0",
@@ -348,7 +348,7 @@
         "react-native": ">=0.84.1",
       },
       "peerDependencies": {
-        "@vitus-labs/hooks": "2.1.0",
+        "@vitus-labs/hooks": "workspace:^",
         "react": ">= 19",
         "react-native": ">= 0.76",
       },
@@ -358,7 +358,7 @@
     },
     "packages/kinetic-presets": {
       "name": "@vitus-labs/kinetic-presets",
-      "version": "2.1.0",
+      "version": "2.5.0",
       "devDependencies": {
         "@vitus-labs/tools-rolldown": "2.3.0",
         "@vitus-labs/tools-typescript": "2.3.0",
@@ -369,7 +369,7 @@
     },
     "packages/rocketstories": {
       "name": "@vitus-labs/rocketstories",
-      "version": "2.1.0",
+      "version": "2.5.0",
       "dependencies": {
         "@vitus-labs/elements": "workspace:*",
       },
@@ -382,16 +382,16 @@
         "@vitus-labs/unistyle": "workspace:*",
       },
       "peerDependencies": {
-        "@storybook/react": "10.3.6",
-        "@vitus-labs/core": "2.1.0",
-        "@vitus-labs/rocketstyle": "2.1.0",
-        "@vitus-labs/unistyle": "2.1.0",
+        "@storybook/react": "^10.3.6",
+        "@vitus-labs/core": "workspace:^",
+        "@vitus-labs/rocketstyle": "workspace:^",
+        "@vitus-labs/unistyle": "workspace:^",
         "react": ">= 19",
       },
     },
     "packages/rocketstyle": {
       "name": "@vitus-labs/rocketstyle",
-      "version": "2.1.0",
+      "version": "2.5.0",
       "devDependencies": {
         "@vitus-labs/core": "workspace:*",
         "@vitus-labs/elements": "workspace:*",
@@ -401,13 +401,13 @@
         "@vitus-labs/unistyle": "workspace:*",
       },
       "peerDependencies": {
-        "@vitus-labs/core": "2.1.0",
+        "@vitus-labs/core": "workspace:^",
         "react": ">= 19",
       },
     },
     "packages/styler": {
       "name": "@vitus-labs/styler",
-      "version": "2.1.0",
+      "version": "2.5.0",
       "devDependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
@@ -415,23 +415,25 @@
         "@vitus-labs/tools-rolldown": "2.3.0",
         "@vitus-labs/tools-typescript": "2.3.0",
         "goober": "^2.1.18",
+        "jsdom": "^29.1.1",
         "styled-components": "^6.3.11",
+        "tinybench": "^6.0.1",
       },
       "peerDependencies": {
-        "@vitus-labs/core": "2.1.0",
+        "@vitus-labs/core": "workspace:^",
         "react": ">= 19",
       },
     },
     "packages/unistyle": {
       "name": "@vitus-labs/unistyle",
-      "version": "2.1.0",
+      "version": "2.5.0",
       "devDependencies": {
         "@vitus-labs/core": "workspace:*",
         "@vitus-labs/tools-rolldown": "2.3.0",
         "@vitus-labs/tools-typescript": "2.3.0",
       },
       "peerDependencies": {
-        "@vitus-labs/core": "2.1.0",
+        "@vitus-labs/core": "workspace:^",
         "react": ">= 19",
         "react-native": ">= 0.76",
       },
@@ -2113,7 +2115,7 @@
 
     "tiny-invariant": ["tiny-invariant@1.3.3", "", {}, "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="],
 
-    "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
+    "tinybench": ["tinybench@6.0.1", "", {}, "sha512-cMdWsxmysdg8mNWf1pujiWl3TW0cU6m8QuNw55QlnP3I6N96Grb0wnu5N0syHIu3LbiVZCNqlfWzWDq84HZphA=="],
 
     "tinyexec": ["tinyexec@1.1.2", "", {}, "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA=="],
 
@@ -2522,6 +2524,8 @@
     "vite-plugin-storybook-nextjs/@next/env": ["@next/env@16.0.0", "", {}, "sha512-s5j2iFGp38QsG1LWRQaE2iUY3h1jc014/melHFfLdrsMJPqxqDQwWNwyQTcNoUSGZlCVZuM7t7JDMmSyRilsnA=="],
 
     "vite-plugin-storybook-nextjs/vite-tsconfig-paths": ["vite-tsconfig-paths@5.1.4", "", { "dependencies": { "debug": "^4.1.1", "globrex": "^0.1.2", "tsconfck": "^3.0.3" }, "peerDependencies": { "vite": "*" }, "optionalPeers": ["vite"] }, "sha512-cYj0LRuLV2c2sMqhqhGpaO3LretdtMn/BVX4cPLanIZuwwrkVl+lK84E/miEXkCHWXuq65rhNN4rXsBcOB3S4w=="],
+
+    "vitest/tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
 
     "whatwg-url-without-unicode/webidl-conversions": ["webidl-conversions@5.0.0", "", {}, "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA=="],
 

--- a/packages/styler/benchmarks/css-perf.bench.tsx
+++ b/packages/styler/benchmarks/css-perf.bench.tsx
@@ -1,0 +1,297 @@
+/**
+ * CSS-in-JS perf microbench — `@vitus-labs/styler` vs styled-components vs Emotion.
+ *
+ * Run from the styler package: `bun run bench`.
+ *
+ * Six scenarios × three libraries, measured via tinybench. Each lib is
+ * forced to do equivalent work (render + serialize CSS or render + inject
+ * into DOM):
+ *
+ * SSR scenarios (renderToString):
+ *   1. ssr-static   — template with no function interpolations.
+ *   2. ssr-dynamic  — template reads a prop via function interpolation.
+ *   3. ssr-themed   — template reads from ThemeProvider context.
+ *
+ * Client scenarios (jsdom + react-dom/client):
+ *   4. csr-mount    — createRoot + render fresh tree (cold cache).
+ *   5. csr-update   — render initial tree, then update props N times.
+ *   6. csr-many     — mount many different components per tick (cache-bust).
+ *
+ * `styled-components` does NOT use React 19 `<style precedence>` — it
+ * emits class names only and defers CSS collection. For a fair SSR
+ * comparison, the sc paths wrap each render in `ServerStyleSheet` and
+ * call `getStyleTags()` so the work matches styler/emotion's inline
+ * style-tag emission.
+ *
+ * Numbers are per-tick (each tick runs N renders). Divide ms/op by N for
+ * per-render cost.
+ */
+
+// ─── jsdom bootstrap (must be before react-dom/client) ───────────────
+import { JSDOM } from 'jsdom'
+
+const dom = new JSDOM('<!doctype html><html><body><div id="root"></div></body></html>', {
+  url: 'http://localhost/',
+  pretendToBeVisual: true,
+})
+;(globalThis as any).window = dom.window
+;(globalThis as any).document = dom.window.document
+;(globalThis as any).navigator = dom.window.navigator
+;(globalThis as any).HTMLElement = dom.window.HTMLElement
+;(globalThis as any).Element = dom.window.Element
+;(globalThis as any).Node = dom.window.Node
+;(globalThis as any).getComputedStyle = dom.window.getComputedStyle
+
+// ─── Imports after jsdom is ready ────────────────────────────────────
+import React from 'react'
+import { renderToString } from 'react-dom/server'
+import { type Root, createRoot } from 'react-dom/client'
+import { Bench } from 'tinybench'
+
+import {
+  ThemeProvider as StylerProvider,
+  styled as stylerStyled,
+} from '../lib/index.js'
+
+import scStyled, {
+  ServerStyleSheet,
+  ThemeProvider as ScProvider,
+} from 'styled-components'
+
+import { ThemeProvider as EmProvider } from '@emotion/react'
+import emStyled from '@emotion/styled'
+
+const SSR_N = 500 // renders per SSR tick
+const CSR_N = 100 // mounts/updates per CSR tick
+const MANY_N = 50 // distinct components per "many" tick
+
+const theme = { color: '#1e88e5', bg: '#fff' }
+
+// ─── Component factories (so we can vary template per scenario) ─────
+const stylerStatic = stylerStyled.div`color: red; padding: 8px;`
+const scStatic = scStyled.div`color: red; padding: 8px;`
+const emStatic = emStyled.div`color: red; padding: 8px;`
+
+const stylerDynamic = stylerStyled.div<{ color: string }>`
+  color: ${(p) => p.color};
+  padding: 8px;
+`
+const scDynamic = scStyled.div<{ color: string }>`
+  color: ${(p) => p.color};
+  padding: 8px;
+`
+const emDynamic = emStyled.div<{ color: string }>`
+  color: ${(p) => p.color};
+  padding: 8px;
+`
+
+const stylerThemed = stylerStyled.div`
+  color: ${(p: any) => p.theme.color};
+  background: ${(p: any) => p.theme.bg};
+`
+const scThemed = scStyled.div`
+  color: ${(p) => p.theme.color};
+  background: ${(p) => p.theme.bg};
+`
+const emThemed = emStyled.div`
+  color: ${(p: any) => p.theme.color};
+  background: ${(p: any) => p.theme.bg};
+`
+
+// ─── SSR helpers ─────────────────────────────────────────────────────
+const ssrStatic = (Component: any) => {
+  for (let i = 0; i < SSR_N; i++) renderToString(React.createElement(Component))
+}
+const ssrDynamic = (Component: any) => {
+  for (let i = 0; i < SSR_N; i++) {
+    renderToString(
+      React.createElement(Component, { color: i % 2 ? '#f00' : '#0f0' }),
+    )
+  }
+}
+const ssrThemed = (Component: any, Provider: any) => {
+  for (let i = 0; i < SSR_N; i++) {
+    renderToString(
+      React.createElement(Provider, { theme }, React.createElement(Component)),
+    )
+  }
+}
+const ssrScStatic = (Component: any) => {
+  for (let i = 0; i < SSR_N; i++) {
+    const sheet = new ServerStyleSheet()
+    try {
+      renderToString(sheet.collectStyles(React.createElement(Component)))
+      sheet.getStyleTags()
+    } finally {
+      sheet.seal()
+    }
+  }
+}
+const ssrScDynamic = (Component: any) => {
+  for (let i = 0; i < SSR_N; i++) {
+    const sheet = new ServerStyleSheet()
+    try {
+      renderToString(
+        sheet.collectStyles(
+          React.createElement(Component, { color: i % 2 ? '#f00' : '#0f0' }),
+        ),
+      )
+      sheet.getStyleTags()
+    } finally {
+      sheet.seal()
+    }
+  }
+}
+const ssrScThemed = (Component: any) => {
+  for (let i = 0; i < SSR_N; i++) {
+    const sheet = new ServerStyleSheet()
+    try {
+      renderToString(
+        sheet.collectStyles(
+          React.createElement(
+            ScProvider,
+            { theme },
+            React.createElement(Component),
+          ),
+        ),
+      )
+      sheet.getStyleTags()
+    } finally {
+      sheet.seal()
+    }
+  }
+}
+
+// ─── CSR helpers ─────────────────────────────────────────────────────
+// Fresh container + createRoot per tick. Mount N components in one batch.
+const csrMount = (Component: any) => {
+  const container = document.createElement('div')
+  const root = createRoot(container)
+  const children = []
+  for (let i = 0; i < CSR_N; i++) {
+    children.push(
+      React.createElement(Component, {
+        key: i,
+        color: i % 2 ? '#f00' : '#0f0',
+      }),
+    )
+  }
+  root.render(React.createElement(React.Fragment, null, children))
+  root.unmount()
+}
+
+// Mount once, then update N times (each update re-renders with new prop).
+const csrUpdate = (Component: any) => {
+  const container = document.createElement('div')
+  const root: Root = createRoot(container)
+  root.render(React.createElement(Component, { color: '#000' }))
+  for (let i = 0; i < CSR_N; i++) {
+    root.render(
+      React.createElement(Component, { color: i % 2 ? '#f00' : '#0f0' }),
+    )
+  }
+  root.unmount()
+}
+
+// Cache-bust scenario: mount N DIFFERENT styled components per tick. This
+// exposes per-template setup cost (vs per-render cost which dominates the
+// other scenarios). Each component is created inside the tick so module-
+// level caches don't help.
+const csrManyStyler = () => {
+  const container = document.createElement('div')
+  const root = createRoot(container)
+  const children = []
+  for (let i = 0; i < MANY_N; i++) {
+    const C = stylerStyled.div<{ c: string }>`color: ${(p) => p.c};`
+    children.push(React.createElement(C, { key: i, c: '#abc' }))
+  }
+  root.render(React.createElement(React.Fragment, null, children))
+  root.unmount()
+}
+const csrManySc = () => {
+  const container = document.createElement('div')
+  const root = createRoot(container)
+  const children = []
+  for (let i = 0; i < MANY_N; i++) {
+    const C = scStyled.div<{ c: string }>`color: ${(p) => p.c};`
+    children.push(React.createElement(C, { key: i, c: '#abc' }))
+  }
+  root.render(React.createElement(React.Fragment, null, children))
+  root.unmount()
+}
+const csrManyEm = () => {
+  const container = document.createElement('div')
+  const root = createRoot(container)
+  const children = []
+  for (let i = 0; i < MANY_N; i++) {
+    const C = emStyled.div<{ c: string }>`color: ${(p) => p.c};`
+    children.push(React.createElement(C, { key: i, c: '#abc' }))
+  }
+  root.render(React.createElement(React.Fragment, null, children))
+  root.unmount()
+}
+
+// ─── Bench ───────────────────────────────────────────────────────────
+const bench = new Bench({ time: 1500, warmupTime: 300 })
+
+bench
+  // SSR
+  .add('styler  · ssr-static  · 500x', () => ssrStatic(stylerStatic))
+  .add('sc      · ssr-static  · 500x', () => ssrScStatic(scStatic))
+  .add('emotion · ssr-static  · 500x', () => ssrStatic(emStatic))
+  .add('styler  · ssr-dynamic · 500x', () => ssrDynamic(stylerDynamic))
+  .add('sc      · ssr-dynamic · 500x', () => ssrScDynamic(scDynamic))
+  .add('emotion · ssr-dynamic · 500x', () => ssrDynamic(emDynamic))
+  .add('styler  · ssr-themed  · 500x', () => ssrThemed(stylerThemed, StylerProvider))
+  .add('sc      · ssr-themed  · 500x', () => ssrScThemed(scThemed))
+  .add('emotion · ssr-themed  · 500x', () => ssrThemed(emThemed, EmProvider))
+  // CSR
+  .add('styler  · csr-mount   · 100x', () => csrMount(stylerDynamic))
+  .add('sc      · csr-mount   · 100x', () => csrMount(scDynamic))
+  .add('emotion · csr-mount   · 100x', () => csrMount(emDynamic))
+  .add('styler  · csr-update  · 100x', () => csrUpdate(stylerDynamic))
+  .add('sc      · csr-update  · 100x', () => csrUpdate(scDynamic))
+  .add('emotion · csr-update  · 100x', () => csrUpdate(emDynamic))
+  .add('styler  · csr-many    · 50x',  () => csrManyStyler())
+  .add('sc      · csr-many    · 50x',  () => csrManySc())
+  .add('emotion · csr-many    · 50x',  () => csrManyEm())
+
+await bench.run()
+
+const rows = bench.tasks.map((t) => {
+  const r = t.result
+  if (!r) return null
+  const [lib, scenario] = t.name.split(' · ').map((s: string) => s.trim())
+  return {
+    scenario,
+    lib,
+    'ops/sec': r.throughput.mean,
+    'ms/op': r.latency.mean,
+  }
+}).filter((r): r is NonNullable<typeof r> => r !== null)
+
+const grouped: Record<string, typeof rows> = {}
+for (const r of rows) {
+  ;(grouped[r.scenario] ??= []).push(r)
+}
+
+console.log('\n=== CSS-in-JS perf — styler vs styled-components vs emotion ===\n')
+console.log(`Runtime: bun ${process.versions.bun ?? 'n/a'}, react ${React.version}`)
+console.log(`SSR per-tick: ${SSR_N} renderToString calls`)
+console.log(`CSR per-tick: ${CSR_N} mounts / updates, ${MANY_N} distinct components for csr-many\n`)
+
+for (const [scenario, group] of Object.entries(grouped)) {
+  group.sort((a, b) => Number(b['ops/sec']) - Number(a['ops/sec']))
+  const max = Number(group[0]['ops/sec'])
+  console.log(`── ${scenario} ──`)
+  for (const r of group) {
+    const ops = Number(r['ops/sec']).toFixed(1)
+    const ms = Number(r['ms/op']).toFixed(3)
+    const ratio = (Number(r['ops/sec']) / max).toFixed(2)
+    const bar = '█'.repeat(Math.round(Number(ratio) * 20))
+    console.log(
+      `  ${r.lib.padEnd(8)}  ${ops.padStart(7)} ops/s   ${ms.padStart(8)} ms/op   ${ratio}× ${bar}`,
+    )
+  }
+  console.log()
+}

--- a/packages/styler/benchmarks/results.md
+++ b/packages/styler/benchmarks/results.md
@@ -1,0 +1,96 @@
+# CSS-in-JS perf benchmark
+
+Comparison of `@vitus-labs/styler` against `styled-components` 6 and `@emotion/styled` 11 on render performance across SSR and CSR paths.
+
+**Reproduce**: `bun run bench` from `packages/styler/`.
+
+## Setup
+
+- bun 1.3.13, react 19.2.5
+- `NODE_ENV=production`
+- jsdom for CSR scenarios
+- tinybench: 1500 ms timed window, 300 ms warmup
+- Apple Silicon
+
+## Scenarios
+
+| Scenario | What it measures |
+|---|---|
+| `ssr-static` | `renderToString` 500× with a template that has no function interpolations |
+| `ssr-dynamic` | `renderToString` 500× with a template that reads a prop via fn interpolation |
+| `ssr-themed` | `renderToString` 500× with a template that reads from `ThemeProvider` context |
+| `csr-mount` | `createRoot` → mount 100 components per tick (jsdom) |
+| `csr-update` | mount once, then re-render 100× with different props |
+| `csr-many` | mount 50 **distinct** styled components per tick (defeats per-component cache) |
+
+**Fairness note**: `styled-components` 6 does NOT use React 19's `<style precedence>` mechanism — `renderToString` only emits class names, deferring CSS serialization. The SSR sc paths wrap each render in `ServerStyleSheet.collectStyles()` + `getStyleTags()` so all three libs do equivalent work (render + serialize CSS).
+
+## Latest results
+
+```
+── ssr-static ──
+  styler     1528 ops/s   0.685 ms/op   1.00× ████████████████████
+  emotion    1008 ops/s   1.040 ms/op   0.66× █████████████
+  sc          259 ops/s   3.905 ms/op   0.17× ███
+
+── ssr-dynamic ──
+  styler     1174 ops/s   0.887 ms/op   1.00× ████████████████████
+  emotion     904 ops/s   1.152 ms/op   0.77× ███████████████
+  sc          242 ops/s   4.179 ms/op   0.21× ████
+
+── ssr-themed ──
+  styler     1148 ops/s   0.910 ms/op   1.00× ████████████████████
+  emotion     903 ops/s   1.148 ms/op   0.79× ████████████████
+  sc          250 ops/s   4.054 ms/op   0.22× ████
+
+── csr-mount ──
+  emotion   48630 ops/s   0.022 ms/op   1.00× ████████████████████
+  styler    46611 ops/s   0.024 ms/op   0.96× ███████████████████
+  sc        45659 ops/s   0.024 ms/op   0.94× ███████████████████
+
+── csr-update ──
+  styler    36386 ops/s   0.029 ms/op   1.00× ████████████████████
+  emotion   35896 ops/s   0.030 ms/op   0.99× ████████████████████
+  sc        35844 ops/s   0.029 ms/op   0.99× ████████████████████
+
+── csr-many ──
+  styler    42842 ops/s   0.027 ms/op   1.00× ████████████████████
+  emotion   38800 ops/s   0.027 ms/op   0.91× ██████████████████
+  sc        13936 ops/s   0.090 ms/op   0.33× ███████
+```
+
+## Per-render translation
+
+SSR per-render cost (each tick = 500 renders):
+
+| Scenario | styler | emotion | sc |
+|---|---|---|---|
+| ssr-static | **1.37 μs** | 2.08 μs | 7.81 μs |
+| ssr-dynamic | **1.77 μs** | 2.30 μs | 8.36 μs |
+| ssr-themed | **1.82 μs** | 2.30 μs | 8.11 μs |
+
+CSR per-mount cost (each tick = 100 mounts):
+
+| Scenario | styler | emotion | sc |
+|---|---|---|---|
+| csr-mount | 0.24 μs | **0.22 μs** | 0.24 μs |
+| csr-update | **0.29 μs** | 0.30 μs | 0.29 μs |
+| csr-many | **0.54 μs/tick / 50** | 0.55 μs | 1.79 μs |
+
+## Takeaways
+
+1. **SSR**: styler leads by **1.3–1.4× vs emotion** and **4–5× vs sc**. The React 19 `<style precedence>` integration + cached static templates + lazy resolve all contribute.
+2. **CSR mount/update**: within ~5% across all three libs. React's reconciler dominates; CSS-in-JS work is in the noise.
+3. **CSR many** (distinct components per tick, cache-defeating): styler/emotion are similar (~10% gap), **sc is 3× slower**. Each new `styled.div` template carries setup cost that sc pays at create-time.
+4. **Bundle size (orthogonal)**: styler gzip ≈ 3.06 KB, emotion ≈ 7 KB, sc6 ≈ 16 KB.
+
+## Caveats
+
+- jsdom CSR doesn't paint — real browser perf includes layout/style recalc that this bench doesn't reflect. Component count, layout complexity, and CSS rule count will shift the picture.
+- `tinybench` numbers within ~5% are noise. The dramatic SSR sc gap and `csr-many` sc gap are well outside the noise floor; the close-fought CSR mount/update results are within it.
+- `styled-components` 6 ships a streaming-SSR path (`renderToPipeableStream`) optimized for large trees — this bench measures sync `renderToString` only.
+- styler's cache benefits from the same component being rendered many times per tick. Real apps see this for the most-rendered components.
+
+## Regression check
+
+Future PRs that touch the styler hot path should re-run `bun run bench` and update this file. If you see a >10% regression on any styler row vs the numbers here, investigate before merging.

--- a/packages/styler/package.json
+++ b/packages/styler/package.json
@@ -50,6 +50,7 @@
     "prepublish": "bun run build",
     "build": "bun run vl_rolldown_build",
     "build:watch": "bun run vl_rolldown_build-watch",
+    "bench": "bun benchmarks/css-perf.bench.tsx",
     "lint": "biome check src/",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
@@ -67,6 +68,8 @@
     "@vitus-labs/tools-rolldown": "2.3.0",
     "@vitus-labs/tools-typescript": "2.3.0",
     "goober": "^2.1.18",
-    "styled-components": "^6.3.11"
+    "jsdom": "^29.1.1",
+    "styled-components": "^6.3.11",
+    "tinybench": "^6.0.1"
   }
 }


### PR DESCRIPTION
## Summary

Adds `packages/styler/benchmarks/` with a tinybench-based comparison of `@vitus-labs/styler` against `styled-components` 6 and `@emotion/styled` 11. Six scenarios cover both SSR and CSR paths.

Run from styler: `bun run bench`. Results doc: [packages/styler/benchmarks/results.md](packages/styler/benchmarks/results.md).

## Scenarios

| | What it measures |
|---|---|
| `ssr-static`  | `renderToString` 500× of a template with no fn interpolations |
| `ssr-dynamic` | `renderToString` 500× reading a prop via fn interpolation |
| `ssr-themed`  | `renderToString` 500× reading from ThemeProvider context |
| `csr-mount`   | `createRoot` + mount 100 components (jsdom) |
| `csr-update`  | mount once, then re-render 100× with new props |
| `csr-many`    | mount 50 **distinct** styled components per tick (cache-defeating) |

**Fairness**: sc6 doesn't use React 19's `<style precedence>` — its `renderToString` only emits class names, deferring CSS serialization. The sc SSR paths wrap each render in `ServerStyleSheet.collectStyles()` + `getStyleTags()` so all three libs do equivalent work.

## Current numbers

(bun 1.3.13, react 19.2.5, NODE_ENV=production)

```
── ssr-static ──    styler 1.0×, emotion 0.66×, sc 0.17×
── ssr-dynamic ──   styler 1.0×, emotion 0.77×, sc 0.21×
── ssr-themed ──    styler 1.0×, emotion 0.79×, sc 0.22×
── csr-mount ──     all within 6% (React reconciler dominates)
── csr-update ──    all within 2%
── csr-many ──      styler 1.0×, emotion 0.91×, sc 0.33×  ← sc per-template cost
```

## Takeaways

1. **SSR** is where styler's design wins clearly — 1.3–1.4× emotion, 4–5× sc. The React 19 `<style precedence>` integration + cached static templates + lazy resolve pay off.
2. **CSR mount/update**: indistinguishable across all three libs. React's reconciler dominates.
3. **CSR many**: the "create lots of distinct styled components" path shows sc 3× slower — per-template setup cost. styler and emotion handle this within ~10% of each other.

## Regression check role

A `>10%` drop on any styler row vs `results.md` should be investigated before merging. Future hot-path changes (styler/src/resolve.ts, styler/src/styled.ts, the cache/sheet code) should re-run `bun run bench` and update the results table.

## Caveats (in `results.md`)

- jsdom CSR doesn't paint — no layout/style recalc.
- 5% noise floor; small differences on csr-mount/update are not significant.
- sc6's streaming SSR (`renderToPipeableStream`) isn't measured.
- Bundle-size axis is orthogonal (styler 3.06 KB, emotion ~7 KB, sc6 ~16 KB gzipped).

## No runtime change

This PR adds bench infra + tracked results doc. Two new devDependencies on `@vitus-labs/styler`: `jsdom` and `tinybench`. Patch changeset noting infra-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)