### PR TITLE
test(styler): behavioural lock-ins for LRU-2 cacheRef + _isDynamic memo + _staticResolved cache

### DIFF
--- a/.changeset/test-styler-behavioral-lockins.md
+++ b/.changeset/test-styler-behavioral-lockins.md
@@ -1,0 +1,24 @@
+---
+'@vitus-labs/styler': patch
+---
+
+Add behavioural lock-in tests for three perf-critical paths shipped earlier this session whose original tests were lost during PR #242's squash-merge.
+
+**What's tested**
+
+1. **`DynamicStyled` LRU-2 cacheRef alternation** (`styled.test.tsx`) — spy on `sheet.getClassName` and assert zero additional calls across 6 alternation renders after both slots prime. Locks in the LRU-2 cache-hit behaviour from PR #242. Without this, a future regression that quietly broke the two-slot ring buffer would only show up via downstream perf signals.
+2. **`CSSResult._isDynamic` memoization** (`shared.test.ts`) — four tests covering populate-on-first-call (static + dynamic), cache-on-subsequent-call (via sentinel mutation of `values`), and nested-CSSResult propagation. Locks in the PR #242 memo behaviour.
+3. **`CSSResult._staticResolved` cache** (`resolve.test.ts`) — four tests covering populate-on-first-resolveValue, cache-hit via sentinel mutation, no-cache for dynamic CSSResults, and fallthrough when `_isDynamic` is unclassified. Locks in the PR #253 static-resolve memoization.
+
+**Why now**
+
+The follow-up audit found these three perf-critical behaviours had no behavioural tests on `main`. The original tests I added in PR #242's correction commit `f4226464` weren't captured in the squash because auto-merge had already snapped its squash body to the prior commits. Without tests, a future regression silently breaks the cache hit/miss path — downstream perf signals are too slow.
+
+No production code changes; tests only.
+
+**Verification**
+
+- 403 styler tests pass (+10 from this PR)
+- 2699 monorepo tests pass
+- Coverage: lines 99.34%, statements 98.71%, branches 94.46%, functions 98.45% — all above thresholds
+- `bun run lint`, `bun run typecheck` clean

--- a/packages/styler/src/__tests__/resolve.test.ts
+++ b/packages/styler/src/__tests__/resolve.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { css } from '../css'
-import { normalizeCSS, resolve } from '../resolve'
+import { CSSResult, normalizeCSS, resolve, resolveValue } from '../resolve'
+import { isDynamic } from '../shared'
 
 // Helper to create a TemplateStringsArray
 const tsa = (strings: readonly string[]): TemplateStringsArray => {
@@ -228,5 +229,56 @@ describe('normalizeCSS', () => {
       const result = normalizeCSS('; color: red;')
       expect(result).toBe('color: red;')
     })
+  })
+})
+
+describe('CSSResult._staticResolved cache (PR #253)', () => {
+  it('populates _staticResolved on first resolveValue of a known-static CSSResult', () => {
+    const inner = css`color: red;`
+    // Pre-classify as static via isDynamic (the same call shared.ts makes
+    // at styled-component creation time).
+    isDynamic(inner)
+    expect(inner._isDynamic).toBe(false)
+    expect(inner._staticResolved).toBe(undefined)
+
+    resolveValue(inner, {})
+    expect(inner._staticResolved).toBe('color: red;')
+  })
+
+  it('returns cached _staticResolved on subsequent resolveValue calls', () => {
+    const inner = css`padding: 12px;`
+    isDynamic(inner)
+    resolveValue(inner, {})
+    expect(inner._staticResolved).toBe('padding: 12px;')
+
+    // Mutate values to a sentinel that would change the resolved output if
+    // recomputed. The cache MUST return the prior result.
+    ;(inner as unknown as { values: unknown[] }).values = ['SENTINEL']
+    expect(resolveValue(inner, {})).toBe('padding: 12px;')
+  })
+
+  it('does NOT cache dynamic CSSResults (props vary per call)', () => {
+    const dyn = css`color: ${(p: { c: string }) => p.c};`
+    isDynamic(dyn)
+    expect(dyn._isDynamic).toBe(true)
+
+    // Resolve twice with different props; cache should not be populated.
+    resolveValue(dyn, { c: 'red' })
+    expect(dyn._staticResolved).toBe(undefined)
+    resolveValue(dyn, { c: 'blue' })
+    expect(dyn._staticResolved).toBe(undefined)
+  })
+
+  it('skips cache when _isDynamic is undefined (not yet classified)', () => {
+    // Construct a CSSResult directly without going through isDynamic.
+    // resolveValue's cache check is `_isDynamic === false` (strict), so an
+    // unclassified CSSResult falls through to the regular resolve path.
+    const tpl = Object.assign(['color: ', ';'], {
+      raw: ['color: ', ';'],
+    }) as unknown as TemplateStringsArray
+    const r = new CSSResult(tpl, ['red'])
+    expect(r._isDynamic).toBe(undefined)
+    expect(resolve(r.strings, r.values, {})).toBe('color: red;')
+    expect(r._staticResolved).toBe(undefined) // cache stays unpopulated
   })
 })

--- a/packages/styler/src/__tests__/shared.test.ts
+++ b/packages/styler/src/__tests__/shared.test.ts
@@ -70,4 +70,42 @@ describe('isDynamic', () => {
     )
     expect(isDynamic(result)).toBe(true)
   })
+
+  describe('CSSResult _isDynamic memoization', () => {
+    it('populates _isDynamic on first call for dynamic templates', () => {
+      const r = css`color: ${() => 'red'};`
+      expect(r._isDynamic).toBe(undefined)
+      isDynamic(r)
+      expect(r._isDynamic).toBe(true)
+    })
+
+    it('populates _isDynamic on first call for static templates', () => {
+      const r = css`color: ${'red'};`
+      expect(r._isDynamic).toBe(undefined)
+      isDynamic(r)
+      expect(r._isDynamic).toBe(false)
+    })
+
+    it('returns cached result on subsequent calls without rescanning values', () => {
+      const r = css`color: ${() => 'red'};`
+      const first = isDynamic(r)
+      expect(first).toBe(true)
+      expect(r._isDynamic).toBe(true)
+
+      // Mutate values to a sentinel that would invert the answer if rescanned.
+      // The memoized path must NOT consult `values` again — it should return
+      // the cached `_isDynamic` directly.
+      ;(r as unknown as { values: unknown[] }).values = ['static-only']
+      expect(isDynamic(r)).toBe(true) // still uses cached value, not rescan
+    })
+
+    it('memoizes nested CSSResults independently', () => {
+      const inner = css`color: ${() => 'red'};`
+      const outer = css`${inner}`
+      isDynamic(outer)
+      // Recursing through outer populates inner too.
+      expect(inner._isDynamic).toBe(true)
+      expect(outer._isDynamic).toBe(true)
+    })
+  })
 })

--- a/packages/styler/src/__tests__/styled.test.tsx
+++ b/packages/styler/src/__tests__/styled.test.tsx
@@ -1,6 +1,7 @@
 import { render } from '@testing-library/react'
 import { createRef, type FC, forwardRef } from 'react'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
+import { sheet } from '../sheet'
 import { styled } from '../styled'
 import { ThemeProvider } from '../ThemeProvider'
 
@@ -400,6 +401,65 @@ describe('styled', () => {
       const { container } = render(<Comp />)
       const el = container.lastElementChild as HTMLElement
       expect(el.className).toMatch(/^vl-/)
+    })
+  })
+
+  describe('DynamicStyled LRU-2 cacheRef', () => {
+    it('hits the cache on both slots when cssText alternates between two values', () => {
+      // Behavioural lock-in for the LRU-2 cacheRef in DynamicStyled
+      // (shipped in PR #242). The slot cache stores the two most-recent
+      // cssText results; the spy proves `sheet.getClassName` is only called
+      // for the two priming renders and zero times across subsequent
+      // alternation renders — i.e. the alternation case hits both slots.
+      const spy = vi.spyOn(sheet, 'getClassName')
+      const callsBefore = spy.mock.calls.length
+
+      const Comp = styled('div')`
+        color: ${(p: { $color: string }) => p.$color};
+      `
+
+      const { container, rerender } = render(<Comp $color="rebeccapurple" />)
+      const cls1 = (container.lastElementChild as HTMLElement).className
+      rerender(<Comp $color="seagreen" />) // primes slot b
+      const callsAfterPrime = spy.mock.calls.length
+      const cls2 = (container.lastElementChild as HTMLElement).className
+
+      for (let i = 0; i < 6; i++) {
+        rerender(<Comp $color={i % 2 === 0 ? 'rebeccapurple' : 'seagreen'} />)
+      }
+      const callsAfterAlternation = spy.mock.calls.length
+
+      expect(cls1).toMatch(/^vl-/)
+      expect(cls2).toMatch(/^vl-/)
+      expect(cls1).not.toBe(cls2)
+
+      const clsFinal = (container.lastElementChild as HTMLElement).className
+      expect(clsFinal).toBe(cls2)
+
+      // Priming renders MUST hit getClassName; alternation renders MUST NOT.
+      expect(callsAfterPrime).toBeGreaterThan(callsBefore)
+      expect(callsAfterAlternation).toBe(callsAfterPrime)
+
+      spy.mockRestore()
+    })
+
+    it('preserves correctness across many alternations (functional check)', () => {
+      const Comp = styled('div')`
+        color: ${(p: { $color: string }) => p.$color};
+      `
+      const { container, rerender } = render(<Comp $color="red" />)
+      const classes: string[] = []
+      const colours = ['red', 'blue', 'red', 'blue', 'red', 'blue']
+      for (const c of colours) {
+        rerender(<Comp $color={c} />)
+        classes.push((container.lastElementChild as HTMLElement).className)
+      }
+      // Every render with the same colour produces the same className
+      expect(classes[0]).toBe(classes[2])
+      expect(classes[0]).toBe(classes[4])
+      expect(classes[1]).toBe(classes[3])
+      expect(classes[1]).toBe(classes[5])
+      expect(classes[0]).not.toBe(classes[1])
     })
   })
 


### PR DESCRIPTION
## Why

Follow-up audit of today's perf PRs found that **three perf-critical behaviours shipped this session have no behavioural tests on main**:

1. **`DynamicStyled` LRU-2 cacheRef** (from PR #242) — the two-slot ring buffer that lets cssText alternation hit cache without re-hashing.
2. **`CSSResult._isDynamic` memoization** (from PR #242) — the static/dynamic classification cache that powers the new `_staticResolved` path.
3. **`CSSResult._staticResolved` cache** (from PR #253) — the static-snippet resolve-once memo.

PR #242's correction commit `f4226464` originally added tests for #1 and #2, but they were lost during auto-merge: GitHub captured the squash body from the commit list *before* I pushed the correction, and the new test file changes didn't end up in the squash. PR #253 never added a behavioural test for #3.

**Without these tests, a future regression silently breaks the cache hit/miss path** — downstream perf signals are too slow.

## What this PR adds

**`styled.test.tsx`** — 2 new tests for LRU-2 alternation:
- spy on `sheet.getClassName`, assert zero additional calls across 6 alternation renders after both slots prime
- functional correctness across many alternations (stable distinct classNames)

**`shared.test.ts`** — 4 new tests for `_isDynamic` memoization:
- populates on first call for dynamic templates
- populates on first call for static templates
- returns cached value on subsequent calls (verified via sentinel mutation of `.values`)
- memoizes nested CSSResults independently

**`resolve.test.ts`** — 4 new tests for `_staticResolved` cache:
- populates on first `resolveValue` for known-static CSSResult
- cache hit on subsequent calls (verified via sentinel mutation)
- skipped for dynamic CSSResults (no false cache)
- falls through when `_isDynamic` is unclassified (strict equality check)

No production code changes.

## Test plan

- [x] 403 styler tests pass (+10 from this PR; was 393)
- [x] 2699 monorepo tests pass (was 2689)
- [x] Coverage: lines 99.34%, statements 98.71%, branches 94.46%, functions 98.45% — all above thresholds
- [x] `bun run lint` clean
- [x] `bun run typecheck` clean
- [x] `bun run pkgs:build` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)