### PR TITLE
refactor: audit pass-1 — package-independence cleanups (after #274)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -323,11 +323,9 @@
         "@vitus-labs/unistyle": "workspace:^",
         "react": ">= 19",
         "react-dom": ">= 19",
-        "react-native": ">= 0.76",
       },
       "optionalPeers": [
         "react-dom",
-        "react-native",
       ],
     },
     "packages/hooks": {
@@ -398,11 +396,9 @@
     "packages/rocketstories": {
       "name": "@vitus-labs/rocketstories",
       "version": "2.6.2",
-      "dependencies": {
-        "@vitus-labs/elements": "workspace:*",
-      },
       "devDependencies": {
         "@vitus-labs/core": "workspace:*",
+        "@vitus-labs/elements": "workspace:*",
         "@vitus-labs/rocketstyle": "workspace:*",
         "@vitus-labs/tools-rolldown": "2.5.0",
         "@vitus-labs/tools-storybook": "2.5.0",
@@ -410,8 +406,8 @@
         "@vitus-labs/unistyle": "workspace:*",
       },
       "peerDependencies": {
-        "@storybook/react": "^10.3.6",
         "@vitus-labs/core": "workspace:^",
+        "@vitus-labs/elements": "workspace:^",
         "@vitus-labs/rocketstyle": "workspace:^",
         "@vitus-labs/unistyle": "workspace:^",
         "react": ">= 19",
@@ -430,8 +426,12 @@
       },
       "peerDependencies": {
         "@vitus-labs/core": "workspace:^",
+        "@vitus-labs/unistyle": "workspace:^",
         "react": ">= 19",
       },
+      "optionalPeers": [
+        "@vitus-labs/unistyle",
+      ],
     },
     "packages/styler": {
       "name": "@vitus-labs/styler",
@@ -463,11 +463,7 @@
       "peerDependencies": {
         "@vitus-labs/core": "workspace:^",
         "react": ">= 19",
-        "react-native": ">= 0.76",
       },
-      "optionalPeers": [
-        "react-native",
-      ],
     },
   },
   "overrides": {

--- a/packages/coolgrid/src/useContext.tsx
+++ b/packages/coolgrid/src/useContext.tsx
@@ -1,5 +1,4 @@
-import { get, pick, useStableValue } from '@vitus-labs/core'
-import { context } from '@vitus-labs/unistyle'
+import { context, get, pick, useStableValue } from '@vitus-labs/core'
 import { useContext, useMemo } from 'react'
 import { CONTEXT_KEYS } from '~/constants'
 import type { Context, Obj, ValueType } from '~/types'

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -60,14 +60,10 @@
     "@vitus-labs/core": "workspace:^",
     "@vitus-labs/unistyle": "workspace:^",
     "react": ">= 19",
-    "react-dom": ">= 19",
-    "react-native": ">= 0.76"
+    "react-dom": ">= 19"
   },
   "peerDependenciesMeta": {
     "react-dom": {
-      "optional": true
-    },
-    "react-native": {
       "optional": true
     }
   },

--- a/packages/elements/src/types.ts
+++ b/packages/elements/src/types.ts
@@ -5,10 +5,10 @@
  * and defining VL component signatures with static metadata.
  */
 import type { BreakpointKeys, config, render } from '@vitus-labs/core'
-import type { MakeItResponsive } from '@vitus-labs/unistyle'
+import type { MakeItResponsiveStyles } from '@vitus-labs/unistyle'
 import type { ComponentType, FC, ForwardedRef, ReactElement } from 'react'
 
-export type ResponsiveStylesCallback = Parameters<MakeItResponsive>[0]['styles']
+export type ResponsiveStylesCallback = MakeItResponsiveStyles
 
 type ExtractNullableKeys<T> = {
   [P in keyof T as T[P] extends null | undefined ? never : P]: T[P]

--- a/packages/rocketstories/package.json
+++ b/packages/rocketstories/package.json
@@ -64,17 +64,15 @@
     "typecheck": "tsc --noEmit"
   },
   "peerDependencies": {
-    "@storybook/react": "^10.3.6",
     "@vitus-labs/core": "workspace:^",
+    "@vitus-labs/elements": "workspace:^",
     "@vitus-labs/rocketstyle": "workspace:^",
     "@vitus-labs/unistyle": "workspace:^",
     "react": ">= 19"
   },
-  "dependencies": {
-    "@vitus-labs/elements": "workspace:*"
-  },
   "devDependencies": {
     "@vitus-labs/core": "workspace:*",
+    "@vitus-labs/elements": "workspace:*",
     "@vitus-labs/rocketstyle": "workspace:*",
     "@vitus-labs/tools-rolldown": "2.5.0",
     "@vitus-labs/tools-storybook": "2.5.0",

--- a/packages/rocketstories/src/index.ts
+++ b/packages/rocketstories/src/index.ts
@@ -7,8 +7,6 @@ import type {
   Controls,
   ControlTypes,
   ElementType,
-  ExtractDimensions,
-  ExtractProps,
   PartialControls,
   RocketStoryConfiguration,
   RocketType,
@@ -17,14 +15,19 @@ import type {
   StoryConfiguration,
 } from '~/types'
 
+// NOTE: `ExtractDimensions` and `ExtractProps` exist in `~/types` for
+// internal use, but are NOT re-exported here. Both names also exist in
+// `@vitus-labs/rocketstyle` with different shapes — re-exporting them
+// from rocketstories created a silent name collision in any module that
+// pulled both. Consumers needing those helpers should import them from
+// `@vitus-labs/rocketstyle` (the canonical source).
+
 export type {
   Configuration,
   Control,
   Controls,
   ControlTypes,
   ElementType,
-  ExtractDimensions,
-  ExtractProps,
   Init,
   IRocketStories,
   PartialControls,

--- a/packages/unistyle/package.json
+++ b/packages/unistyle/package.json
@@ -51,13 +51,7 @@
   },
   "peerDependencies": {
     "@vitus-labs/core": "workspace:^",
-    "react": ">= 19",
-    "react-native": ">= 0.76"
-  },
-  "peerDependenciesMeta": {
-    "react-native": {
-      "optional": true
-    }
+    "react": ">= 19"
   },
   "devDependencies": {
     "@vitus-labs/core": "workspace:*",


### PR DESCRIPTION
## Summary

Apply 8 architectural cleanups from a multi-agent independence audit. Targets PR #274 as base — merge after #274. Stacks cleanly on top.

| Pkg | Fix | Severity |
|---|---|---|
| rocketstories | Move `@vitus-labs/elements` from `dependencies` → `peerDependencies` (was the only sibling declaring an internal pkg as a runtime dep) | medium |
| rocketstories | Drop `ExtractDimensions` / `ExtractProps` from public exports — silent name collision with rocketstyle's same-named types | medium |
| rocketstories | Remove dead `@storybook/react` peer (never imported in src) | medium |
| unistyle | Remove dead `react-native` optional peer (delegates all native concerns to connector-native) | low |
| elements | Remove dead `react-native` optional peer (`__WEB__`/`__NATIVE__` flags + connector-native handle RN) | low |
| elements | `ResponsiveStylesCallback` now uses the directly-exported `MakeItResponsiveStyles` alias instead of `Parameters<MakeItResponsive>[0]['styles']` indexing | low |
| coolgrid | Import `context` from `@vitus-labs/core` directly instead of through unistyle's pass-through re-export | low |

The audit's original rank-1 (rocketstyle optional unistyle peer) is dropped here — superseded by PR #274's move of `recipe()` into its own `@vitus-labs/recipe` package, which removes any rocketstyle→unistyle coupling at all.

## Test plan
- [x] `bun run test` — 2796 tests pass
- [x] `bun run lint` — clean
- [x] `bun run typecheck` — clean
- [x] `bun run pkgs:build` — all packages build
- [x] `bun run size` — all within budget

🤖 Generated with [Claude Code](https://claude.com/claude-code)