### PR TITLE
perf(core): omit() accepts a prebuilt Set; stop rebuilding it per render

### DIFF
--- a/.changeset/perf-omit-prebuilt-set.md
+++ b/.changeset/perf-omit-prebuilt-set.md
@@ -1,0 +1,32 @@
+---
+'@vitus-labs/core': patch
+'@vitus-labs/rocketstyle': patch
+'@vitus-labs/elements': patch
+'@vitus-labs/attrs': patch
+---
+
+`omit()` now accepts a prebuilt `ReadonlySet` of keys in addition to an array, and the three per-render callers feed it a stable Set so the lookup Set is no longer rebuilt on every render.
+
+**Why**
+
+`omit` builds `new Set(keys)` internally for O(1) lookups. When the key list is stable for a component's lifetime — which it is at every render-path caller — that Set was being reconstructed every render for nothing. The Set construction dominates the call cost when the source object is small (the usual case for props).
+
+Three hot callers, all previously passing a stable key array and paying the rebuild:
+
+- **rocketstyle** (`rocketstyle.tsx`, `finalProps` assembly) — additionally rebuilt a 3-way `[...RESERVED_STYLING_PROPS_KEYS, ...PSEUDO_KEYS, ...options.filterAttrs]` array each render. Now memoized into a single `Set` via `useMemo` (all three sources are stable for the instance).
+- **elements/List** — built a module-scope `Set` from the constant `Iterator.RESERVED_PROPS`.
+- **attrs** — built the `Set` once in the factory closure from `options.filterAttrs` (fixed at component-config time).
+
+`omit` stays fully backward compatible: array callers hit the same `new Set(keys)` path as before; only the internal length check moved from `keys.length` to `keysSet.size`.
+
+**Measured delta**
+
+Head-to-head microbench (median of 5 passes), realistic `finalProps` call: ~18-key mergeProps (dimension keywords + DOM/component props), 18 stable omit keys. Outputs byte-identical across all three strategies.
+
+| Strategy | V8 (Node) | JSC (Bun) |
+|---|---|---|
+| current (concat + `new Set` each render) | 1.6M ops/s | 1.5M ops/s |
+| memoized array (Set still rebuilt) | 1.7M ops/s (+5%) | 1.5M ops/s (+2%) |
+| **prebuilt Set (this change)** | **3.0M ops/s (+47%)** | **6.5M ops/s (+77%)** |
+
+Memoizing the array alone barely moves the needle — the per-render `new Set` rebuild is the real cost, and passing a prebuilt Set removes it entirely.

--- a/packages/attrs/src/attrs.tsx
+++ b/packages/attrs/src/attrs.tsx
@@ -62,6 +62,13 @@ const attrsComponent: InitAttrsComponent = (options) => {
 
   const RenderComponent = options.component
 
+  // `filterAttrs` is fixed for the component's lifetime, so build the omit-key
+  // Set once here instead of letting `omit` rebuild it on every render.
+  const hasFilterAttrs = !!options.filterAttrs && options.filterAttrs.length > 0
+  const filterAttrsSet = hasFilterAttrs
+    ? new Set<string>(options.filterAttrs)
+    : undefined
+
   // Build the HOC chain: attrsHoc is always first (resolves default props),
   // followed by user-composed HOCs in reverse order (outermost wraps first).
   const hocsFuncs = [attrsHoc(options), ...calculateHocsFuncs(options.compose)]
@@ -77,11 +84,10 @@ const attrsComponent: InitAttrsComponent = (options) => {
     // both the consumer's ref and intermediate HOC refs point to the same node.
     const internalRef = useRef({ $attrsRef, ref })
     const needsRef = ref ?? $attrsRef
-    const needsFiltering = options.filterAttrs && options.filterAttrs.length > 0
 
     const baseProps = needsRef ? { ...props, ref: internalRef } : props
-    const filteredProps = needsFiltering
-      ? omit(baseProps, options.filterAttrs)
+    const filteredProps = filterAttrsSet
+      ? omit(baseProps, filterAttrsSet)
       : baseProps
 
     const finalProps =

--- a/packages/core/src/__tests__/utils.test.ts
+++ b/packages/core/src/__tests__/utils.test.ts
@@ -45,6 +45,26 @@ describe('omit', () => {
     obj.own = 1
     expect(omit(obj, [])).toEqual({ own: 1 })
   })
+
+  // A prebuilt Set is accepted in place of an array so hot callers can skip
+  // the per-call `new Set(...)` rebuild.
+  it('accepts a Set of keys (same result as an array)', () => {
+    const obj = { a: 1, b: 2, c: 3, d: 4 }
+    expect(omit(obj, new Set(['a', 'c']))).toEqual({ b: 2, d: 4 })
+  })
+
+  it('returns a shallow copy when given an empty Set', () => {
+    const obj = { a: 1, b: 2 }
+    const result = omit(obj, new Set())
+    expect(result).toEqual({ a: 1, b: 2 })
+    expect(result).not.toBe(obj)
+  })
+
+  it('does not mutate the passed-in Set', () => {
+    const keys = new Set(['b'])
+    omit({ a: 1, b: 2 }, keys)
+    expect([...keys]).toEqual(['b'])
+  })
 })
 
 // --------------------------------------------------------

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -2,16 +2,24 @@
 // omit — create a new object without the specified keys.
 // Accepts nullable input for convenience (returns `{}`).
 // Uses a Set for O(1) key lookup.
+//
+// `keys` may be an array OR a prebuilt `ReadonlySet`. Hot callers whose key
+// list is stable across renders (e.g. a component's reserved-prop list) should
+// pass a memoized/module-scope Set so we skip rebuilding it on every call —
+// the Set construction otherwise dominates the cost when `obj` is small.
 // --------------------------------------------------------
 export const omit = <T extends Record<string, any>>(
   obj: T | null | undefined,
-  keys?: readonly (string | keyof T)[],
+  keys?: readonly (string | keyof T)[] | ReadonlySet<string | keyof T>,
 ): Partial<T> => {
   if (obj == null) return {} as Partial<T>
-  if (!keys || keys.length === 0) return { ...obj }
+  if (!keys) return { ...obj }
+
+  const keysSet: ReadonlySet<unknown> =
+    keys instanceof Set ? keys : new Set(keys as readonly unknown[])
+  if (keysSet.size === 0) return { ...obj }
 
   const result: Record<string, any> = {}
-  const keysSet = new Set(keys as readonly string[])
 
   for (const key in obj) {
     if (Object.hasOwn(obj, key) && !keysSet.has(key)) {

--- a/packages/elements/src/List/component.tsx
+++ b/packages/elements/src/List/component.tsx
@@ -57,6 +57,10 @@ type ListExtras = ElementProps & ListOnly
  */
 export type Props<T = unknown> = MergeTypes<[IteratorProps<T>, ListExtras]>
 
+// Built once at module load — `Iterator.RESERVED_PROPS` is a static constant
+// array, so feeding `omit` a prebuilt Set skips the per-render Set rebuild.
+const RESERVED_PROPS_SET = new Set<string>(Iterator.RESERVED_PROPS)
+
 const Component: VLElement<IteratorLooseProps & ListExtras> = ({
   rootElement = false,
   ref,
@@ -77,7 +81,7 @@ const Component: VLElement<IteratorLooseProps & ListExtras> = ({
   if (!rootElement) return renderedList
 
   return (
-    <Element ref={ref} {...omit(props, Iterator.RESERVED_PROPS)}>
+    <Element ref={ref} {...omit(props, RESERVED_PROPS_SET)}>
       {renderedList}
     </Element>
   )

--- a/packages/rocketstyle/src/rocketstyle.tsx
+++ b/packages/rocketstyle/src/rocketstyle.tsx
@@ -322,6 +322,22 @@ const rocketComponent: RocketComponent = (options) => {
       [reservedPropNames],
     )
 
+    // Prebuilt omit-key Set for the finalProps assembly below. All three
+    // sources are stable for the instance (RESERVED_STYLING_PROPS_KEYS is
+    // memoized, PSEUDO_KEYS is a module constant, options.filterAttrs is fixed
+    // at component-config time), so the Set — and the 3-way array spread that
+    // fed it — were being rebuilt every render for nothing. `omit` now consumes
+    // the Set directly, skipping its own per-call `new Set(...)`.
+    const omitKeysSet = useMemo(
+      () =>
+        new Set<string>([
+          ...RESERVED_STYLING_PROPS_KEYS,
+          ...PSEUDO_KEYS,
+          ...options.filterAttrs,
+        ]),
+      [RESERVED_STYLING_PROPS_KEYS],
+    )
+
     // --------------------------------------------------
     // get final props which are (latest has the highest priority):
     // (1) merged styling from context,
@@ -391,11 +407,7 @@ const rocketComponent: RocketComponent = (options) => {
     const finalProps: Record<string, any> = {
       // this removes styling state from props and passes its state
       // under rocketstate key only
-      ...omit(mergeProps, [
-        ...RESERVED_STYLING_PROPS_KEYS,
-        ...PSEUDO_KEYS,
-        ...options.filterAttrs,
-      ]),
+      ...omit(mergeProps, omitKeysSet),
       // if enforced to pass styling props, we pass them directly
       ...(options.passProps ? pick(mergeProps, options.passProps) : {}),
       ref: (ref ?? $rocketstyleRef) ? internalRef : undefined,


### PR DESCRIPTION
## Summary

`omit()` builds `new Set(keys)` internally for O(1) lookups. Every render-path caller passed a **stable** key list, so that Set was reconstructed on every render for nothing — and the Set construction dominates the call cost when the source object is small (the usual props case).

### Change
- **`@vitus-labs/core`** — `omit()` now accepts a `ReadonlySet` in addition to an array. Fully backward compatible: array callers hit the same `new Set(keys)` path as before; only the internal empty-check moved from `keys.length` to `keysSet.size`.
- **rocketstyle** — the `finalProps` omit also rebuilt a 3-way `[...RESERVED_STYLING_PROPS_KEYS, ...PSEUDO_KEYS, ...options.filterAttrs]` array each render. Now a single `useMemo` Set (all three sources stable for the instance).
- **elements/List** — module-scope Set from the constant `Iterator.RESERVED_PROPS`.
- **attrs** — factory-closure Set from `options.filterAttrs` (fixed at component-config time).

## Measured delta

Head-to-head microbench (median of 5), realistic `finalProps` call (~18-key `mergeProps` = dimension keywords + DOM/component props, 18 stable omit keys). Outputs byte-identical across strategies.

| Strategy | V8 (Node) | JSC (Bun) |
|---|---|---|
| current (concat + `new Set` each render) | 1.6M ops/s | 1.5M ops/s |
| memoized array (Set still rebuilt) | 1.7M (+5%) | 1.5M (+2%) |
| **prebuilt Set (this PR)** | **3.0M (+47%)** | **6.5M (+77%)** |

Memoizing the array alone barely moved the needle — the per-render `new Set` rebuild was the real cost.

## Test plan

- [x] omit Set-path tests added (Set keys, empty Set, no-mutation of the passed Set)
- [x] `bun run test` — 2705 pass (was 2702)
- [x] `bun run typecheck` — clean across 15 packages (core rebuilt so the widened signature propagates)
- [x] `bun run lint` — clean
- [x] `bun run pkgs:build` — all packages build
- [x] CI perf bench gate will confirm no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)