### PR TITLE
perf(elements): fuse Iterator scan, drop Text closure, hoist Overlay set

### DIFF
--- a/.changeset/perf-elements-iterator-text-overlay.md
+++ b/.changeset/perf-elements-iterator-text-overlay.md
@@ -1,0 +1,23 @@
+---
+'@vitus-labs/elements': patch
+---
+
+Three small structural cleanups in `elements`. No public API or behavioural changes.
+
+**Changes**
+
+1. **Iterator: fuse `filterValidItems` + `detectKind` into one scan** (`helpers/Iterator/component.tsx`). The previous code allocated an intermediate filtered array, then iterated it again to detect whether the surviving items were uniformly simple (string/number) or complex (objects). The new `filterAndDetectKind` builds the filtered array and detects kind in a single pass, then early-exits on mixed shape. Saves one full array allocation + traversal per data-driven Iterator render. The 48 existing Iterator tests cover the behaviour; all still pass.
+
+2. **Text: drop the per-render `renderContent` closure** (`Text/component.tsx`). The component was creating a wrapper function inside its render body and immediately calling it. Inlined the JSX directly — same output shape, one fewer function allocation per render.
+
+3. **Overlay: hoist the `closeOn` click-kinds array** (`Overlay/useOverlay.tsx`). The click-listener `useEffect` was allocating a fresh `['click', 'clickOnTrigger', 'clickOutsideContent']` array on every re-run for an `Array.includes` check. Replaced with a module-scoped `ReadonlySet` checked via `Set.has`. Same semantics, one fewer allocation per effect re-run.
+
+**Verification**
+
+- 271 elements tests pass (no new tests added — the existing suite covers all three changes)
+- 2694 monorepo tests pass
+- `bun run lint`, `bun run typecheck`, `bun run pkgs:build` all green
+
+**Honest framing**
+
+These are structural/allocation cleanups, not headline perf bumps. The package has no microbench in-tree, so I am not claiming a measurable delta — the wins are theoretical (fewer allocations per Iterator render, per Overlay effect re-run, per Text render). They compound at scale (long lists, frequent overlay state changes, large text-heavy trees) but are below the noise floor of any single-component scenario.

--- a/packages/elements/src/Overlay/useOverlay.tsx
+++ b/packages/elements/src/Overlay/useOverlay.tsx
@@ -32,6 +32,15 @@ import useEscapeKey from './useEscapeKey'
 import useHoverListeners from './useHoverListeners'
 import useScrollReposition from './useScrollReposition'
 
+// Hoisted: closeOn values that count as "click-driven close". Inlined
+// previously, allocating a fresh 3-element array on each click-listener
+// useEffect re-run.
+const CLICK_CLOSE_KINDS: ReadonlySet<string> = new Set([
+  'click',
+  'clickOnTrigger',
+  'clickOutsideContent',
+])
+
 export type UseOverlayProps = Partial<{
   /**
    * Defines default state whether **Overlay** component should be active.
@@ -399,9 +408,7 @@ const useOverlay = ({
   useEffect(() => {
     if (blocked || disabled) return undefined
 
-    const enabledClick =
-      openOn === 'click' ||
-      ['click', 'clickOnTrigger', 'clickOutsideContent'].includes(closeOn)
+    const enabledClick = openOn === 'click' || CLICK_CLOSE_KINDS.has(closeOn)
 
     if (enabledClick) window.addEventListener('click', handleClick)
 

--- a/packages/elements/src/Text/component.tsx
+++ b/packages/elements/src/Text/component.tsx
@@ -5,7 +5,7 @@
  * a static `isText` flag so other components can detect text children.
  */
 import type { HTMLTextTags } from '@vitus-labs/core'
-import type { ReactElement, ReactNode } from 'react'
+import type { ReactNode } from 'react'
 import { PKG_NAME } from '~/constants'
 import type { ExtendCss, VLComponent } from '~/types'
 import Styled from './styled'
@@ -33,27 +33,18 @@ export type Props = Partial<{
   css: ExtendCss
 }>
 
-type RenderContent = (as?: any) => ReactElement | null
-
 const Component: VLComponent<Props> & {
   isText?: true
 } = ({ paragraph, label, children, tag, css, ref, ...props }: any) => {
-  const renderContent: RenderContent = (as = undefined) => (
-    <Styled ref={ref} as={as} $text={{ extraStyles: css }} {...props}>
+  // `finalTag` only diverges from `tag` on web (paragraph → `<p>`). On native
+  // the underlying Styled handles the platform default, so we pass undefined.
+  const finalTag = __WEB__ ? (paragraph ? 'p' : tag) : undefined
+
+  return (
+    <Styled ref={ref} as={finalTag} $text={{ extraStyles: css }} {...props}>
       {children ?? label}
     </Styled>
   )
-
-  let finalTag: string | undefined
-
-  if (__WEB__) {
-    if (paragraph) finalTag = 'p'
-    else {
-      finalTag = tag
-    }
-  }
-
-  return renderContent(finalTag)
 }
 
 // ----------------------------------------------

--- a/packages/elements/src/helpers/Iterator/component.tsx
+++ b/packages/elements/src/helpers/Iterator/component.tsx
@@ -116,31 +116,38 @@ const flattenChildren = (children: ReactNode): ReactNode[] => {
   return [children]
 }
 
-/** Drop nullish entries and empty objects (matches legacy behavior). */
-const filterValidItems = (data: unknown[]): unknown[] =>
-  data.filter(
-    (item) =>
-      item != null &&
-      !(typeof item === 'object' && isEmpty(item as Record<string, unknown>)),
-  )
-
 type DataKind = 'simple' | 'complex' | null
 
-/** Determine if the array is uniformly simple (string/number) or complex (object). Mixed → null. */
-const detectKind = (items: unknown[]): DataKind => {
+const classifyItem = (item: unknown): DataKind => {
+  const t = typeof item
+  if (t === 'string' || t === 'number') return 'simple'
+  if (t === 'object') return 'complex'
+  return null
+}
+
+/**
+ * Single-pass: filter out nullish + empty-object entries and detect whether
+ * the surviving items form a uniformly simple (string/number) or complex
+ * (object) collection. Mixed shapes → kind `null`. Replaces the prior
+ * `filterValidItems` + `detectKind` two-pass which allocated an intermediate
+ * filtered array; this fuses both into one scan.
+ */
+const filterAndDetectKind = (
+  data: unknown[],
+): { items: unknown[]; kind: DataKind } => {
+  const items: unknown[] = []
   let kind: DataKind = null
-  for (const item of items) {
-    const t =
-      typeof item === 'string' || typeof item === 'number'
-        ? 'simple'
-        : typeof item === 'object'
-          ? 'complex'
-          : null
-    if (t === null) return null
+  for (const item of data) {
+    if (item == null) continue
+    if (typeof item === 'object' && isEmpty(item as Record<string, unknown>))
+      continue
+    items.push(item)
+    const t = classifyItem(item)
+    if (t === null) return { items, kind: null }
     if (kind === null) kind = t
-    else if (kind !== t) return null
+    else if (kind !== t) return { items, kind: null }
   }
-  return kind
+  return { items, kind }
 }
 
 const objectKey = (
@@ -206,10 +213,8 @@ const buildDataSpecs = (
   valueName: string | undefined,
   itemKey: Props['itemKey'],
 ): ItemSpec[] | null => {
-  const items = filterValidItems(data)
-  if (items.length === 0) return null
-  const kind = detectKind(items)
-  if (!kind) return null
+  const { items, kind } = filterAndDetectKind(data)
+  if (items.length === 0 || !kind) return null
   return kind === 'simple'
     ? buildSimpleSpecs(items as SimpleValue[], component, valueName, itemKey)
     : buildObjectSpecs(items as ObjectValue[], component, itemKey)


### PR DESCRIPTION
## Summary

Three small structural cleanups in `@vitus-labs/elements`. No public API or behavioural changes; no new tests required (the existing 271-test elements suite covers all three paths).

## Changes

1. **`Iterator`: fuse `filterValidItems` + `detectKind` into one scan** ([`helpers/Iterator/component.tsx`](packages/elements/src/helpers/Iterator/component.tsx)).
   The old code allocated an intermediate filtered array, then re-iterated it to detect simple/complex/mixed shape. The new `filterAndDetectKind` does both in a single pass and early-exits on mixed shape. Saves one array allocation + traversal per data-driven Iterator render.
2. **`Text`: drop the per-render `renderContent` closure** ([`Text/component.tsx`](packages/elements/src/Text/component.tsx)).
   The component was creating a wrapper function inside its render body and immediately calling it. Inlined the JSX — one fewer function allocation per Text render.
3. **`Overlay`: hoist the `closeOn` click-kinds set** ([`Overlay/useOverlay.tsx`](packages/elements/src/Overlay/useOverlay.tsx)).
   Click-listener `useEffect` was allocating a fresh `['click', 'clickOnTrigger', 'clickOutsideContent']` array on every re-run for an `Array.includes` check. Replaced with a module-scoped `ReadonlySet` checked via `Set.has`.

## Honest framing

These are structural / allocation cleanups, **not headline perf bumps**. The package ships no microbench, so I'm not claiming a measurable delta — the wins are allocation reductions that compound at scale (long iterator lists, frequent overlay state changes, deeply nested text trees) but live below the noise floor of any single-component scenario.

## Test plan

- [x] 271 elements tests pass (no new tests — existing suite covers Iterator data modes, Text rendering, Overlay open/close events)
- [x] 2694 monorepo tests pass
- [x] `bun run lint` clean
- [x] `bun run typecheck` clean
- [x] `bun run pkgs:build` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)