### PR TITLE
perf(styler): cache static-component element for no-props renders

### DIFF
--- a/.changeset/perf-styler-static-cache.md
+++ b/.changeset/perf-styler-static-cache.md
@@ -1,0 +1,11 @@
+---
+'@vitus-labs/styler': patch
+---
+
+Cache the pre-built ReactElement for the no-extra-props case of static `styled` components.
+
+Most `<MyStyled />` call sites pass no props beyond `ref` — the destructure, `buildProps` iteration, and `createElement` calls produce the same element shape every render. Pre-build that element once at component creation and short-circuit in the render fn when `rawProps` is empty and `ref` is nullish.
+
+**Impact**: styler's overhead-over-bare-React for static SSR drops from ~0.065 μs/render to ~0.008 μs/render (~88% reduction). Net effect on full SSR throughput is +3–4% because React's `renderToString` itself dominates the remaining cost. Most-benefit consumers: pages that emit many static styled components with no extra props (typical layout/typography building blocks).
+
+ReactElement values are immutable so sharing the cached element across renders is safe; React still treats each render as a fresh tree by identity.

--- a/packages/styler/src/styled.ts
+++ b/packages/styler/src/styled.ts
@@ -144,9 +144,34 @@ const createStyledComponent = (
       staticClassName = sheet.insert(cssText, boost)
     }
 
+    // Tag is known at creation time — hoist the typeof check out of render.
+    const tagIsDOM = typeof tag === 'string'
+
+    // Pre-built ReactElement returned when the consumer passes no props
+    // (the most common case: `<MyStyled />`). Saves the destructure +
+    // buildProps + createElement chain per render. ReactElement values
+    // are immutable so sharing across renders is safe — React treats it
+    // as a fresh element by identity for reconciliation.
+    const baselineMainEl = createElement(tag, {
+      className: staticClassName || undefined,
+    })
+    const baselineFragmentEl = cachedStyleEl
+      ? createElement(Fragment, null, cachedStyleEl, baselineMainEl)
+      : baselineMainEl
+
     const StaticStyled = ({ ref, ...rawProps }: Record<string, any>) => {
+      // Hot path: no props beyond ref → return the pre-cached element.
+      // `for…in` over an empty object has zero iterations; the `break`
+      // ensures we exit on the first key seen.
+      let hasExtraProps = false
+      for (const _k in rawProps) {
+        hasExtraProps = true
+        break
+      }
+      if (!hasExtraProps && ref == null) return baselineFragmentEl
+
       const finalTag = rawProps.as || tag
-      const isDOM = typeof finalTag === 'string'
+      const isDOM = finalTag === tag ? tagIsDOM : typeof finalTag === 'string'
       const finalProps = buildProps(
         rawProps,
         staticClassName,


### PR DESCRIPTION
## Summary

Pre-build the ReactElement once at static-component creation and short-circuit the render fn when no extra props are passed. The most common call site for static styled components — `<MyLayoutDiv />` style usage with no per-instance props — now bypasses the destructure + `buildProps` + `createElement` chain entirely.

## Profile that motivated this

After the bench PR (#231) ran, I added a profile harness comparing styler's static SSR against a hand-written equivalent React tree:

```
bare-div         · 500x         3116 ops/s   0.336 ms/op
class-div        · 500x         2597 ops/s   0.404 ms/op
class+style-tag  · 500x         1830 ops/s   0.563 ms/op
styler-static    · 500x         1728 ops/s   0.596 ms/op

  styler overhead per render: 0.065 μs
  bare React tree cost per render: 1.126 μs
```

94% of styler's SSR time was already React's `renderToString` itself. The 6% remainder was the destructure + buildProps + 2× `createElement` chain — which produces an identical element shape on every render of the no-props case.

## Optimization

In `createStyledComponent`'s static fast path, pre-build the result element once at component creation:

```ts
const baselineMainEl = createElement(tag, {
  className: staticClassName || undefined,
})
const baselineFragmentEl = cachedStyleEl
  ? createElement(Fragment, null, cachedStyleEl, baselineMainEl)
  : baselineMainEl
```

Then in the render fn:

```ts
let hasExtraProps = false
for (const _k in rawProps) {
  hasExtraProps = true
  break
}
if (!hasExtraProps && ref == null) return baselineFragmentEl
// …fall through to existing path for the with-props case
```

`ReactElement` values are immutable so sharing across renders is safe — React treats each render as a fresh tree by identity for reconciliation.

## Result

```
bare-div         · 500x         3254 ops/s   0.321 ms/op
class-div        · 500x         2744 ops/s   0.382 ms/op
class+style-tag  · 500x         1917 ops/s   0.538 ms/op
styler-static    · 500x         1907 ops/s   0.542 ms/op

  styler overhead per render: 0.008 μs       ← -88%
```

styler-static is now within 0.7% of a hand-written equivalent React tree — essentially the floor of \`renderToString\` for this shape.

Full-bench impact (\`bun run bench\` from styler):

| | Before | After | Δ |
|---|---|---|---|
| ssr-static  | 1528 ops/s | 1588 ops/s | +4% |
| ssr-dynamic | unchanged  | unchanged  | — |
| ssr-themed  | unchanged  | unchanged  | — |
| csr-* | unchanged | unchanged | — |

ssr-static is the headline-affected scenario; the rest go through different code paths and are dominated by React work that styler can't avoid.

## Verification

- [x] \`bun run test\` — 2668 tests pass.
- [x] \`bun run typecheck\` — all 15 packages clean.
- [x] \`bun run lint\` — clean.
- [x] \`bun run pkgs:build\` — all 15 packages build.

## Caveats

- The optimization only triggers for the no-extra-props case. \`<MyStyled color=\"red\" />\` still goes through the normal path.
- \`ref\` being non-null also disables the fast path (ref must be threaded to the underlying element).
- Bench harness (and updated \`results.md\`) lives in PR #231; that PR should land first, then update results.md here once both are merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)