### PR TITLE
perf(elements): memoize Element/Wrapper + drop hot-path allocations + fix ref churn

### DIFF
--- a/.changeset/elements-perf-audit.md
+++ b/.changeset/elements-perf-audit.md
@@ -1,0 +1,25 @@
+---
+'@vitus-labs/elements': patch
+---
+
+Performance and correctness pass on `@vitus-labs/elements`:
+
+- `Element` and `Wrapper` are now wrapped in `memo()` — parent re-renders no longer re-execute the full body when props are referentially stable. VL statics (`displayName`/`pkgName`/`VITUS_LABS__COMPONENT`) attach to the memoized wrapper so rocketstyle/attrs detection still works.
+- `Element` `WRAPPER_PROPS` literal removed — keys inlined into the JSX so the build-then-spread copy pass disappears. `Wrapper` `COMMON_PROPS` literal removed the same way.
+- `Wrapper`'s three separate `useMemo` calls (`normalElement`/`parentFixElement`/`childFixElement`) collapsed into one — each render previously paid the dep-array compare cost for all three even though only one shape is used.
+- `Element` `mergedRef` is now ref-stable. The previous `useCallback` listed `externalRef` in its deps, so an inline parent ref-callback caused React to detach/attach the DOM ref every render.
+- `useOverlay`: `onOpen`/`onClose` ref-captured. The previous dep array re-ran the lifecycle effect on every parent render and fired spurious `onClose`/`setUnblocked` cleanup callbacks while the overlay was still open.
+- `useOverlay`: `isNodeOrChild` curry replaced with two stable predicates allocated once. The old shape allocated two fresh closures per click event.
+- `useOverlay`: click listener uses `document` instead of `window` (one fewer propagation hop, matches `useFocusTrap`'s convention).
+- `useFocusTrap`: `for…of` over `NodeList` swapped for an index loop (no iterator-protocol allocation). MutationObserver refreshes coalesced via `requestAnimationFrame` so a burst of child mounts doesn't re-run `querySelectorAll` per mutation.
+- `Element/equalize`: skip the style write when both sides are already equal AND non-zero. Breaks a potential `ResizeObserver` loop in real browsers without affecting jsdom (where sizes always read 0).
+- `Overlay/component`: dropped two `useMemo` calls over primitive results (`passHandlers`, `ariaHasPopup`) where memo bookkeeping exceeded the recomputation cost. Replaced `...(cond ? { … } : {})` ternaries with conditional property assignment — no per-render `{}` allocation.
+- `Util/component`: dropped `useMemo` over a one-shot string `join(' ')`.
+- `positionMath`: hoisted `['dropdown', 'tooltip', 'popover'].includes(type)` into a module-level `Set` lookup. The array literal allocated per `computePosition` call (throttled scroll/resize hot path).
+- `Content/styled`: deduped identical `equalColsCSS` and `typeContentCSS` literals into one `FLEX_1` constant.
+
+Dead code removed:
+
+- `types.ts`: drop `SimpleHoc`, `CssCallback`, `isEmpty`, `Ref`, `ExtractProps`, `VLForwardedComponent` — zero monorepo consumers; `SimpleHoc`/`ExtractProps` were also drift hazards (different shapes in attrs/rocketstyle).
+- `Element/constants.ts`: drop `RESERVED_PROPS` (unused; `Iterator` has its own); drop `keygen` from `EMPTY_ELEMENTS` (removed from HTML5 spec in 2017).
+- `helpers/Wrapper/types.ts`: drop `Reference = unknown` (unused).

--- a/packages/elements/src/Element/component.tsx
+++ b/packages/elements/src/Element/component.tsx
@@ -7,7 +7,7 @@
  * skipping children or switching sub-tags accordingly.
  */
 import { render } from '@vitus-labs/core'
-import { useCallback, useLayoutEffect, useMemo, useRef } from 'react'
+import { memo, useCallback, useLayoutEffect, useMemo, useRef } from 'react'
 import { PKG_NAME } from '~/constants'
 import { Content, Wrapper } from '~/helpers'
 import type { VLElement } from './types'
@@ -16,25 +16,31 @@ import { getShouldBeEmpty, isInlineElement } from './utils'
 const equalize = (el: HTMLElement, direction: unknown) => {
   const beforeEl = el.firstElementChild as HTMLElement | null
   const afterEl = el.lastElementChild as HTMLElement | null
+  if (!beforeEl || !afterEl || beforeEl === afterEl) return
 
-  if (beforeEl && afterEl && beforeEl !== afterEl) {
-    const type: 'height' | 'width' = direction === 'rows' ? 'height' : 'width'
-    const prop = type === 'height' ? 'offsetHeight' : 'offsetWidth'
-    const beforeSize = beforeEl[prop]
-    const afterSize = afterEl[prop]
+  const type: 'height' | 'width' = direction === 'rows' ? 'height' : 'width'
+  const prop = type === 'height' ? 'offsetHeight' : 'offsetWidth'
+  const beforeSize = beforeEl[prop]
+  const afterSize = afterEl[prop]
+  if (!Number.isInteger(beforeSize) || !Number.isInteger(afterSize)) return
+  // Already balanced (and not the initial 0/0 case) — skip the write to
+  // break the ResizeObserver loop. The `> 0` guard lets jsdom (no layout
+  // engine, all sizes return 0) still exercise the write path.
+  if (beforeSize === afterSize && beforeSize > 0) return
 
-    if (Number.isInteger(beforeSize) && Number.isInteger(afterSize)) {
-      const maxSize = `${Math.max(beforeSize, afterSize)}px`
-      beforeEl.style[type] = maxSize
-      afterEl.style[type] = maxSize
-    }
-  }
+  const maxSize = `${Math.max(beforeSize, afterSize)}px`
+  beforeEl.style[type] = maxSize
+  afterEl.style[type] = maxSize
 }
 
 const defaultDirection = 'inline'
 const defaultContentDirection = 'rows'
 const defaultAlignX = 'left'
 const defaultAlignY = 'center'
+
+// Hoisted — passed via spread so TS doesn't reject `as` on Wrapper's Props
+// (Wrapper forwards it to Styled). Resets styled-components' `as` prop.
+const AS_RESET = { as: undefined } as const
 
 const Component: VLElement = ({
   innerRef,
@@ -125,16 +131,20 @@ const Component: VLElement = ({
   const equalizeRef = useRef<HTMLElement | null>(null)
   const externalRef = ref ?? innerRef
 
-  const mergedRef = useCallback(
-    (node: HTMLElement | null) => {
-      equalizeRef.current = node
-      if (typeof externalRef === 'function') externalRef(node)
-      else if (externalRef != null) {
-        ;(externalRef as { current: HTMLElement | null }).current = node
-      }
-    },
-    [externalRef],
-  )
+  // Ref-capture the external ref so `mergedRef` stays stable. Without
+  // this, inline ref-callbacks from parents would change identity every
+  // render, forcing React to detach/attach the DOM ref each cycle.
+  const latestExternalRef = useRef(externalRef)
+  latestExternalRef.current = externalRef
+
+  const mergedRef = useCallback((node: HTMLElement | null) => {
+    equalizeRef.current = node
+    const r = latestExternalRef.current
+    if (typeof r === 'function') r(node)
+    else if (r != null) {
+      ;(r as { current: HTMLElement | null }).current = node
+    }
+  }, [])
 
   useLayoutEffect(() => {
     if (!__WEB__) return
@@ -152,29 +162,36 @@ const Component: VLElement = ({
     return () => observer.disconnect()
   }, [equalBeforeAfter, beforeContent, afterContent, direction])
 
-  // --------------------------------------------------------
-  // common wrapper props
-  // --------------------------------------------------------
-  const WRAPPER_PROPS = {
-    ref: mergedRef,
-    extendCss: css,
-    tag,
-    block,
-    direction: wrapperDirection,
-    alignX: wrapperAlignX,
-    alignY: wrapperAlignY,
-    as: undefined, // reset styled-components `as` prop
-  }
-
-  // --------------------------------------------------------
-  // return simple/empty element like input or image etc.
-  // --------------------------------------------------------
+  // Empty self-closing elements (input, img, …) render Wrapper alone.
   if (shouldBeEmpty) {
-    return <Wrapper {...props} {...WRAPPER_PROPS} />
+    return (
+      <Wrapper
+        {...props}
+        ref={mergedRef}
+        extendCss={css}
+        tag={tag}
+        block={block}
+        direction={wrapperDirection}
+        alignX={wrapperAlignX}
+        alignY={wrapperAlignY}
+        {...AS_RESET}
+      />
+    )
   }
 
   return (
-    <Wrapper {...props} {...WRAPPER_PROPS} isInline={isInline}>
+    <Wrapper
+      {...props}
+      ref={mergedRef}
+      extendCss={css}
+      tag={tag}
+      block={block}
+      direction={wrapperDirection}
+      alignX={wrapperAlignX}
+      alignY={wrapperAlignY}
+      isInline={isInline}
+      {...AS_RESET}
+    >
       {beforeContent && (
         <Content
           tag={SUB_TAG}
@@ -229,8 +246,12 @@ const Component: VLElement = ({
 
 const name = `${PKG_NAME}/Element` as const
 
-Component.displayName = name
-Component.pkgName = PKG_NAME
-Component.VITUS_LABS__COMPONENT = name
+// Memoize so parent re-renders don't re-run the body when Element's props
+// are referentially stable. The VL statics are attached to the memoized
+// wrapper so rocketstyle/attrs detection still works.
+const MemoComponent = memo(Component) as unknown as VLElement
+MemoComponent.displayName = name
+MemoComponent.pkgName = PKG_NAME
+MemoComponent.VITUS_LABS__COMPONENT = name
 
-export default Component
+export default MemoComponent

--- a/packages/elements/src/Element/constants.ts
+++ b/packages/elements/src/Element/constants.ts
@@ -1,37 +1,3 @@
-/** Props consumed by Element that should not be forwarded to the underlying DOM node. */
-export const RESERVED_PROPS = [
-  'innerRef',
-  'tag',
-  'block',
-  'label',
-  'children',
-  'beforeContent',
-  'afterContent',
-
-  'equalCols',
-  'vertical',
-  'direction',
-  'alignX',
-  'alignY',
-
-  'css',
-  'contentCss',
-  'beforeContentCss',
-  'afterContentCss',
-
-  'contentDirection',
-  'contentAlignX',
-  'contentAlignY',
-
-  'beforeContentDirection',
-  'beforeContentAlignX',
-  'beforeContentAlignY',
-
-  'afterContentDirection',
-  'afterContentAlignX',
-  'afterContentAlignY',
-] as const
-
 /**
  * HTML tags that are inline-level by default. When Element renders one of
  * these tags, child Content wrappers use `span` instead of `div` to
@@ -85,7 +51,6 @@ export const EMPTY_ELEMENTS = {
   hr: true,
   img: true,
   input: true,
-  keygen: true,
   link: true,
   textarea: true,
   // 'meta': true,

--- a/packages/elements/src/Overlay/component.tsx
+++ b/packages/elements/src/Overlay/component.tsx
@@ -6,7 +6,7 @@
  * a dropdown inside another dropdown) via blocked-state propagation.
  */
 import { render } from '@vitus-labs/core'
-import { type ReactNode, useId, useMemo } from 'react'
+import { type ReactNode, useId } from 'react'
 import { PKG_NAME } from '~/constants'
 import Portal from '~/Portal'
 import type { Content, VLComponent } from '~/types'
@@ -92,53 +92,58 @@ const Component: VLComponent<Props> = ({
   const { openOn, closeOn, type } = props
   const contentId = useId()
 
-  const passHandlers = useMemo(
-    () =>
-      openOn === 'manual' ||
-      closeOn === 'manual' ||
-      closeOn === 'clickOutsideContent',
-    [openOn, closeOn],
-  )
+  // Primitives — useMemo overhead exceeds recomputation cost.
+  const passHandlers =
+    openOn === 'manual' ||
+    closeOn === 'manual' ||
+    closeOn === 'clickOutsideContent'
 
-  const ariaHasPopup = useMemo(() => {
-    switch (type) {
-      case 'modal':
-        return 'dialog' as const
-      case 'tooltip':
-        return 'true' as const
-      default:
-        return 'menu' as const
-    }
-  }, [type])
+  const ariaHasPopup =
+    type === 'modal'
+      ? ('dialog' as const)
+      : type === 'tooltip'
+        ? ('true' as const)
+        : ('menu' as const)
+
+  const triggerProps: Record<string, unknown> = {
+    [triggerRefName]: triggerRef,
+    active,
+    'aria-expanded': active,
+    'aria-haspopup': ariaHasPopup,
+    'aria-controls': active ? contentId : undefined,
+  }
+  if (passHandlers) {
+    triggerProps.showContent = showContent
+    triggerProps.hideContent = hideContent
+  }
 
   return (
     <>
-      {render(trigger, {
-        [triggerRefName]: triggerRef,
-        active,
-        'aria-expanded': active,
-        'aria-haspopup': ariaHasPopup,
-        'aria-controls': active ? contentId : undefined,
-        ...(passHandlers ? { showContent, hideContent } : {}),
-      })}
+      {render(trigger, triggerProps)}
 
-      {IS_BROWSER && active && (
-        <Portal DOMLocation={DOMLocation}>
-          <Provider {...ctx}>
-            {render(children, {
-              [contentRefName]: contentRef,
-              id: contentId,
-              role: type === 'modal' ? 'dialog' : undefined,
-              'aria-modal': type === 'modal' ? true : undefined,
-              active,
-              align,
-              alignX,
-              alignY,
-              ...(passHandlers ? { showContent, hideContent } : {}),
-            })}
-          </Provider>
-        </Portal>
-      )}
+      {IS_BROWSER &&
+        active &&
+        (() => {
+          const contentProps: Record<string, unknown> = {
+            [contentRefName]: contentRef,
+            id: contentId,
+            role: type === 'modal' ? 'dialog' : undefined,
+            'aria-modal': type === 'modal' ? true : undefined,
+            active,
+            align,
+            alignX,
+            alignY,
+          }
+          if (passHandlers) {
+            contentProps.showContent = showContent
+            contentProps.hideContent = hideContent
+          }
+          return (
+            <Portal DOMLocation={DOMLocation}>
+              <Provider {...ctx}>{render(children, contentProps)}</Provider>
+            </Portal>
+          )
+        })()}
     </>
   )
 }

--- a/packages/elements/src/Overlay/positionMath.ts
+++ b/packages/elements/src/Overlay/positionMath.ts
@@ -24,6 +24,12 @@ export type OverlayType =
   | 'modal'
   | 'custom'
 
+const DROPDOWN_TYPES: ReadonlySet<OverlayType> = new Set([
+  'dropdown',
+  'tooltip',
+  'popover',
+])
+
 export type PositionResult = {
   pos: OverlayPosition
   resolvedAlignX: AlignX
@@ -212,7 +218,7 @@ export const computePosition = (
   contentEl: HTMLElement | null,
   ancestorOffset: { top: number; left: number },
 ): ComputeResult => {
-  const isDropdown = ['dropdown', 'tooltip', 'popover'].includes(type)
+  const isDropdown = DROPDOWN_TYPES.has(type)
 
   if (isDropdown && (!triggerEl || !contentEl)) {
     devWarn(

--- a/packages/elements/src/Overlay/useFocusTrap.ts
+++ b/packages/elements/src/Overlay/useFocusTrap.ts
@@ -47,18 +47,7 @@ const useFocusTrap: UseFocusTrap = (ref, enabled = true, options) => {
     }
     refresh()
 
-    // Debounce mutation refreshes — children mount in bursts inside modals
-    // (forms, lists). Coalescing into rAF avoids re-running `querySelectorAll`
-    // dozens of times in a single tick.
-    let refreshRafId: number | null = null
-    const scheduleRefresh = () => {
-      if (refreshRafId != null) return
-      refreshRafId = requestAnimationFrame(() => {
-        refreshRafId = null
-        refresh()
-      })
-    }
-    const observer = new MutationObserver(scheduleRefresh)
+    const observer = new MutationObserver(refresh)
     observer.observe(container, { childList: true, subtree: true })
 
     const prevFocus = document.activeElement as HTMLElement | null
@@ -98,7 +87,6 @@ const useFocusTrap: UseFocusTrap = (ref, enabled = true, options) => {
 
     document.addEventListener('keydown', handler)
     return () => {
-      if (refreshRafId != null) cancelAnimationFrame(refreshRafId)
       observer.disconnect()
       document.removeEventListener('keydown', handler)
       if (autoFocus && prevFocus && typeof prevFocus.focus === 'function') {

--- a/packages/elements/src/Overlay/useFocusTrap.ts
+++ b/packages/elements/src/Overlay/useFocusTrap.ts
@@ -38,12 +38,27 @@ const useFocusTrap: UseFocusTrap = (ref, enabled = true, options) => {
     const refresh = () => {
       const all = container.querySelectorAll<HTMLElement>(FOCUSABLE)
       const result: HTMLElement[] = []
-      for (const el of all) if (isTabbable(el)) result.push(el)
+      // Index loop — `NodeList` iterator allocates; index access doesn't.
+      for (let i = 0; i < all.length; i++) {
+        const el = all[i]
+        if (el && isTabbable(el)) result.push(el)
+      }
       focusable = result
     }
     refresh()
 
-    const observer = new MutationObserver(refresh)
+    // Debounce mutation refreshes — children mount in bursts inside modals
+    // (forms, lists). Coalescing into rAF avoids re-running `querySelectorAll`
+    // dozens of times in a single tick.
+    let refreshRafId: number | null = null
+    const scheduleRefresh = () => {
+      if (refreshRafId != null) return
+      refreshRafId = requestAnimationFrame(() => {
+        refreshRafId = null
+        refresh()
+      })
+    }
+    const observer = new MutationObserver(scheduleRefresh)
     observer.observe(container, { childList: true, subtree: true })
 
     const prevFocus = document.activeElement as HTMLElement | null
@@ -83,6 +98,7 @@ const useFocusTrap: UseFocusTrap = (ref, enabled = true, options) => {
 
     document.addEventListener('keydown', handler)
     return () => {
+      if (refreshRafId != null) cancelAnimationFrame(refreshRafId)
       observer.disconnect()
       document.removeEventListener('keydown', handler)
       if (autoFocus && prevFocus && typeof prevFocus.focus === 'function') {

--- a/packages/elements/src/Overlay/useOverlay.tsx
+++ b/packages/elements/src/Overlay/useOverlay.tsx
@@ -43,6 +43,11 @@ const CLICK_CLOSE_KINDS: ReadonlySet<string> = new Set([
   'clickOutsideContent',
 ])
 
+const isNodeOrChildOf = (
+  node: HTMLElement | null,
+  target: Element | null,
+): boolean => !!(node && target && (node.contains(target) || target === node))
+
 export type UseOverlayProps = Partial<{
   /**
    * Defines default state whether **Overlay** component should be active.
@@ -259,15 +264,15 @@ const useOverlay = ({
     assignContentPosition(calculateContentPosition())
   }, [assignContentPosition, calculateContentPosition])
 
-  const isNodeOrChild = useCallback(
-    (ref: { current: HTMLElement | null }) => (e: Event) => {
-      if (e?.target && ref.current) {
-        return (
-          ref.current.contains(e.target as Element) || e.target === ref.current
-        )
-      }
-      return false
-    },
+  // Stable per-ref predicates — created once, reused across every event.
+  const isTriggerOrChild = useCallback(
+    (e: Event) =>
+      isNodeOrChildOf(triggerRef.current, e?.target as Element | null),
+    [],
+  )
+  const isContentOrChild = useCallback(
+    (e: Event) =>
+      isNodeOrChildOf(contentRef.current, e?.target as Element | null),
     [],
   )
 
@@ -279,8 +284,8 @@ const useOverlay = ({
         active,
         openOn,
         closeOn,
-        isNodeOrChild(triggerRef),
-        isNodeOrChild(contentRef),
+        isTriggerOrChild,
+        isContentOrChild,
         showContent,
         hideContent,
       )
@@ -293,7 +298,8 @@ const useOverlay = ({
       closeOn,
       hideContent,
       showContent,
-      isNodeOrChild,
+      isTriggerOrChild,
+      isContentOrChild,
     ],
   )
 
@@ -344,19 +350,27 @@ const useOverlay = ({
     return () => cancelAnimationFrame(rafId)
   }, [active, isContentLoaded, setContentPosition])
 
-  // Track previous active state so callbacks only fire on actual transitions,
-  // not on every dependency change or unmount-while-closed.
+  // Ref-capture lifecycle callbacks — consumers typically pass inline arrows,
+  // so including them in the dep array re-runs the effect every parent render
+  // and fires spurious `onClose`/`setUnblocked` cleanup while the overlay
+  // is still open.
+  const latestOnOpen = useRef(onOpen)
+  latestOnOpen.current = onOpen
+  const latestOnClose = useRef(onClose)
+  latestOnClose.current = onClose
+
+  // Track previous active state so callbacks only fire on actual transitions.
   const prevActiveRef = useRef(false)
   useEffect(() => {
     const wasActive = prevActiveRef.current
     prevActiveRef.current = active
 
     if (active && !wasActive) {
-      onOpen?.()
+      latestOnOpen.current?.()
       ctx.setBlocked?.()
     } else if (!active && wasActive) {
       setContentLoaded(false)
-      onClose?.()
+      latestOnClose.current?.()
       ctx.setUnblocked?.()
     } else if (!active) {
       setContentLoaded(false)
@@ -365,11 +379,11 @@ const useOverlay = ({
     return () => {
       // On unmount, only clean up if currently active
       if (active) {
-        onClose?.()
+        latestOnClose.current?.()
         ctx.setUnblocked?.()
       }
     }
-  }, [active, ctx, onClose, onOpen])
+  }, [active, ctx])
 
   // Modal a11y — trap Tab + lock page scroll while open. Both hooks
   // no-op when `enabled` is false, so non-modal overlays pay nothing.
@@ -387,15 +401,16 @@ const useOverlay = ({
     handleVisibility,
   })
 
-  // Click-based open/close: attach to window
+  // Click-based open/close — listen on `document` (matches useEscapeKey +
+  // useFocusTrap; one fewer propagation hop than `window`).
   useEffect(() => {
     if (blocked || disabled) return undefined
 
     const enabledClick = openOn === 'click' || CLICK_CLOSE_KINDS.has(closeOn)
 
-    if (enabledClick) window.addEventListener('click', handleClick)
+    if (enabledClick) document.addEventListener('click', handleClick)
 
-    return () => window.removeEventListener('click', handleClick)
+    return () => document.removeEventListener('click', handleClick)
   }, [openOn, closeOn, blocked, disabled, handleClick])
 
   useHoverListeners({

--- a/packages/elements/src/Util/component.tsx
+++ b/packages/elements/src/Util/component.tsx
@@ -4,7 +4,7 @@
  * helper to clone children with the merged props.
  */
 import { render } from '@vitus-labs/core'
-import { type ReactNode, useMemo } from 'react'
+import type { ReactNode } from 'react'
 import { PKG_NAME } from '~/constants'
 import type { VLComponent } from '~/types'
 
@@ -24,10 +24,9 @@ export interface Props {
 }
 
 const Component: VLComponent<Props> = ({ children, className, style }) => {
-  const mergedClasses = useMemo(
-    () => (Array.isArray(className) ? className.join(' ') : className),
-    [className],
-  )
+  const mergedClasses = Array.isArray(className)
+    ? className.join(' ')
+    : className
 
   const finalProps: Record<string, any> = {}
   if (style) finalProps.style = style

--- a/packages/elements/src/helpers/Content/styled.ts
+++ b/packages/elements/src/helpers/Content/styled.ts
@@ -17,11 +17,7 @@ import type { StyledProps, ThemeProps } from './types'
 
 const { styled, css, component } = config
 
-const equalColsCSS = `
-  flex: 1;
-`
-
-const typeContentCSS = `
+const FLEX_1 = `
   flex: 1;
 `
 
@@ -73,7 +69,7 @@ const styles: ResponsiveStylesCallback = ({ css, theme: t, rootSize }) => css`
     alignY: t.alignY,
   })};
 
-  ${t.equalCols && equalColsCSS};
+  ${t.equalCols && FLEX_1};
 
   ${
     t.gap &&
@@ -97,8 +93,7 @@ const StyledComponent = styled(component)`
   align-self: stretch;
   flex-wrap: wrap;
 
-  ${({ $contentType }: StyledProps) =>
-    $contentType === 'content' && typeContentCSS};
+  ${({ $contentType }: StyledProps) => $contentType === 'content' && FLEX_1};
 
   ${makeItResponsive({
     key: '$element',

--- a/packages/elements/src/helpers/Wrapper/component.tsx
+++ b/packages/elements/src/helpers/Wrapper/component.tsx
@@ -4,15 +4,15 @@
  * (parent + child Styled) because these HTML elements do not natively
  * support `display: flex` consistently across browsers.
  */
-import { useMemo } from 'react'
+import { memo, useMemo } from 'react'
 import { IS_DEVELOPMENT } from '~/utils'
 import Styled from './styled'
 import type { Props } from './types'
 import { isWebFixNeeded } from './utils'
 
-const DEV_PROPS: Record<string, string> = IS_DEVELOPMENT
+const DEV_PROPS: Record<string, string> | null = IS_DEVELOPMENT
   ? { 'data-vl-element': 'Element' }
-  : {}
+  : null
 
 const Component = ({
   children,
@@ -27,56 +27,57 @@ const Component = ({
   isInline,
   ...props
 }: Partial<Props> & { ref?: any }) => {
-  const COMMON_PROPS = {
-    ...props,
-    ...DEV_PROPS,
-    ref,
-    as: tag,
-  }
-
   const needsFix = __WEB__
     ? !props.dangerouslySetInnerHTML && isWebFixNeeded(tag)
     : false
 
-  const normalElement = useMemo(
-    () => ({
-      block,
-      direction,
-      alignX,
-      alignY,
-      equalCols,
-      extraStyles: extendCss,
-    }),
-    [block, direction, alignX, alignY, equalCols, extendCss],
-  )
-
-  const parentFixElement = useMemo(
-    () => ({ parentFix: true as const, block, extraStyles: extendCss }),
-    [block, extendCss],
-  )
-
-  const childFixElement = useMemo(
-    () => ({ childFix: true as const, direction, alignX, alignY, equalCols }),
-    [direction, alignX, alignY, equalCols],
-  )
+  // Collapsed from three separate `useMemo` calls into one — the previous
+  // version paid the dep-array compare cost for all three on every render
+  // even though only one shape is used. One memo, one dep set, one allocation.
+  const $element = useMemo(() => {
+    if (!__WEB__ || !needsFix) {
+      return {
+        block,
+        direction,
+        alignX,
+        alignY,
+        equalCols,
+        extraStyles: extendCss,
+      }
+    }
+    return {
+      parent: { parentFix: true as const, block, extraStyles: extendCss },
+      child: { childFix: true as const, direction, alignX, alignY, equalCols },
+    }
+  }, [needsFix, block, direction, alignX, alignY, equalCols, extendCss])
 
   if (!needsFix || __NATIVE__) {
     return (
-      <Styled {...COMMON_PROPS} $element={normalElement}>
+      <Styled
+        {...props}
+        {...DEV_PROPS}
+        ref={ref}
+        as={tag}
+        $element={$element as Record<string, unknown>}
+      >
         {children}
       </Styled>
     )
   }
 
   const asTag = __WEB__ ? (isInline ? 'span' : 'div') : undefined
+  const fix = $element as {
+    parent: Record<string, unknown>
+    child: Record<string, unknown>
+  }
 
   return (
-    <Styled {...COMMON_PROPS} $element={parentFixElement}>
-      <Styled as={asTag} $childFix $element={childFixElement}>
+    <Styled {...props} {...DEV_PROPS} ref={ref} as={tag} $element={fix.parent}>
+      <Styled as={asTag} $childFix $element={fix.child}>
         {children}
       </Styled>
     </Styled>
   )
 }
 
-export default Component
+export default memo(Component)

--- a/packages/elements/src/helpers/Wrapper/types.ts
+++ b/packages/elements/src/helpers/Wrapper/types.ts
@@ -13,8 +13,6 @@ import type {
   ResponsiveBoolType,
 } from '~/types'
 
-export type Reference = unknown
-
 export interface Props {
   children: ReactNode
   tag: HTMLTags

--- a/packages/elements/src/types.ts
+++ b/packages/elements/src/types.ts
@@ -6,7 +6,7 @@
  */
 import type { BreakpointKeys, config, render } from '@vitus-labs/core'
 import type { MakeItResponsiveStyles } from '@vitus-labs/unistyle'
-import type { ComponentType, FC, ForwardedRef, ReactElement } from 'react'
+import type { ForwardedRef, ReactElement } from 'react'
 
 export type ResponsiveStylesCallback = MakeItResponsiveStyles
 
@@ -27,17 +27,12 @@ export type MergeTypes<A extends readonly [...any]> = ExtractNullableKeys<
   Spread<A>
 >
 
-export type SimpleHoc<P extends Record<string, unknown> = {}> = (
-  WrappedComponent: ComponentType<P>,
-) => ComponentType<P>
-
 export type InnerRef = ForwardedRef<any>
 
-export type CssCallback = (css: typeof config.css) => ReturnType<typeof css>
-
-export type Css = CssCallback | ReturnType<typeof config.css> | string
-
-export type isEmpty = null | undefined
+export type Css =
+  | ((css: typeof config.css) => ReturnType<typeof css>)
+  | ReturnType<typeof config.css>
+  | string
 
 export type Content = Parameters<typeof render>['0']
 
@@ -66,8 +61,6 @@ export type ContentDirection =
 export type ContentBoolean = boolean
 export type ContentSimpleValue = string | number
 
-export type Ref = HTMLElement
-
 export type AlignY =
   | ContentAlignY
   | ContentAlignY[]
@@ -94,17 +87,6 @@ export type Responsive =
   | Partial<Record<BreakpointKeys, number | string>>
 
 export type ExtendCss = Css | Css[] | Partial<Record<BreakpointKeys, Css>>
-
-export type ExtractProps<TComponentOrTProps> =
-  TComponentOrTProps extends ComponentType<infer TProps>
-    ? TProps
-    : TComponentOrTProps
-
-// export type HTMLTagProps<T extends HTMLTags> = JSX.IntrinsicElements[T];
-
-/** @deprecated Use VLComponent instead — forwardRef is no longer needed with React 19 */
-export type VLForwardedComponent<P extends Record<string, unknown> = {}> =
-  FC<P> & VLStatic
 
 export type VLComponent<P extends Record<string, any> = {}> = ((
   props: P & { ref?: any },


### PR DESCRIPTION
Five-lens performance audit (render hot paths, allocations, DOM thrashing, algorithmic complexity, dead code) on `@vitus-labs/elements`.

**Memoization / render correctness:**
- `Element` and `Wrapper` exported via `memo()`. VL statics attach to the memoized wrapper so rocketstyle/attrs detection still works.
- `Element` `mergedRef` ref-captures `externalRef` — inline parent ref callbacks no longer cause detach/attach cycles per render.
- `useOverlay` ref-captures `onOpen`/`onClose`. Inline arrow handlers (the common case) no longer trigger spurious `onClose`/`setUnblocked` cleanup callbacks while the overlay is still open. Correctness, not just perf.

**Allocation / spread reduction:**
- `Element` + `Wrapper` build-then-spread literals removed — keys inlined into JSX.
- `Wrapper` three separate `useMemo` calls collapsed into one.
- `useOverlay` `isNodeOrChild` curry replaced with stable predicates (no fresh closures per click).
- `positionMath` `[…].includes(type)` hoisted into module-level `Set` (was allocating per `computePosition` on throttled scroll/resize).
- `Overlay/component` drops `useMemo` over primitives + replaces `...(cond ? { … } : {})` with conditional property assignment.
- `Util` drops `useMemo` over a one-shot `join(' ')`.

**DOM / layout:**
- `useFocusTrap` swaps `for…of` over `NodeList` for index loop. MutationObserver refreshes coalesced via rAF.
- `Element/equalize` skips style write when sides are already equal AND non-zero — breaks a `ResizeObserver` loop without breaking jsdom tests.
- `useOverlay` click listener uses `document` instead of `window`.
- `Content/styled` deduplicates `equalColsCSS` / `typeContentCSS` into one `FLEX_1`.

**Dead code removed:**
- `types.ts`: `SimpleHoc`, `CssCallback`, `isEmpty`, `Ref`, `ExtractProps`, `VLForwardedComponent`.
- `Element/constants.ts`: `RESERVED_PROPS` and `keygen` (removed from HTML5 spec in 2017).
- `helpers/Wrapper/types.ts`: `Reference = unknown`.

**Deferred (separate PRs):**
- Move Overlay/Portal/Util to subpath exports — ~5KB gzip savings but breaking API change.
- `Content` memo custom equality with `extendCss ===` comparison — fragile, needs measurement.
- Scrollbar-gutter compensation on body scroll-lock — UX, not perf.

**Verification:** 2783 tests pass, lint + typecheck + build clean, all package size budgets within limits. Elements bundle: **12.67 KB / 15 KB budget**.