### PR TITLE
fix(connector-native): expand multi-value shorthands + reactive breakpoints

### DIFF
--- a/.changeset/fix-connector-native-shorthands-reactivity.md
+++ b/.changeset/fix-connector-native-shorthands-reactivity.md
@@ -1,0 +1,9 @@
+---
+'@vitus-labs/connector-native': patch
+---
+
+Fundamentally fix the two remaining React Native styling gaps:
+
+1. **Multi-value box shorthands now expand correctly.** `padding: 8px 16px`, `margin: 0 auto`, `border-radius: 4px 8px 12px 16px`, etc. previously parsed to just their first token (`padding: 8`), because React Native has no multi-value shorthand. They now expand into RN longhands following the CSS box-model value rules: edge shorthands (`margin`/`padding`/`inset`/`border-width`) → `*Top/*Right/*Bottom/*Left`, `border-radius` → per-corner radii, and `gap: row col` → `rowGap`/`columnGap`. Single values are unchanged (RN supports them); `calc()` and elliptical (`/`) radii are left untouched.
+
+2. **Responsive breakpoints are now reactive to rotation / resize.** `createMediaQueries` deferred its `Dimensions.get('window').width` check from breakpoint-call time to `resolve()` time, so the current width is read on every resolve instead of being baked into upstream caches (e.g. `makeItResponsive`'s per-theme cache). The native `styled` component subscribes to `useWindowDimensions()` so a rotation/resize re-renders and re-resolves — matching how the browser re-evaluates `@media`. Previously a responsive component kept its first-render breakpoint until something else forced a re-render.

--- a/.size-limit.json
+++ b/.size-limit.json
@@ -14,7 +14,7 @@
   {
     "name": "@vitus-labs/connector-native",
     "path": "packages/connector-native/lib/index.js",
-    "limit": "3.5 KB",
+    "limit": "4.5 KB",
     "gzip": true
   },
   {

--- a/packages/connector-native/src/__mocks__/react-native.ts
+++ b/packages/connector-native/src/__mocks__/react-native.ts
@@ -1,5 +1,17 @@
 import { vi } from 'vitest'
 
 export const Dimensions = {
-  get: vi.fn(() => ({ width: 375, height: 812, scale: 1, fontScale: 1 })),
+  get: vi.fn((_dim?: 'window' | 'screen') => ({
+    width: 375,
+    height: 812,
+    scale: 1,
+    fontScale: 1,
+  })),
 }
+
+/**
+ * Minimal `useWindowDimensions` mock — returns the current `Dimensions.get`
+ * value. Real React Native subscribes and re-renders on change; the unit
+ * tests drive re-renders explicitly, so a plain read is sufficient here.
+ */
+export const useWindowDimensions = () => Dimensions.get('window')

--- a/packages/connector-native/src/__tests__/createMediaQueries.test.ts
+++ b/packages/connector-native/src/__tests__/createMediaQueries.test.ts
@@ -19,12 +19,15 @@ describe('createMediaQueries', () => {
     expect(result.resolve({})).toEqual({ width: 100 })
   })
 
-  it('applies styles when width >= breakpoint', () => {
-    // Default mock: width=375, so sm (576) should NOT apply
+  it('resolves to empty when width < breakpoint (lazy)', () => {
+    // Default mock: width=375, so sm (576) should NOT apply. The result is a
+    // lazy CSSResult that resolves to {} rather than the literal '' it used
+    // to return eagerly.
     const media = createMediaQueries({ breakpoints, rootSize: 16, css })
     const result = media.sm`width: 200px;`
 
-    expect(result).toBe('')
+    expect(result.__brand).toBe('vl.native.css')
+    expect(result.resolve({})).toEqual({})
   })
 
   it('applies styles when width matches breakpoint exactly', () => {
@@ -53,7 +56,33 @@ describe('createMediaQueries', () => {
     const media = createMediaQueries({ breakpoints, rootSize: 16, css })
     const result = media.md`width: 300px;`
 
-    expect(result).toBe('')
+    expect(result.resolve({})).toEqual({})
+  })
+
+  it('re-evaluates width lazily at resolve time (rotation reactivity)', () => {
+    // The width check must happen at resolve(), NOT when media.md`…` is
+    // called — otherwise a cached result would freeze the width. Build the
+    // result while narrow, then "rotate" wider and resolve again.
+    vi.mocked(Dimensions.get).mockReturnValue({
+      width: 375,
+      height: 812,
+      scale: 1,
+      fontScale: 1,
+    })
+    const media = createMediaQueries({ breakpoints, rootSize: 16, css })
+    const result = media.md`width: 300px;` // md = 768, built at width 375
+
+    // Still narrow → empty
+    expect(result.resolve({})).toEqual({})
+
+    // Rotate to a wider screen; the SAME result must now apply
+    vi.mocked(Dimensions.get).mockReturnValue({
+      width: 1024,
+      height: 768,
+      scale: 1,
+      fontScale: 1,
+    })
+    expect(result.resolve({})).toEqual({ width: 300 })
   })
 
   it('skips breakpoint with null value', () => {
@@ -81,11 +110,11 @@ describe('createMediaQueries', () => {
   })
 
   // End-to-end shape of the responsive pipeline: unistyle's makeItResponsive
-  // emits `[media.xs`…`, media.md`…`, …]` (CSSResult when the breakpoint
-  // applies, '' when it doesn't) and feeds that array into the engine's css
-  // as an interpolation. This exercises createMediaQueries + array-flattening
-  // + the breakpoint cascade together, the way a real responsive native
-  // component does.
+  // emits `[media.xs`…`, media.md`…`, …]` (each a lazy CSSResult that resolves
+  // to its styles when the breakpoint applies, or {} when it doesn't) and
+  // feeds that array into the engine's css as an interpolation. This exercises
+  // createMediaQueries + array-flattening + the breakpoint cascade together,
+  // the way a real responsive native component does.
   describe('responsive pipeline (media → array → css)', () => {
     it('applies base + matching breakpoint, later one wins', () => {
       vi.mocked(Dimensions.get).mockReturnValue({

--- a/packages/connector-native/src/__tests__/parse.test.ts
+++ b/packages/connector-native/src/__tests__/parse.test.ts
@@ -66,6 +66,105 @@ describe('parseCSS', () => {
     // NaN.parseFloat('autopx') returns NaN → falls through to string return
     expect(parseCSS('width: autopx')).toEqual({ width: 'autopx' })
   })
+
+  // Multi-value box shorthands — RN has no `padding: 8px 16px`, so they expand
+  // into longhands per CSS box-model rules (previously parsed to first value).
+  describe('multi-value box shorthands', () => {
+    it('expands 2-value padding (vertical / horizontal)', () => {
+      expect(parseCSS('padding: 8px 16px')).toEqual({
+        paddingTop: 8,
+        paddingRight: 16,
+        paddingBottom: 8,
+        paddingLeft: 16,
+      })
+    })
+
+    it('expands 3-value margin (top / horizontal / bottom)', () => {
+      expect(parseCSS('margin: 4px 8px 12px')).toEqual({
+        marginTop: 4,
+        marginRight: 8,
+        marginBottom: 12,
+        marginLeft: 8,
+      })
+    })
+
+    it('expands 4-value margin (top right bottom left)', () => {
+      expect(parseCSS('margin: 1px 2px 3px 4px')).toEqual({
+        marginTop: 1,
+        marginRight: 2,
+        marginBottom: 3,
+        marginLeft: 4,
+      })
+    })
+
+    it('keeps single-value shorthand as the shorthand prop (RN supports it)', () => {
+      expect(parseCSS('padding: 8px')).toEqual({ padding: 8 })
+      expect(parseCSS('margin: 0')).toEqual({ margin: 0 })
+    })
+
+    it('supports `margin: 0 auto` (mixed numeric + keyword)', () => {
+      expect(parseCSS('margin: 0 auto')).toEqual({
+        marginTop: 0,
+        marginRight: 'auto',
+        marginBottom: 0,
+        marginLeft: 'auto',
+      })
+    })
+
+    it('expands inset (RN has no inset shorthand)', () => {
+      expect(parseCSS('inset: 0 10px 20px 30px')).toEqual({
+        top: 0,
+        right: 10,
+        bottom: 20,
+        left: 30,
+      })
+    })
+
+    it('expands border-width to per-side widths', () => {
+      expect(parseCSS('border-width: 1px 2px')).toEqual({
+        borderTopWidth: 1,
+        borderRightWidth: 2,
+        borderBottomWidth: 1,
+        borderLeftWidth: 2,
+      })
+    })
+
+    it('expands border-radius by corner (TL TR BR BL)', () => {
+      expect(parseCSS('border-radius: 4px 8px 12px 16px')).toEqual({
+        borderTopLeftRadius: 4,
+        borderTopRightRadius: 8,
+        borderBottomRightRadius: 12,
+        borderBottomLeftRadius: 16,
+      })
+    })
+
+    it('expands 2-value gap into rowGap / columnGap', () => {
+      expect(parseCSS('gap: 8px 16px')).toEqual({ rowGap: 8, columnGap: 16 })
+    })
+
+    it('does not split function values like calc()', () => {
+      // calc() contains spaces; must not be naively split
+      expect(parseCSS('padding: calc(8px + 2px)')).toEqual({
+        padding: 'calc(8px + 2px)',
+      })
+    })
+
+    it('degrades elliptical border-radius to the horizontal radius', () => {
+      // RN has no elliptical radii; `10px / 20px` isn't expanded (contains /)
+      // and falls back to the single-value path → 10 applied to all corners.
+      expect(parseCSS('border-radius: 10px / 20px')).toEqual({
+        borderRadius: 10,
+      })
+    })
+
+    it('does not expand non-box multi-value props (e.g. border)', () => {
+      // `border: 1px solid red` is left as a string (RN ignores it); the
+      // expander only targets numeric box shorthands.
+      expect(parseCSS('border: 1px solid red')).toEqual({
+        border: '1px solid red',
+      })
+    })
+  })
 })
 
 describe('mergeStyles', () => {

--- a/packages/connector-native/src/__tests__/styled.test.tsx
+++ b/packages/connector-native/src/__tests__/styled.test.tsx
@@ -1,6 +1,9 @@
 import { render, screen } from '@testing-library/react'
 import { type FC, forwardRef } from 'react'
+import { Dimensions } from 'react-native'
 import { describe, expect, it, vi } from 'vitest'
+import createMediaQueries from '~/createMediaQueries'
+import { css } from '~/css'
 import { ThemeProvider } from '~/provider'
 import { styled } from '~/styled'
 
@@ -212,5 +215,47 @@ describe('styled', () => {
     `
 
     expect(StyledComponent.displayName).toBe('styled(Component)')
+  })
+
+  // Rotation reactivity: a component whose styles depend on a media query
+  // re-resolves with the new width when the window dimensions change. In
+  // production `useWindowDimensions()` (called inside styled) triggers the
+  // re-render; here we simulate that re-render and assert the resolved style
+  // tracks the width.
+  it('re-resolves responsive media styles when window width changes', () => {
+    const media = createMediaQueries({
+      breakpoints: { xs: 0, md: 768 },
+      rootSize: 16,
+      css,
+    })
+    // mimic makeItResponsive's output: a prop carrying the per-breakpoint array
+    const Box = styled(MockView)`
+      ${(p: any) => p.$responsive}
+    `
+    const responsive = [media.xs`color: red;`, media.md`color: blue;`]
+
+    // start narrow → only base (xs) applies
+    vi.mocked(Dimensions.get).mockReturnValue({
+      width: 375,
+      height: 812,
+      scale: 1,
+      fontScale: 1,
+    })
+    const { rerender } = render(<Box $responsive={responsive} />)
+    expect(
+      JSON.parse(screen.getByTestId('view').getAttribute('data-style')!),
+    ).toEqual({ color: 'red' })
+
+    // rotate wider → md now applies and overrides
+    vi.mocked(Dimensions.get).mockReturnValue({
+      width: 1024,
+      height: 768,
+      scale: 1,
+      fontScale: 1,
+    })
+    rerender(<Box $responsive={responsive} />)
+    expect(
+      JSON.parse(screen.getByTestId('view').getAttribute('data-style')!),
+    ).toEqual({ color: 'blue' })
   })
 })

--- a/packages/connector-native/src/createMediaQueries.ts
+++ b/packages/connector-native/src/createMediaQueries.ts
@@ -1,6 +1,6 @@
 import { Dimensions } from 'react-native'
 
-import type { css } from '~/css'
+import type { CSSResult, css } from '~/css'
 
 type CreateMediaQueries = <B extends Record<string, number>>(props: {
   breakpoints: B
@@ -8,11 +8,33 @@ type CreateMediaQueries = <B extends Record<string, number>>(props: {
   css: typeof css
 }) => Record<keyof B, (...args: any[]) => any>
 
+const EMPTY_STYLE = {} as const
+
+/**
+ * Wraps a breakpoint's CSSResult so the screen-width check happens at
+ * `resolve()` time, not when the breakpoint function is called. This keeps
+ * the width OUT of any upstream cache (e.g. unistyle's makeItResponsive
+ * caches the array of these results by theme reference): the cached result
+ * re-evaluates the current width on every resolve. Combined with the native
+ * `styled` component subscribing to `useWindowDimensions`, responsive styles
+ * stay correct across device rotation / window resize without a manual
+ * re-render — matching how the browser re-evaluates `@media` on the web.
+ */
+const lazyBreakpoint = (inner: CSSResult, minWidth: number): CSSResult => ({
+  __brand: 'vl.native.css',
+  statics: {},
+  dynamics: [],
+  resolve: (props: any) =>
+    Dimensions.get('window').width >= minWidth
+      ? inner.resolve(props)
+      : EMPTY_STYLE,
+})
+
 /**
  * React Native version of createMediaQueries.
  * Instead of wrapping styles in @media queries (web),
  * evaluates the current screen width against breakpoints
- * and conditionally applies styles (mobile-first).
+ * and conditionally applies styles (mobile-first), lazily at resolve time.
  */
 const createMediaQueries: CreateMediaQueries = ({ breakpoints, css }) => {
   // Direct for-in + mutation. The prior `Object.keys.reduce` allocated the
@@ -27,12 +49,11 @@ const createMediaQueries: CreateMediaQueries = ({ breakpoints, css }) => {
       acc[key] = (strings: TemplateStringsArray, ...values: any[]) =>
         css(strings, ...values)
     } else if (breakpointValue != null) {
-      // Conditional — only apply when screen width >= breakpoint px value
-      acc[key] = (strings: TemplateStringsArray, ...values: any[]) => {
-        const { width } = Dimensions.get('window')
-        if (width >= breakpointValue) return css(strings, ...values)
-        return ''
-      }
+      // Conditional — apply when screen width >= breakpoint, checked lazily
+      // at resolve time so rotation/resize is reflected without baking the
+      // width into upstream caches.
+      acc[key] = (strings: TemplateStringsArray, ...values: any[]) =>
+        lazyBreakpoint(css(strings, ...values), breakpointValue)
     }
   }
   return acc as any

--- a/packages/connector-native/src/parse.ts
+++ b/packages/connector-native/src/parse.ts
@@ -28,6 +28,131 @@ const parseValue = (_prop: string, raw: string): string | number => {
   return trimmed
 }
 
+// ── Multi-value box shorthands ──────────────────────────────────────────
+// React Native has no `padding: 8px 16px` shorthand — each side is its own
+// property. CSS authors expect the shorthand to work, so we expand it into
+// RN longhands per the CSS box-model value rules. Without this, multi-value
+// shorthands silently parsed to their first token (`padding: 8px 16px` → 8).
+
+// Edge shorthands expand to [top, right, bottom, left] longhands.
+const EDGE_SHORTHANDS: Record<
+  string,
+  readonly [string, string, string, string]
+> = {
+  margin: ['marginTop', 'marginRight', 'marginBottom', 'marginLeft'],
+  padding: ['paddingTop', 'paddingRight', 'paddingBottom', 'paddingLeft'],
+  inset: ['top', 'right', 'bottom', 'left'],
+  borderWidth: [
+    'borderTopWidth',
+    'borderRightWidth',
+    'borderBottomWidth',
+    'borderLeftWidth',
+  ],
+}
+
+// border-radius shorthand is corner-based: [TL, TR, BR, BL].
+const RADIUS_LONGHANDS = [
+  'borderTopLeftRadius',
+  'borderTopRightRadius',
+  'borderBottomRightRadius',
+  'borderBottomLeftRadius',
+] as const
+
+/**
+ * Expand 1–4 CSS edge values into the four [top, right, bottom, left] slots,
+ * following CSS shorthand rules:
+ *   1 → all sides · 2 → [V, H] · 3 → [top, H, bottom] · 4 → as-is
+ */
+const expandEdge = <T>(v: T[]): [T, T, T, T] => {
+  // biome-ignore lint/style/noNonNullAssertion: callers only pass 1–4 element arrays; index access guarded by length switch
+  const a = v[0]!
+  switch (v.length) {
+    case 1:
+      return [a, a, a, a]
+    case 2:
+      // biome-ignore lint/style/noNonNullAssertion: length === 2 guarantees v[1]
+      return [a, v[1]!, a, v[1]!]
+    case 3:
+      // biome-ignore lint/style/noNonNullAssertion: length === 3 guarantees v[1],v[2]
+      return [a, v[1]!, v[2]!, v[1]!]
+    default:
+      // biome-ignore lint/style/noNonNullAssertion: length >= 4
+      return [a, v[1]!, v[2]!, v[3]!]
+  }
+}
+
+/**
+ * Expand 1–4 CSS corner values into [TL, TR, BR, BL] for border-radius:
+ *   1 → all corners · 2 → [TL&BR, TR&BL] · 3 → [TL, TR&BL, BR] · 4 → as-is
+ */
+const expandCorners = <T>(v: T[]): [T, T, T, T] => {
+  // biome-ignore lint/style/noNonNullAssertion: callers only pass 1–4 element arrays
+  const a = v[0]!
+  switch (v.length) {
+    case 1:
+      return [a, a, a, a]
+    case 2:
+      // biome-ignore lint/style/noNonNullAssertion: length === 2 guarantees v[1]
+      return [a, v[1]!, a, v[1]!]
+    case 3:
+      // biome-ignore lint/style/noNonNullAssertion: length === 3 guarantees v[1],v[2]
+      return [a, v[1]!, v[2]!, v[1]!]
+    default:
+      // biome-ignore lint/style/noNonNullAssertion: length >= 4
+      return [a, v[1]!, v[2]!, v[3]!]
+  }
+}
+
+/**
+ * Splits a CSS value into space-separated tokens, but bails (returns null)
+ * for values containing `(` (functions like calc()) or `/` (elliptical
+ * radii) where naive whitespace splitting would corrupt the value.
+ */
+const splitTokens = (value: string): string[] | null => {
+  if (value.includes('(') || value.includes('/')) return null
+  const tokens = value.trim().split(/\s+/)
+  return tokens.length > 1 ? tokens : null
+}
+
+/**
+ * If `prop` is a known multi-value box shorthand and `rawValue` has multiple
+ * tokens, expand into RN longhand entries on `style`. Returns true when it
+ * handled the declaration, false to fall through to single-value parsing.
+ */
+const expandShorthand = (
+  style: StyleObject,
+  prop: string,
+  rawValue: string,
+): boolean => {
+  const isEdge = prop in EDGE_SHORTHANDS
+  const isRadius = prop === 'borderRadius'
+  const isGap = prop === 'gap'
+  if (!isEdge && !isRadius && !isGap) return false
+
+  const tokens = splitTokens(rawValue)
+  if (!tokens) return false // single value or unsplittable → caller handles
+
+  const values = tokens.map((t) => parseValue(prop, t))
+
+  if (isGap) {
+    // CSS `gap: row column` (1 value → both axes)
+    // biome-ignore lint/style/noNonNullAssertion: tokens.length > 1 here
+    style.rowGap = values[0]!
+    // biome-ignore lint/style/noNonNullAssertion: tokens.length > 1 here
+    style.columnGap = values[1]!
+    return true
+  }
+
+  // biome-ignore lint/style/noNonNullAssertion: isEdge (prop in EDGE_SHORTHANDS) guaranteed here when not radius/gap
+  const slots = isRadius ? RADIUS_LONGHANDS : EDGE_SHORTHANDS[prop]!
+  const expanded = isRadius ? expandCorners(values) : expandEdge(values)
+  for (let i = 0; i < 4; i++) {
+    // biome-ignore lint/style/noNonNullAssertion: slots and expanded are fixed length 4
+    style[slots[i]!] = expanded[i]!
+  }
+  return true
+}
+
 /**
  * Parses a CSS declaration string into a React Native style object.
  * Converts kebab-case properties to camelCase and numeric/px values to numbers.
@@ -53,7 +178,11 @@ export const parseCSS = (cssText: string): StyleObject => {
     if (!rawProp.trim() || !rawValue.trim()) continue
 
     const prop = toCamelCase(rawProp)
-    style[prop] = parseValue(prop, rawValue)
+    // Multi-value box shorthands (`padding: 8px 16px`) expand into RN
+    // longhands; everything else is a single value.
+    if (!expandShorthand(style, prop, rawValue)) {
+      style[prop] = parseValue(prop, rawValue)
+    }
   }
 
   return style

--- a/packages/connector-native/src/parse.ts
+++ b/packages/connector-native/src/parse.ts
@@ -59,47 +59,27 @@ const RADIUS_LONGHANDS = [
 ] as const
 
 /**
- * Expand 1–4 CSS edge values into the four [top, right, bottom, left] slots,
- * following CSS shorthand rules:
- *   1 → all sides · 2 → [V, H] · 3 → [top, H, bottom] · 4 → as-is
+ * Expand 1–4 CSS shorthand values into four slots. The slot-fill pattern is
+ * identical for edges ([top, right, bottom, left]) and border-radius corners
+ * ([TL, TR, BR, BL]):
+ *   1 → all · 2 → [a, b, a, b] · 3 → [a, b, c, b] · 4 → [a, b, c, d]
  */
-const expandEdge = <T>(v: T[]): [T, T, T, T] => {
-  // biome-ignore lint/style/noNonNullAssertion: callers only pass 1–4 element arrays; index access guarded by length switch
+const expand4 = <T>(v: T[]): [T, T, T, T] => {
+  // biome-ignore lint/style/noNonNullAssertion: callers only pass 1–4 element arrays; index access guarded by the length switch
   const a = v[0]!
+  // biome-ignore lint/style/noNonNullAssertion: lengths ≥ 2 guarantee v[1]; b unused for length 1
+  const b = v[1]!
   switch (v.length) {
     case 1:
       return [a, a, a, a]
     case 2:
-      // biome-ignore lint/style/noNonNullAssertion: length === 2 guarantees v[1]
-      return [a, v[1]!, a, v[1]!]
+      return [a, b, a, b]
     case 3:
-      // biome-ignore lint/style/noNonNullAssertion: length === 3 guarantees v[1],v[2]
-      return [a, v[1]!, v[2]!, v[1]!]
+      // biome-ignore lint/style/noNonNullAssertion: length === 3 guarantees v[2]
+      return [a, b, v[2]!, b]
     default:
-      // biome-ignore lint/style/noNonNullAssertion: length >= 4
-      return [a, v[1]!, v[2]!, v[3]!]
-  }
-}
-
-/**
- * Expand 1–4 CSS corner values into [TL, TR, BR, BL] for border-radius:
- *   1 → all corners · 2 → [TL&BR, TR&BL] · 3 → [TL, TR&BL, BR] · 4 → as-is
- */
-const expandCorners = <T>(v: T[]): [T, T, T, T] => {
-  // biome-ignore lint/style/noNonNullAssertion: callers only pass 1–4 element arrays
-  const a = v[0]!
-  switch (v.length) {
-    case 1:
-      return [a, a, a, a]
-    case 2:
-      // biome-ignore lint/style/noNonNullAssertion: length === 2 guarantees v[1]
-      return [a, v[1]!, a, v[1]!]
-    case 3:
-      // biome-ignore lint/style/noNonNullAssertion: length === 3 guarantees v[1],v[2]
-      return [a, v[1]!, v[2]!, v[1]!]
-    default:
-      // biome-ignore lint/style/noNonNullAssertion: length >= 4
-      return [a, v[1]!, v[2]!, v[3]!]
+      // biome-ignore lint/style/noNonNullAssertion: length ≥ 4 guarantees v[2],v[3]
+      return [a, b, v[2]!, v[3]!]
   }
 }
 
@@ -145,7 +125,7 @@ const expandShorthand = (
 
   // biome-ignore lint/style/noNonNullAssertion: isEdge (prop in EDGE_SHORTHANDS) guaranteed here when not radius/gap
   const slots = isRadius ? RADIUS_LONGHANDS : EDGE_SHORTHANDS[prop]!
-  const expanded = isRadius ? expandCorners(values) : expandEdge(values)
+  const expanded = expand4(values)
   for (let i = 0; i < 4; i++) {
     // biome-ignore lint/style/noNonNullAssertion: slots and expanded are fixed length 4
     style[slots[i]!] = expanded[i]!

--- a/packages/connector-native/src/styled.ts
+++ b/packages/connector-native/src/styled.ts
@@ -1,4 +1,5 @@
 import { type ComponentType, createElement } from 'react'
+import { useWindowDimensions } from 'react-native'
 
 import { type CSSResult, css as cssFactory } from '~/css'
 import { mergeStyles } from '~/parse'
@@ -31,6 +32,12 @@ const createStyledComponent = (
   const template = cssFactory(strings, ...values)
 
   const Styled = ({ ref, ...props }: Record<string, any>) => {
+    // Subscribe to window dimensions so the component re-renders on
+    // rotation / resize. The width itself is read lazily inside
+    // createMediaQueries at resolve time — this call only provides the
+    // re-render trigger, mirroring how the browser re-evaluates `@media`.
+    useWindowDimensions()
+
     // Inject the context theme so dynamic interpolations (`p.theme.*`) and
     // unistyle's makeItResponsive (which reads `props.theme`) resolve on
     // native, mirroring the web styler. Only injected into the resolve props


### PR DESCRIPTION
## Summary

The previous native-connector PR (#271) noted two remaining gaps as "fundamental limitations." They aren't — both are now fixed properly.

### 1. Multi-value box shorthands now expand
RN has no `padding: 8px 16px` shorthand, so multi-value declarations silently parsed to their **first token** (`padding: 8`). They now expand into RN longhands per the CSS box-model value rules:

| Input | Output |
|---|---|
| `padding: 8px 16px` | `paddingTop/Bottom: 8`, `paddingLeft/Right: 16` |
| `margin: 4px 8px 12px` | top 4 · L/R 8 · bottom 12 |
| `margin: 0 auto` | `marginTop/Bottom: 0`, `marginLeft/Right: 'auto'` |
| `border-radius: 4 8 12 16` | per-corner TL/TR/BR/BL |
| `border-width: 1px 2px` | per-side widths |
| `gap: 8px 16px` | `rowGap: 8`, `columnGap: 16` |

Single values are unchanged (RN supports them). `calc()` and elliptical (`/`) radii are left untouched (degrade to the single-value path).

### 2. Responsive breakpoints react to rotation / resize
`createMediaQueries` now defers the `Dimensions.get('window').width` check from **breakpoint-call time** to **`resolve()` time** (lazy). This keeps the width out of upstream caches (e.g. `makeItResponsive`'s per-theme cache), so the current width is re-read on every resolve. The native `styled` component subscribes to `useWindowDimensions()`, so a rotation/resize triggers a re-render → re-resolve — mirroring how the browser re-evaluates `@media`. Previously a responsive component froze at its first-render breakpoint.

## Test plan
- [x] +14 tests: 12 shorthand-expansion cases (1–4 values, `0 auto`, gap, border-radius corners, calc/elliptical guards, non-box props), lazy-resolve reactivity (same result object reflects width change), styled-level rotation e2e (`red`→`blue` on resize + re-render)
- [x] `bun run test` — 2728 pass
- [x] `bun run typecheck` / `lint` / `pkgs:build` — clean
- [x] Changeset (patch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)