### PR TITLE
perf(coolgrid): drop pickThemeProps wrapper, direct prop access in getGridContext

### DIFF
--- a/.changeset/perf-coolgrid-cleanup.md
+++ b/.changeset/perf-coolgrid-cleanup.md
@@ -1,0 +1,20 @@
+---
+'@vitus-labs/coolgrid': patch
+---
+
+Two small structural cleanups in `useContext.tsx`. No public API or behavioural changes.
+
+**Changes**
+
+1. **Drop the `pickThemeProps` wrapper.** It was a one-line indirection around `pick(props, keywords)` used at a single call site. Inlined the `pick` call and removed the unused `PickThemeProps` exported type (no external consumers — `useContext.tsx` is not re-exported from `index.ts`).
+2. **`getGridContext`: direct property access on `props` for top-level keys.** Callers always pass a plain object (a `pick()` result or a user-supplied literal), so `(props as Obj).columns` is equivalent to `get(props, 'columns')` but skips `get`'s path-parsing + safety-guard loop. The nested theme lookups (`'grid.columns'` / `'coolgrid.columns'`) still go through `get` because they have real nested paths.
+
+**Verification**
+
+- 77 coolgrid tests pass (no new tests — the existing suite covers `getGridContext`, `useGridContext`, and the Container/Row/Col consumer paths)
+- 2688 monorepo tests pass
+- `bun run lint`, `bun run typecheck` clean
+
+**Honest framing**
+
+Structural cleanup, not a measurable headline perf win. Two `get` calls saved per `getGridContext` invocation (which fires once per Container/Row/Col render), plus one less function call per `useGridContext`. No microbench in-tree, so no claimed delta — the wins are theoretical and compound across deep grid trees but are not visible at single-component granularity.

--- a/packages/coolgrid/src/useContext.tsx
+++ b/packages/coolgrid/src/useContext.tsx
@@ -5,17 +5,6 @@ import { CONTEXT_KEYS } from '~/constants'
 import type { Context, Obj, ValueType } from '~/types'
 
 /**
- * Picks only the recognized grid configuration keys from a props object,
- * filtering out any non-grid props before they enter context resolution.
- */
-export type PickThemeProps = <T extends Record<string, unknown>>(
-  props: T,
-  keywords: Array<keyof T>,
-) => ReturnType<typeof pick>
-const pickThemeProps: PickThemeProps = (props, keywords) =>
-  pick(props, keywords)
-
-/**
  * Resolves grid columns and container width using a three-layer fallback:
  * 1. Explicit component props (e.g. `columns={6}`)
  * 2. `theme.grid.columns` / `theme.grid.container`
@@ -30,10 +19,13 @@ type GetGridContext = (
 }
 
 export const getGridContext: GetGridContext = (props = {}, theme = {}) => ({
-  columns: (get(props, 'columns') ||
+  // `props` is always a plain object (callers pass a `pick()` result or a
+  // user-supplied object literal), so direct property access is safe and
+  // skips `get`'s path-parsing for these single-key lookups.
+  columns: ((props as Obj).columns ||
     get(theme, 'grid.columns') ||
     get(theme, 'coolgrid.columns')) as ValueType,
-  containerWidth: (get(props, 'width') ||
+  containerWidth: ((props as Obj).width ||
     get(theme, 'grid.container') ||
     get(theme, 'coolgrid.container')) as Record<string, number>,
 })
@@ -54,7 +46,7 @@ type UseGridContext = (props: Obj) => Context
 const useGridContext: UseGridContext = (props) => {
   const { theme } = useContext(context)
   const stableCtxProps = useStableValue(
-    pickThemeProps(props, CONTEXT_KEYS) as Obj,
+    pick(props, CONTEXT_KEYS as Array<keyof typeof props>) as Obj,
   )
   return useMemo(() => {
     const gridContext = getGridContext(


### PR DESCRIPTION
## Summary

Two small structural cleanups in `@vitus-labs/coolgrid`'s [`useContext.tsx`](packages/coolgrid/src/useContext.tsx). No public API or behavioural changes; no new tests required.

## Changes

1. **Drop the `pickThemeProps` wrapper.** It was a one-line indirection around `pick(props, keywords)` with a single internal call site. Inlined the `pick` call; removed the unused `PickThemeProps` exported type (no external consumers — `useContext.tsx` is not re-exported from `index.ts`).
2. **`getGridContext`: direct property access on `props` for top-level keys.** Callers always pass a plain object (a `pick()` result or a user-supplied literal), so `(props as Obj).columns` is equivalent to `get(props, 'columns')` but skips `get`'s path-parsing + safety-guard loop. The nested theme lookups (`'grid.columns'` / `'coolgrid.columns'`) still go through `get` because they have real nested paths.

## Honest framing

Structural cleanup, **not a measurable headline perf win**. The package ships no microbench, so I'm not claiming a measured delta — the wins are two fewer `get()` path-parses per `getGridContext` invocation (fires once per Container/Row/Col render). They compound across deep grid trees but live below single-component noise.

## Test plan

- [x] 77 coolgrid tests pass (existing suite covers `getGridContext`, `useGridContext`, Container/Row/Col consumers)
- [x] 2688 monorepo tests pass
- [x] `bun run lint` clean
- [x] `bun run typecheck` clean
- [x] `bun run pkgs:build` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)