### PR TITLE
fix(unistyle): emit border-collapse + revalidate README size/count claims

### DIFF
--- a/.changeset/fix-unistyle-border-collapse.md
+++ b/.changeset/fix-unistyle-border-collapse.md
@@ -1,0 +1,5 @@
+---
+'@vitus-labs/unistyle': patch
+---
+
+Fix `borderCollapse`: it was declared in the `ITheme` prop type but had no `propertyMap` descriptor, so passing it type-checked yet emitted no CSS. Added the missing `simple` descriptor so `borderCollapse: 'collapse' | 'separate'` now produces `border-collapse: …`. Verified by diffing all 305 typed `ITheme` keys against the property map — this was the only typed-but-unmapped key (the other, `keyframe`, is intentionally consumed by the `animation` special handler).

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ UI System is not a component library. It's a set of composable packages for buil
 | Package | Description |
 | ------- | ----------- |
 | [@vitus-labs/core](./packages/core) | Shared utilities, styling engine bridge, theme context |
-| [@vitus-labs/styler](./packages/styler) | Lightweight CSS-in-JS engine (3.81 KB gz) — drop-in styled-components replacement |
+| [@vitus-labs/styler](./packages/styler) | Lightweight CSS-in-JS engine (4.82 KB gz) — drop-in styled-components replacement |
 | [@vitus-labs/attrs](./packages/attrs) | Immutable chainable default-props factory for React components |
 | [@vitus-labs/elements](./packages/elements) | Layout primitives — Element, Text, List, Overlay, Portal |
 | [@vitus-labs/unistyle](./packages/unistyle) | Responsive CSS engine — media queries, unit conversion, style processing |
@@ -38,8 +38,8 @@ UI System is not a component library. It's a set of composable packages for buil
 
 | Package | Size (gzip) | Description |
 | ------- | ----------- | ----------- |
-| [@vitus-labs/kinetic](./packages/kinetic) | 3.2 KB | CSS-first animation — enter/exit, stagger, collapse, list reconciliation |
-| [@vitus-labs/kinetic-presets](./packages/kinetic-presets) | 2.3 KB | 122 presets, 5 factories, 5 composition utilities for kinetic |
+| [@vitus-labs/kinetic](./packages/kinetic) | 3.4 KB | CSS-first animation — enter/exit, stagger, collapse, list reconciliation |
+| [@vitus-labs/kinetic-presets](./packages/kinetic-presets) | 3.7 KB | 123 presets, 5 factories, 5 composition utilities for kinetic |
 
 ### Connectors
 

--- a/packages/hooks/README.md
+++ b/packages/hooks/README.md
@@ -1,6 +1,6 @@
 # @vitus-labs/hooks
 
-28 React hooks for UI interactions, state management, DOM observation, accessibility, and theming. 2.15KB gzipped.
+28 React hooks for UI interactions, state management, DOM observation, accessibility, and theming. ~3.4 KB gzipped.
 
 [![npm](https://img.shields.io/npm/v/@vitus-labs/hooks)](https://www.npmjs.com/package/@vitus-labs/hooks)
 [![license](https://img.shields.io/npm/l/@vitus-labs/hooks)](https://github.com/vitus-labs/ui-system/blob/main/LICENSE)

--- a/packages/kinetic-presets/README.md
+++ b/packages/kinetic-presets/README.md
@@ -1,9 +1,9 @@
 # @vitus-labs/kinetic-presets
 
-122 animation presets, 5 configurable factories, and 5 composition utilities for `@vitus-labs/kinetic`.
+123 animation presets, 5 configurable factories, and 5 composition utilities for `@vitus-labs/kinetic`.
 
 [![npm](https://img.shields.io/npm/v/@vitus-labs/kinetic-presets)](https://www.npmjs.com/package/@vitus-labs/kinetic-presets)
-[![gzip size](https://img.shields.io/badge/gzip-2.3KB-brightgreen)](https://bundlephobia.com/package/@vitus-labs/kinetic-presets)
+[![gzip size](https://img.shields.io/badge/gzip-3.7KB-brightgreen)](https://bundlephobia.com/package/@vitus-labs/kinetic-presets)
 [![license](https://img.shields.io/npm/l/@vitus-labs/kinetic-presets)](./LICENSE)
 
 All exports are tree-shakeable. Import only what you use.
@@ -33,7 +33,7 @@ const FadeSlide = kinetic('div').preset(compose(presets.fade, presets.slideUp))
 const QuickBounce = kinetic('div').preset(withDuration(presets.bounceIn, 200))
 ```
 
-## Presets (122 total)
+## Presets (123 total)
 
 All presets are available as named exports and via the `presets` map object.
 

--- a/packages/kinetic/README.md
+++ b/packages/kinetic/README.md
@@ -3,20 +3,20 @@
 CSS-first animation library for React. Enter/exit transitions, staggered animations, height collapse, and list reconciliation — all in ~3KB gzipped.
 
 [![npm](https://img.shields.io/npm/v/@vitus-labs/kinetic)](https://www.npmjs.com/package/@vitus-labs/kinetic)
-[![gzip size](https://img.shields.io/badge/gzip-3.2KB-brightgreen)](https://bundlephobia.com/package/@vitus-labs/kinetic)
+[![gzip size](https://img.shields.io/badge/gzip-3.4KB-brightgreen)](https://bundlephobia.com/package/@vitus-labs/kinetic)
 [![license](https://img.shields.io/npm/l/@vitus-labs/kinetic)](./LICENSE)
 
 ## Why Kinetic?
 
 Most React animation libraries run their own JavaScript animation loop on the main thread. Kinetic takes a different approach: it delegates all interpolation to the browser's CSS transition engine (compositor thread for `transform`/`opacity`), and only handles orchestration — mount/unmount lifecycle, stagger timing, height measurement, and list diffing.
 
-The result: GPU-composited 60/120 FPS animations with a 3.2KB footprint.
+The result: GPU-composited 60/120 FPS animations with a 3.4KB footprint.
 
 ### How It Compares
 
 | Library | Gzipped | Engine | Enter/Exit | Stagger | List Recon. | Collapse | Reduced Motion |
 | ------- | ------- | ------ | ---------- | ------- | ----------- | -------- | -------------- |
-| **@vitus-labs/kinetic** | **3.2 KB** | CSS transitions | Yes | Yes | Yes | Yes | Yes |
+| **@vitus-labs/kinetic** | **3.4 KB** | CSS transitions | Yes | Yes | Yes | Yes | Yes |
 | Motion (framer-motion) | ~34 KB | JS (rAF + WAAPI) | Yes | Yes | Yes | Quirky | Yes |
 | @react-spring/web | ~16-24 KB | JS (spring physics) | Yes | Partial | Yes | Manual | Yes |
 | react-transition-group | ~5 KB | CSS classes | Yes | No | Yes | No | No |
@@ -29,7 +29,7 @@ The result: GPU-composited 60/120 FPS animations with a 3.2KB footprint.
 - **CSS-first**: `transform`/`opacity` run on GPU compositor thread, not main thread
 - **Modern replacement for react-transition-group** (dead since 2022, broken on React 19)
 - **Only library** combining CSS transitions + stagger + collapse + list reconciliation
-- **122 presets** available via `@vitus-labs/kinetic-presets`
+- **123 presets** available via `@vitus-labs/kinetic-presets`
 
 ### Performance: CSS vs JS Animation Engines
 
@@ -238,7 +238,7 @@ Six presets are included in the core package:
 import { fade, scaleIn, slideUp, slideDown, slideLeft, slideRight } from '@vitus-labs/kinetic'
 ```
 
-For 122 presets, factories, and composition utilities, install `@vitus-labs/kinetic-presets`.
+For 123 presets, factories, and composition utilities, install `@vitus-labs/kinetic-presets`.
 
 ## Hooks
 

--- a/packages/styler/README.md
+++ b/packages/styler/README.md
@@ -2,7 +2,7 @@
 
 A lightweight CSS-in-JS engine for React. Drop-in replacement for `styled-components` at a fraction of the size.
 
-**3.81 KB** gzipped | **React 19+** | **SSR & static export ready** | **TypeScript strict**
+**4.82 KB** gzipped | **React 19+** | **SSR & static export ready** | **TypeScript strict**
 
 ## Installation
 
@@ -313,7 +313,7 @@ All benchmarks run via Vitest bench on the same machine. React is externalized i
 | Library | Minified | Gzipped |
 |---------|--------:|--------:|
 | goober | 2.32 KB | 1.31 KB |
-| **@vitus-labs/styler** | **10.13 KB** | **3.81 KB** |
+| **@vitus-labs/styler** | **12.21 KB** | **4.82 KB** |
 | styled-components | 44.93 KB | 17.89 KB |
 | @emotion/react + styled | 48.26 KB | 16.59 KB |
 
@@ -344,7 +344,7 @@ Key differences:
 
 | Feature | styled-components | @vitus-labs/styler |
 |---------|------------------|-------------------|
-| Bundle size | ~16 KB gz | **3.81 KB gz** |
+| Bundle size | ~16 KB gz | **4.82 KB gz** |
 | `styled.div` shorthand | Yes | Yes |
 | `as` prop | Yes | Yes |
 | Ref forwarding | Yes | Yes |

--- a/packages/styler/benchmarks/results.md
+++ b/packages/styler/benchmarks/results.md
@@ -6,11 +6,12 @@ Comparison of `@vitus-labs/styler` against `styled-components` 6 and `@emotion/s
 
 ## Setup
 
-- bun 1.3.13, react 19.2.5
-- `NODE_ENV=production`
+- bun 1.3.14, react 19.2.6
+- styler 2.6.2, styled-components 6.4.2, @emotion/styled 11.14.1 / @emotion/react 11.14.0
 - jsdom for CSR scenarios
 - tinybench: 1500 ms timed window, 300 ms warmup
 - Apple Silicon
+- Medians of 3 full passes (within-pass variance < 5%)
 
 ## Scenarios
 
@@ -25,39 +26,16 @@ Comparison of `@vitus-labs/styler` against `styled-components` 6 and `@emotion/s
 
 **Fairness note**: `styled-components` 6 does NOT use React 19's `<style precedence>` mechanism — `renderToString` only emits class names, deferring CSS serialization. The SSR sc paths wrap each render in `ServerStyleSheet.collectStyles()` + `getStyleTags()` so all three libs do equivalent work (render + serialize CSS).
 
-## Latest results
+## Results (median ops/sec, higher is better)
 
-```
-── ssr-static ──
-  styler     1528 ops/s   0.685 ms/op   1.00× ████████████████████
-  emotion    1008 ops/s   1.040 ms/op   0.66× █████████████
-  sc          259 ops/s   3.905 ms/op   0.17× ███
-
-── ssr-dynamic ──
-  styler     1174 ops/s   0.887 ms/op   1.00× ████████████████████
-  emotion     904 ops/s   1.152 ms/op   0.77× ███████████████
-  sc          242 ops/s   4.179 ms/op   0.21× ████
-
-── ssr-themed ──
-  styler     1148 ops/s   0.910 ms/op   1.00× ████████████████████
-  emotion     903 ops/s   1.148 ms/op   0.79× ████████████████
-  sc          250 ops/s   4.054 ms/op   0.22× ████
-
-── csr-mount ──
-  emotion   48630 ops/s   0.022 ms/op   1.00× ████████████████████
-  styler    46611 ops/s   0.024 ms/op   0.96× ███████████████████
-  sc        45659 ops/s   0.024 ms/op   0.94× ███████████████████
-
-── csr-update ──
-  styler    36386 ops/s   0.029 ms/op   1.00× ████████████████████
-  emotion   35896 ops/s   0.030 ms/op   0.99× ████████████████████
-  sc        35844 ops/s   0.029 ms/op   0.99× ████████████████████
-
-── csr-many ──
-  styler    42842 ops/s   0.027 ms/op   1.00× ████████████████████
-  emotion   38800 ops/s   0.027 ms/op   0.91× ██████████████████
-  sc        13936 ops/s   0.090 ms/op   0.33× ███████
-```
+| Scenario | styler | emotion | sc | styler vs emotion | styler vs sc |
+|---|---|---|---|---|---|
+| ssr-static | **674.5** | 315.6 | 196.6 | **2.14×** | **3.43×** |
+| ssr-dynamic | **400.7** | 303.0 | 188.4 | **1.32×** | **2.13×** |
+| ssr-themed | **346.1** | 251.7 | 171.0 | **1.37×** | **2.02×** |
+| csr-mount | 13715 | 13048 | 13266 | 1.05× | 1.03× |
+| csr-update | 12800 | 12664 | 12844 | 1.01× | 1.00× |
+| csr-many | **18714** | 17938 | 5463 | 1.04× | **3.43×** |
 
 ## Per-render translation
 
@@ -65,32 +43,32 @@ SSR per-render cost (each tick = 500 renders):
 
 | Scenario | styler | emotion | sc |
 |---|---|---|---|
-| ssr-static | **1.37 μs** | 2.08 μs | 7.81 μs |
-| ssr-dynamic | **1.77 μs** | 2.30 μs | 8.36 μs |
-| ssr-themed | **1.82 μs** | 2.30 μs | 8.11 μs |
+| ssr-static | **3.05 μs** | 6.44 μs | 10.26 μs |
+| ssr-dynamic | **5.06 μs** | 6.68 μs | 10.75 μs |
+| ssr-themed | **6.05 μs** | 8.15 μs | 11.82 μs |
 
-CSR per-mount cost (each tick = 100 mounts):
+CSR per-mount cost (each tick = 100 mounts; csr-many = 50 distinct components):
 
 | Scenario | styler | emotion | sc |
 |---|---|---|---|
-| csr-mount | 0.24 μs | **0.22 μs** | 0.24 μs |
-| csr-update | **0.29 μs** | 0.30 μs | 0.29 μs |
-| csr-many | **0.54 μs/tick / 50** | 0.55 μs | 1.79 μs |
+| csr-mount | **0.78 μs** | 0.84 μs | 0.82 μs |
+| csr-update | 0.84 μs | 0.85 μs | **0.82 μs** |
+| csr-many (per component) | **1.18 μs** | 1.20 μs | 4.22 μs |
 
 ## Takeaways
 
-1. **SSR**: styler leads by **1.3–1.4× vs emotion** and **4–5× vs sc**. The React 19 `<style precedence>` integration + cached static templates + lazy resolve all contribute.
-2. **CSR mount/update**: within ~5% across all three libs. React's reconciler dominates; CSS-in-JS work is in the noise.
-3. **CSR many** (distinct components per tick, cache-defeating): styler/emotion are similar (~10% gap), **sc is 3× slower**. Each new `styled.div` template carries setup cost that sc pays at create-time.
-4. **Bundle size (orthogonal)**: styler gzip ≈ 3.06 KB, emotion ≈ 7 KB, sc6 ≈ 16 KB.
+1. **SSR**: styler leads on every scenario — **2.0–3.4× vs styled-components** and **1.3–2.1× vs emotion**. The lead is largest on `ssr-static` (no function interpolations → class computed once and cached) and narrows on `ssr-dynamic`/`ssr-themed` where all three must resolve per render. The React 19 `<style precedence>` integration + cached static templates + lazy resolve all contribute.
+2. **CSR mount/update**: within ~5% across all three libs — i.e. a statistical tie. React's reconciler + jsdom DOM mutation dominate; CSS-in-JS overhead is in the noise here.
+3. **CSR many** (distinct components per tick, cache-defeating): styler ≈ emotion, both **~3.4× faster than styled-components**. Each new `styled.div` template carries per-component setup cost that sc pays heavily at create-time.
 
-## Caveats
+## Caveats (honesty)
 
-- jsdom CSR doesn't paint — real browser perf includes layout/style recalc that this bench doesn't reflect. Component count, layout complexity, and CSS rule count will shift the picture.
-- `tinybench` numbers within ~5% are noise. The dramatic SSR sc gap and `csr-many` sc gap are well outside the noise floor; the close-fought CSR mount/update results are within it.
-- `styled-components` 6 ships a streaming-SSR path (`renderToPipeableStream`) optimized for large trees — this bench measures sync `renderToString` only.
-- styler's cache benefits from the same component being rendered many times per tick. Real apps see this for the most-rendered components.
+- **jsdom CSR doesn't paint** — a real browser includes layout/style recalc this bench doesn't reflect. The CSR mount/update tie should be read as "CSS engine isn't the bottleneck there," not "all engines paint equally fast."
+- **`tinybench` numbers within ~5% are noise.** The SSR gaps and the `csr-many` sc gap are well outside the noise floor; the CSR mount/update results are within it (reported as ties).
+- **Absolute throughput is machine/thermal-dependent** — only the cross-library ratios on the *same* run are meaningful. These were measured on one machine in one sitting, 3 passes.
+- **`styled-components` 6 ships a streaming-SSR path** (`renderToPipeableStream`) optimized for large trees — this bench measures sync `renderToString` only.
+- **styler's cache benefits from the same component rendering many times per tick.** Real apps see this for their most-rendered components; cold one-off renders look more like `csr-many`.
 
 ## Regression check
 
-Future PRs that touch the styler hot path should re-run `bun run bench` and update this file. If you see a >10% regression on any styler row vs the numbers here, investigate before merging.
+Future PRs that touch the styler hot path should re-run `bun run bench` and update this file. A >10% regression on any styler row vs these numbers warrants investigation before merging. (Compare ratios, not absolute ops/s — the latter drifts with machine/runtime version.)

--- a/packages/unistyle/README.md
+++ b/packages/unistyle/README.md
@@ -13,7 +13,7 @@ Transforms property-centric theme objects into breakpoint-centric CSS with media
 - **px-to-rem conversion** — configurable rootSize, zero-effort unit handling
 - **Breakpoint deduplication** — identical breakpoints are collapsed, no redundant CSS
 - **Three input formats** — scalar, mobile-first array, or breakpoint object per property
-- **Data-driven styles** — 100+ CSS properties processed from a theme object
+- **Data-driven styles** — 170+ CSS properties processed from a theme object
 - **Alignment helpers** — flex alignment constants for X and Y axes
 
 ## Installation

--- a/packages/unistyle/src/__tests__/styles.test.ts
+++ b/packages/unistyle/src/__tests__/styles.test.ts
@@ -16,6 +16,19 @@ describe('styles', () => {
     expect(flat).toContain('color: red')
   })
 
+  // Regression: borderCollapse was declared in ITheme but had no propertyMap
+  // descriptor, so it type-checked yet emitted nothing. Lock in that it now
+  // produces CSS.
+  it('emits border-collapse (was typed but unmapped)', () => {
+    const result = styles({
+      theme: { borderCollapse: 'collapse' } as any,
+      css,
+      rootSize: 16,
+    })
+    const flat = Array.isArray(result) ? result.flat().join('') : String(result)
+    expect(flat).toContain('border-collapse: collapse')
+  })
+
   it('converts number values to rem', () => {
     const result = styles({
       theme: { fontSize: 16 } as any,

--- a/packages/unistyle/src/styles/styles/propertyMap.ts
+++ b/packages/unistyle/src/styles/styles/propertyMap.ts
@@ -341,6 +341,7 @@ const propertyMap: PropertyDescriptor[] = [
   { kind: 'simple', css: 'border-image-source', key: 'borderImageSource' },
   { kind: 'simple', css: 'border-image-width', key: 'borderImageWidth' },
   { kind: 'simple', css: 'border-spacing', key: 'borderSpacing' },
+  { kind: 'simple', css: 'border-collapse', key: 'borderCollapse' },
 
   // Logical borders
   { kind: 'simple', css: 'border-inline', key: 'borderInline' },


### PR DESCRIPTION
## Summary

A correctness pass triggered by "revalidate docs + READMEs against ground truth."

### Bug fix — `borderCollapse` emitted nothing
`borderCollapse` was declared in the `ITheme` prop type but had **no `propertyMap` descriptor** — so `<Element borderCollapse="collapse" />` type-checked yet produced no CSS. Added the missing descriptor.

Found objectively: diffed all **305 typed `ITheme` keys** against the property map. `borderCollapse` was the *only* typed-but-unmapped key (`keyframe` is intentionally consumed by the `animation` special handler). Coverage is otherwise complete: 263 descriptors, every typed key now maps.

### README revalidation
All numbers re-measured (minified + gzipped, React external, fresh build):

| Claim | Was | Now (measured) |
|---|---|---|
| styler gz | 3.81 KB | **4.82 KB** (matches docs site) |
| styler min | 10.13 KB | 12.21 KB |
| kinetic-presets count | 122 | **123** (presets.ts exports) |
| kinetic-presets size | 2.3 KB | 3.7 KB |
| kinetic size | 3.2 KB | 3.4 KB |
| hooks size | 2.15 KB | ~3.4 KB |
| unistyle props | "100+" | "170+" (actual 262 descriptors) |

Also refreshes `packages/styler/benchmarks/results.md` with current medians (bun 1.3.14, react 19.2.6).

## Test plan
- [x] `bun run test` — 2706 pass (+1 borderCollapse lock-in)
- [x] `bun run lint` — clean
- [x] `bun run --filter=@vitus-labs/unistyle build` — clean
- [x] Changeset added (patch @vitus-labs/unistyle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)