### PR TITLE
perf(styler): 4 stacked wins (static-resolve cache + HTML_PROPS in-obj + hashUpdate unroll + globalStyle trim)

### DIFF
--- a/.changeset/perf-styler-static-resolve-cache.md
+++ b/.changeset/perf-styler-static-resolve-cache.md
@@ -1,0 +1,32 @@
+---
+'@vitus-labs/styler': patch
+---
+
+`CSSResult._staticResolved` cache: memoize the resolved CSS string on `CSSResult` instances that `shared.ts#isDynamic` has classified as static. Safe because props don't affect the output when there are no function interpolations — the resolved string is then a pure function of the template literal.
+
+**Why**
+
+`shared.ts#isDynamic` already populates `_isDynamic` on every `CSSResult` reached at styled-component / globalStyle creation time. The follow-up `resolveValue` path re-walked the template's `strings` + `values` on every render even when `_isDynamic === false` was already known. The common pattern is a shared static snippet (e.g. `const base = css\`padding: 12px;\``) interpolated into many dynamic components — that snippet's resolve work was paid once per dynamic render of every consumer. Memoizing on the instance turns that into one resolve per snippet, total.
+
+**Measured delta**
+
+Same-process microbench (median of 3 runs, bun 1.3.13 + tinybench, runnable at [`packages/styler/benchmarks/perf-audit-bench.tsx`](packages/styler/benchmarks/perf-audit-bench.tsx)):
+
+| Helper | Old ops/s | New ops/s | Δ |
+|---|---|---|---|
+| `nested-static resolve` (8 repeated resolves of one shared snippet) | 2.6M | 6.5M | **+149.4%** (~2.5×) |
+
+The 8-repeat fixture models the realistic case: one static `css\`…\`` snippet that gets interpolated into many dynamic styled components. First call computes + caches; subsequent calls return the cached string in O(1).
+
+**Other ideas explored and dropped**
+
+I also benched two other candidates in this round and dropped them after the numbers came in:
+
+1. **`normalizeCSS` slice-batching** (replace per-char `out += css[i]` with run-based `slice` appends): +19% on long CSS strings but **−15% on short CSS**. The flushRun closure overhead dominates for short inputs. Real-app CSS is mixed, so a net regression risk on the common medium-length case wasn't worth keeping.
+2. **`sheet.insertCache` / `prepareCache` split by `boost`** (avoid `${cssText}\0` allocation in boosted lookups): when measured fairly with pre-allocated maps (matching production class-field lifetimes), the delta was **+0.2%** — noise. The string allocation V8 paid was already amortized; doubling the map count for ~0 gain isn't worth the complexity.
+
+**Verification**
+
+- 393 styler tests pass (no new tests — existing `resolve` / nested-CSSResult coverage exercises the new memoized path)
+- 2689 monorepo tests pass
+- `bun run lint`, `bun run typecheck` clean

--- a/packages/styler/src/__tests__/resolve.test.ts
+++ b/packages/styler/src/__tests__/resolve.test.ts
@@ -201,6 +201,21 @@ describe('normalizeCSS', () => {
       const result = normalizeCSS('color: red;\n// trailing comment')
       expect(result).toBe('color: red;')
     })
+
+    it('strips block comment immediately following regular chars (no separator)', () => {
+      // Exercises the inline-flush block inside the block-comment branch:
+      // when chars accumulate as a "run" and a `/*` follows without a
+      // whitespace/semicolon boundary, the flush has to emit the run before
+      // skipping the comment body.
+      const result = normalizeCSS('padding/* gap */: 8px;')
+      expect(result).toBe('padding : 8px;')
+    })
+
+    it('strips line comment immediately following regular chars (no separator)', () => {
+      // Same flush-edge for the line-comment branch.
+      const result = normalizeCSS('padding// gap\n: 8px;')
+      expect(result).toBe('padding : 8px;')
+    })
   })
 
   describe('whitespace and semicolons', () => {

--- a/packages/styler/src/__tests__/resolve.test.ts
+++ b/packages/styler/src/__tests__/resolve.test.ts
@@ -201,21 +201,6 @@ describe('normalizeCSS', () => {
       const result = normalizeCSS('color: red;\n// trailing comment')
       expect(result).toBe('color: red;')
     })
-
-    it('strips block comment immediately following regular chars (no separator)', () => {
-      // Exercises the inline-flush block inside the block-comment branch:
-      // when chars accumulate as a "run" and a `/*` follows without a
-      // whitespace/semicolon boundary, the flush has to emit the run before
-      // skipping the comment body.
-      const result = normalizeCSS('padding/* gap */: 8px;')
-      expect(result).toBe('padding : 8px;')
-    })
-
-    it('strips line comment immediately following regular chars (no separator)', () => {
-      // Same flush-edge for the line-comment branch.
-      const result = normalizeCSS('padding// gap\n: 8px;')
-      expect(result).toBe('padding : 8px;')
-    })
   })
 
   describe('whitespace and semicolons', () => {

--- a/packages/styler/src/forward.ts
+++ b/packages/styler/src/forward.ts
@@ -4,8 +4,13 @@
  * transient (styling-only) and are always filtered out.
  */
 
-// Common HTML attributes, event handlers, and ARIA/data attributes
-const HTML_PROPS = new Set([
+// Common HTML attributes, event handlers, and ARIA/data attributes.
+//
+// Using a plain object with `key in HTML_PROPS` instead of `Set.has(key)`:
+// V8 inlines `in` checks via hidden-class lookups (the object has a fixed
+// shape at module load and never changes), which is meaningfully faster
+// than going through the Set protocol on hot prop-filter paths.
+const HTML_PROPS_LIST = [
   // Core React props
   'children',
   'className',
@@ -190,7 +195,13 @@ const HTML_PROPS = new Set([
   'value',
   'width',
   'wrap',
-])
+] as const
+
+// Build the lookup object once at module load. `null`-prototype keeps the
+// object's hidden class lean and means `in` checks don't accidentally pick
+// up `Object.prototype` keys.
+const HTML_PROPS: Record<string, true> = Object.create(null)
+for (const k of HTML_PROPS_LIST) HTML_PROPS[k] = true
 
 /**
  * Filters props for HTML elements. Keeps valid HTML attrs, data-*, aria-*.
@@ -215,7 +226,7 @@ export const filterProps = (
     }
 
     // Keep known HTML props
-    if (HTML_PROPS.has(key)) {
+    if (key in HTML_PROPS) {
       filtered[key] = props[key]
     }
   }
@@ -281,7 +292,7 @@ export const buildProps = (
       result[key] = rawProps[key]
       continue
     }
-    if (HTML_PROPS.has(key)) result[key] = rawProps[key]
+    if (key in HTML_PROPS) result[key] = rawProps[key]
   }
   return result
 }

--- a/packages/styler/src/globalStyle.ts
+++ b/packages/styler/src/globalStyle.ts
@@ -36,14 +36,19 @@ export const createGlobalStyle = (
   // STATIC FAST PATH: compute once at creation time
   if (!hasDynamicValues) {
     const cssText = normalizeCSS(resolve(strings, values, {}))
-    const href = cssText.trim() ? `g-${hash(cssText)}` : ''
+    // `normalizeCSS` already strips leading/trailing whitespace, so a length
+    // check is equivalent to the prior `.trim()` calls but cheaper (no
+    // O(n) whitespace scan, no string allocation). Same pattern as `useCSS`
+    // (PR #242).
+    const hasContent = cssText.length > 0
+    const href = hasContent ? `g-${hash(cssText)}` : ''
 
     // Client only: inject into shared sheet. On SSR we deliberately do NOT
     // call sheet.insertGlobal() — that would push duplicates into ssrBuffer
     // and the same rule would also re-insert via insertRule() on hydration
     // (cache miss → DOM duplication). React 19 dedupes <style precedence>
     // emissions automatically, so a single precedence tag is sufficient.
-    if (!IS_SERVER && cssText.trim()) sheet.insertGlobal(cssText)
+    if (!IS_SERVER && hasContent) sheet.insertGlobal(cssText)
 
     // SSR: pre-compute <style precedence> for FOUC-free delivery.
     const cachedStyleEl =
@@ -63,11 +68,13 @@ export const createGlobalStyle = (
     const theme = useTheme()
     const allProps = { ...props, theme }
     const cssText = normalizeCSS(resolve(strings, values, allProps))
-    const href = cssText.trim() ? `g-${hash(cssText)}` : ''
+    // Single length check — replaces three `.trim()` calls per render below.
+    const hasContent = cssText.length > 0
+    const href = hasContent ? `g-${hash(cssText)}` : ''
 
     // Client: inject via useInsertionEffect (no-op on server)
     useInsertionEffect(() => {
-      if (cssText.trim()) sheet.insertGlobal(cssText)
+      if (cssText.length > 0) sheet.insertGlobal(cssText)
     }, [cssText])
 
     if (!href) return null

--- a/packages/styler/src/hash.ts
+++ b/packages/styler/src/hash.ts
@@ -16,11 +16,26 @@ const FNV_PRIME = 16777619
 /**
  * Feed a string segment into the running hash state.
  * Streaming: hashUpdate(hashUpdate(HASH_INIT, 'ab'), 'cd') === hash('abcd').
+ *
+ * Manually unrolled to 4-char chunks: cuts loop branches by 4× and lets V8's
+ * JIT pipeline keep `h` in a register across all four steps. Measured wins:
+ * +15% on short (~25-char) inputs, +46% on long (~340-char) inputs over the
+ * naive single-char loop. Sequential dependency on `h` prevents real
+ * parallelism — this is purely a loop-overhead reduction.
  */
 export const hashUpdate = (h: number, str: string): number => {
-  for (let i = 0; i < str.length; i++) {
-    h ^= str.charCodeAt(i)
-    h = Math.imul(h, FNV_PRIME)
+  const len = str.length
+  let i = 0
+  while (i + 4 <= len) {
+    h = Math.imul(h ^ str.charCodeAt(i), FNV_PRIME)
+    h = Math.imul(h ^ str.charCodeAt(i + 1), FNV_PRIME)
+    h = Math.imul(h ^ str.charCodeAt(i + 2), FNV_PRIME)
+    h = Math.imul(h ^ str.charCodeAt(i + 3), FNV_PRIME)
+    i += 4
+  }
+  while (i < len) {
+    h = Math.imul(h ^ str.charCodeAt(i), FNV_PRIME)
+    i++
   }
   return h
 }

--- a/packages/styler/src/resolve.ts
+++ b/packages/styler/src/resolve.ts
@@ -121,15 +121,30 @@ export const normalizeCSS = (css: string): string => {
   let out = ''
   let space = false // pending space to emit before next non-whitespace char
   let last = 0 // charCode of last char written to output (0 = nothing yet)
+  // Run batching: instead of `out += css[i]` per regular character (each
+  // append allocates a 1-char string + cons), track the start of the current
+  // "regular chars" span and flush it via a single `slice()` at the next
+  // special-char boundary. The flush is inlined (not a closure) — the prior
+  // closure-based version regressed short inputs by 15%; inline is net
+  // positive on both short and long CSS strings.
+  let runStart = 0
 
   for (let i = 0; i < len; i++) {
     const c = css.charCodeAt(i)
 
     // /* block comment */
     if (c === 47 /* / */ && css.charCodeAt(i + 1) === 42 /* * */) {
+      // Inline flush of the regular-char run ending at i.
+      if (i > runStart) {
+        if (space && last !== 0) out += ' '
+        space = false
+        out += css.slice(runStart, i)
+        last = css.charCodeAt(i - 1)
+      }
       const end = css.indexOf('*/', i + 2)
       i = end === -1 ? len : end + 1
       space = true
+      runStart = i + 1
       continue
     }
 
@@ -139,40 +154,61 @@ export const normalizeCSS = (css: string): string => {
       css.charCodeAt(i + 1) === 47 /* / */ &&
       last !== 58 /* : */
     ) {
+      if (i > runStart) {
+        if (space && last !== 0) out += ' '
+        space = false
+        out += css.slice(runStart, i)
+        last = css.charCodeAt(i - 1)
+      }
       const nl = css.indexOf('\n', i + 2)
       i = nl === -1 ? len : nl
       space = true
+      runStart = i + 1
       continue
     }
 
     // Whitespace → collapse
     if (c === 32 || c === 9 || c === 10 || c === 13 || c === 12) {
+      if (i > runStart) {
+        if (space && last !== 0) out += ' '
+        space = false
+        out += css.slice(runStart, i)
+        last = css.charCodeAt(i - 1)
+      }
       space = true
+      runStart = i + 1
       continue
     }
 
     // Semicolon → skip if redundant (after start, {, }, or another ;)
     if (c === 59 /* ; */) {
+      if (i > runStart) {
+        if (space && last !== 0) out += ' '
+        space = false
+        out += css.slice(runStart, i)
+        last = css.charCodeAt(i - 1)
+      }
       if (
         last === 0 ||
         last === 123 /* { */ ||
         last === 125 /* } */ ||
         last === 59 /* ; */
       ) {
+        runStart = i + 1
         continue
       }
       space = false
       out += ';'
       last = 59
-      continue
+      runStart = i + 1
     }
 
-    // Regular char — emit pending space (but not at start of output)
+    // Regular char — extend the run; nothing to do until the next boundary.
+  }
+  // Flush trailing run.
+  if (len > runStart) {
     if (space && last !== 0) out += ' '
-    space = false
-
-    out += css[i]
-    last = c
+    out += css.slice(runStart, len)
   }
 
   // Evict oldest ~10% to prevent memory leaks without cliff-edge drop

--- a/packages/styler/src/resolve.ts
+++ b/packages/styler/src/resolve.ts
@@ -121,33 +121,15 @@ export const normalizeCSS = (css: string): string => {
   let out = ''
   let space = false // pending space to emit before next non-whitespace char
   let last = 0 // charCode of last char written to output (0 = nothing yet)
-  // Run batching: instead of `out += css[i]` per regular character (each
-  // append allocates a 1-char string + cons), track the start of the current
-  // "regular chars" span and flush it via a single `slice()` at the next
-  // special-char boundary. The flush is inlined (not a closure) — the prior
-  // closure-based version regressed short inputs by 15%; inline is net
-  // positive on both short and long CSS strings.
-  let runStart = 0
 
   for (let i = 0; i < len; i++) {
     const c = css.charCodeAt(i)
 
     // /* block comment */
     if (c === 47 /* / */ && css.charCodeAt(i + 1) === 42 /* * */) {
-      // Inline flush of the regular-char run ending at i. The pending-space
-      // check that appears in the whitespace/semicolon flush sites is
-      // omitted here: by the state machine, `space` is always false on
-      // entry to a comment (preceding whitespace would have set
-      // `runStart = i+1`, making `i > runStart` false; preceding semicolon
-      // explicitly sets `space = false`).
-      if (i > runStart) {
-        out += css.slice(runStart, i)
-        last = css.charCodeAt(i - 1)
-      }
       const end = css.indexOf('*/', i + 2)
       i = end === -1 ? len : end + 1
       space = true
-      runStart = i + 1
       continue
     }
 
@@ -157,61 +139,40 @@ export const normalizeCSS = (css: string): string => {
       css.charCodeAt(i + 1) === 47 /* / */ &&
       last !== 58 /* : */
     ) {
-      // Same flush shape as the block-comment branch above; same unreachable
-      // pending-space check omitted for the same reason.
-      if (i > runStart) {
-        out += css.slice(runStart, i)
-        last = css.charCodeAt(i - 1)
-      }
       const nl = css.indexOf('\n', i + 2)
       i = nl === -1 ? len : nl
       space = true
-      runStart = i + 1
       continue
     }
 
     // Whitespace → collapse
     if (c === 32 || c === 9 || c === 10 || c === 13 || c === 12) {
-      if (i > runStart) {
-        if (space && last !== 0) out += ' '
-        space = false
-        out += css.slice(runStart, i)
-        last = css.charCodeAt(i - 1)
-      }
       space = true
-      runStart = i + 1
       continue
     }
 
     // Semicolon → skip if redundant (after start, {, }, or another ;)
     if (c === 59 /* ; */) {
-      if (i > runStart) {
-        if (space && last !== 0) out += ' '
-        space = false
-        out += css.slice(runStart, i)
-        last = css.charCodeAt(i - 1)
-      }
       if (
         last === 0 ||
         last === 123 /* { */ ||
         last === 125 /* } */ ||
         last === 59 /* ; */
       ) {
-        runStart = i + 1
         continue
       }
       space = false
       out += ';'
       last = 59
-      runStart = i + 1
+      continue
     }
 
-    // Regular char — extend the run; nothing to do until the next boundary.
-  }
-  // Flush trailing run.
-  if (len > runStart) {
+    // Regular char — emit pending space (but not at start of output)
     if (space && last !== 0) out += ' '
-    out += css.slice(runStart, len)
+    space = false
+
+    out += css[i]
+    last = c
   }
 
   // Evict oldest ~10% to prevent memory leaks without cliff-edge drop

--- a/packages/styler/src/resolve.ts
+++ b/packages/styler/src/resolve.ts
@@ -34,11 +34,21 @@ export type Interpolation =
 export class CSSResult {
   /**
    * Memoized result of `isDynamic(this)`. Populated on first access from
-   * `shared.ts#isDynamic`. CSSResult instances are typically created at
-   * module load and reused, so even one rescan saved per nested result
-   * adds up across nested composition trees.
+   * `shared.ts#isDynamic` (or from `resolveValue` below on lazy populate).
+   * CSSResult instances are typically created at module load and reused,
+   * so even one rescan saved per nested result adds up across nested
+   * composition trees.
    */
   _isDynamic: boolean | undefined = undefined
+
+  /**
+   * Memoized resolved CSS string for static CSSResults — populated by
+   * `resolveValue` the first time a known-static nested CSSResult is
+   * resolved. Safe because props don't affect the output when there are
+   * no function interpolations. Skipped for dynamic CSSResults (the
+   * resolved string depends on props each call).
+   */
+  _staticResolved: string | undefined = undefined
 
   constructor(
     readonly strings: TemplateStringsArray,
@@ -185,9 +195,20 @@ export const resolveValue = (
   if (typeof value === 'function')
     return resolveValue(value(props) as Interpolation, props)
 
-  // nested CSSResult → recursively resolve
-  if (value instanceof CSSResult)
+  // nested CSSResult → recursively resolve, with static-result memoization.
+  // When `_isDynamic === false` (populated by shared.ts#isDynamic at styled
+  // component creation time), the resolved string is independent of props
+  // and can be cached on the instance — saves re-walking strings/values for
+  // every consumer of a shared static snippet.
+  if (value instanceof CSSResult) {
+    if (value._isDynamic === false) {
+      if (value._staticResolved === undefined) {
+        value._staticResolved = resolve(value.strings, value.values, {})
+      }
+      return value._staticResolved
+    }
     return resolve(value.strings, value.values, props)
+  }
 
   // array of results (e.g. from makeItResponsive's breakpoints.map())
   // Uses loop instead of .map().join() to avoid intermediate array allocation

--- a/packages/styler/src/resolve.ts
+++ b/packages/styler/src/resolve.ts
@@ -134,10 +134,13 @@ export const normalizeCSS = (css: string): string => {
 
     // /* block comment */
     if (c === 47 /* / */ && css.charCodeAt(i + 1) === 42 /* * */) {
-      // Inline flush of the regular-char run ending at i.
+      // Inline flush of the regular-char run ending at i. The pending-space
+      // check that appears in the whitespace/semicolon flush sites is
+      // omitted here: by the state machine, `space` is always false on
+      // entry to a comment (preceding whitespace would have set
+      // `runStart = i+1`, making `i > runStart` false; preceding semicolon
+      // explicitly sets `space = false`).
       if (i > runStart) {
-        if (space && last !== 0) out += ' '
-        space = false
         out += css.slice(runStart, i)
         last = css.charCodeAt(i - 1)
       }
@@ -154,9 +157,9 @@ export const normalizeCSS = (css: string): string => {
       css.charCodeAt(i + 1) === 47 /* / */ &&
       last !== 58 /* : */
     ) {
+      // Same flush shape as the block-comment branch above; same unreachable
+      // pending-space check omitted for the same reason.
       if (i > runStart) {
-        if (space && last !== 0) out += ' '
-        space = false
         out += css.slice(runStart, i)
         last = css.charCodeAt(i - 1)
       }


### PR DESCRIPTION
## Summary

Four structural wins from a fresh styler audit. All internal; no public API changes.

## Changes

1. **`CSSResult._staticResolved` cache** ([`resolve.ts`](packages/styler/src/resolve.ts)) — memoize the resolved CSS string on `CSSResult` instances that `shared.ts#isDynamic` has classified as static (`_isDynamic === false`). Safe because props don't affect the output when there are no function interpolations.
2. **`hashUpdate` 4-char unroll** ([`hash.ts`](packages/styler/src/hash.ts)) — manually unroll the FNV-1a per-char loop to process 4 characters per iteration. Cuts loop branches by 4× and lets V8's JIT pipeline keep `h` in a register across the four sequential `Math.imul` steps. FNV-1a's data dependency on `h` precludes real parallelism — this is purely loop-overhead reduction.
3. **`HTML_PROPS` Set → null-prototype object + `key in obj` lookup** ([`forward.ts`](packages/styler/src/forward.ts)) — V8 inlines `in` checks via hidden-class lookups (the object has a fixed shape at module load), avoiding the Set protocol overhead. Hits on every DOM `buildProps` call.
4. **`globalStyle.ts` trim collapse** ([`globalStyle.ts`](packages/styler/src/globalStyle.ts)) — replace 4 `cssText.trim()` calls per render with `cssText.length > 0`. `normalizeCSS` already strips edges. Same pattern PR #242 applied to `useCSS.ts` (missed `globalStyle` at the time).

## Measured deltas (microbench, median of 3 runs)

Same-process microbench (bun 1.3.13 + tinybench, runnable at [`packages/styler/benchmarks/perf-audit-bench.tsx`](packages/styler/benchmarks/perf-audit-bench.tsx)):

| Helper | Old ops/s | New ops/s | Δ |
|---|---|---|---|
| `nested-static resolve` (8 repeated resolves of one shared snippet) | 2.6M | 6.5M | **+149.4%** (~2.5×) |
| `hashUpdate long` (337-char CSS) | 2.0M | 2.9M | **+46.0%** |
| `HTML_PROPS lookup` (5-lookup mix: 4 hits + 1 miss) | 21.2M | 25.2M | **+19.0%** |
| `hashUpdate short` (25-char CSS) | 21.5M | 24.8M | **+15.2%** |

## CI Perf bench (PR vs main, same runner)

The repo's bench-on-PR workflow runs the full CSS-in-JS competitive bench on identical hardware and gates regressions >10%. **PR #253 passes** with all CSR scenarios within noise vs main.

## Ideas explored and reverted this round

1. **`normalizeCSS` slice-batch with inline flush** — microbench showed +19% short / +60% long, but CI's same-runner integration bench surfaced a uniform **−13.5% regression across all 3 CSR scenarios**. Diagnosis: the inlined flush logic ballooned `normalizeCSS` from ~70 lines to ~115 (4 duplicated flush blocks), pushing it past V8's function-inline budget. `normalizeCSS` is called on every render in DynamicStyled (the `normCache.get` check happens INSIDE the function), so losing the inline-call optimization adds a per-render frame across every CSR render — exactly matching the uniform CSR drop. Reverted.
2. **`sheet.insertCache` / `prepareCache` split by `boost`** — when measured fairly with pre-allocated maps (matching production class-field lifetimes), the delta was **+0.3%** — noise. Doubling the map count for ~0 gain isn't worth the complexity.

## Test plan

- [x] 393 styler tests pass
- [x] 2689 monorepo tests pass
- [x] `bun run lint` clean
- [x] `bun run typecheck` clean
- [x] `bun run pkgs:build` green
- [x] **CI Perf bench gate (>10% regression → fail) passes**

🤖 Generated with [Claude Code](https://claude.com/claude-code)