### PR TITLE
chore(release): eliminate Version PR close+reopen — add GitHub App auth

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,10 +28,43 @@ jobs:
         with:
           egress-policy: audit
 
+      # Resolve the token used to push the Version PR commit / publish tags.
+      # Order: GitHub App (preferred — no expiration, machine identity) →
+      # `RELEASE_PAT` (PAT fallback, expires) → `GITHUB_TOKEN` (last resort —
+      # WILL leave the Version PR with empty CI checks because GitHub
+      # suppresses workflows triggered by GITHUB_TOKEN events).
+      - name: Mint GitHub App token
+        id: app_token
+        if: ${{ vars.RELEASE_APP_ID != '' }}
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
+      - name: Resolve release token
+        id: token
+        env:
+          APP_TOKEN: ${{ steps.app_token.outputs.token }}
+          PAT_TOKEN: ${{ secrets.RELEASE_PAT }}
+        run: |
+          if [ -n "$APP_TOKEN" ]; then
+            echo "source=github-app" >> "$GITHUB_OUTPUT"
+            echo "token=$APP_TOKEN" >> "$GITHUB_OUTPUT"
+            echo "::notice::Release auth: GitHub App (preferred — checks will fire on the Version PR)."
+          elif [ -n "$PAT_TOKEN" ]; then
+            echo "source=pat" >> "$GITHUB_OUTPUT"
+            echo "token=$PAT_TOKEN" >> "$GITHUB_OUTPUT"
+            echo "::notice::Release auth: RELEASE_PAT — checks will fire on the Version PR."
+          else
+            echo "source=github-token" >> "$GITHUB_OUTPUT"
+            echo "token=${{ secrets.GITHUB_TOKEN }}" >> "$GITHUB_OUTPUT"
+            echo "::warning title=Version PR will have empty checks::No RELEASE_APP_ID/RELEASE_PAT configured — falling back to GITHUB_TOKEN. The Version PR will land with no CI runs and require a manual close+reopen to trigger them. See CONTRIBUTING.md → Releases → Setup."
+          fi
+
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.token.outputs.token }}
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -84,12 +117,11 @@ jobs:
           title: 'chore: version packages'
           commit: 'chore: version packages'
         env:
-          # Prefer a fine-grained PAT (`RELEASE_PAT`) when present so
-          # commits the action pushes to the Version PR's branch trigger
-          # downstream workflows (CI on the Version PR). Falls back to
-          # the default token, which works for everything except trigger
-          # propagation. See CONTRIBUTING.md → Releases → Setup.
-          GITHUB_TOKEN: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
+          # Token resolved in the `Resolve release token` step above.
+          # App / PAT pushes trigger downstream CI on the Version PR;
+          # bare GITHUB_TOKEN does not — that's the empty-checks footgun
+          # that historically required close+reopen on every release.
+          GITHUB_TOKEN: ${{ steps.token.outputs.token }}
           # Emit npm provenance attestations — the job already grants
           # `id-token: write` for OIDC trusted publishing; this makes npm
           # actually attach the attestation to every published package.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,11 +114,37 @@ CI's `Changeset` check fails any PR that touches `packages/**` without either a 
 4. CI runs on it; once green, mark it auto-merge (or wait for a maintainer).
 5. Merging triggers another `release.yml` run that publishes to npm via OIDC trusted publishing (no secrets needed) and creates a single umbrella `vX.Y.Z` GitHub Release for the suite. Per-package detail lives in each `packages/*/CHANGELOG.md`.
 
-### Setup (optional): `RELEASE_PAT` for self-triggering Version PRs
+### Setup: make Version PRs self-trigger CI
 
-By default, GitHub Actions workflows triggered by pushes from `GITHUB_TOKEN` (which `changesets/action` uses) **do not trigger downstream workflows** — a security feature to prevent infinite-loop scenarios. Without a workaround, Version PRs land with empty CI checks and require a manual close+reopen to start them.
+**Why this matters.** `changesets/action` pushes the Version PR commit using `GITHUB_TOKEN`. GitHub silently suppresses workflow runs for events triggered by `GITHUB_TOKEN` (recursion-prevention), so the Version PR lands with **empty CI checks**. Without a non-`GITHUB_TOKEN` identity, every release requires a manual close+reopen on the Version PR to fire CI.
 
-To make Version PRs self-trigger CI, create a fine-grained Personal Access Token and store it as a `RELEASE_PAT` repository secret:
+`release.yml` resolves auth in priority order: **GitHub App → `RELEASE_PAT` → `GITHUB_TOKEN`**. Configure one of the first two — the App is recommended for long-lived setups, the PAT is faster to set up.
+
+#### Option A — GitHub App (recommended)
+
+Best for: long-lived setups, no token expiration drama, machine identity in audit logs.
+
+1. **Create a GitHub App** under your account or org: github.com/settings/apps → *New GitHub App*
+   - Name: e.g. `vitus-labs-release-bot`
+   - Homepage URL: anything (required field — repo URL works)
+   - Webhooks: uncheck *Active*
+   - Repository permissions: Contents = read+write, Pull requests = read+write, Workflows = read+write
+   - Where can this be installed: *Only on this account*
+2. **Generate a private key**: scroll down on the App settings page → *Generate a private key*. Saves a `.pem` file.
+3. **Install the App on this repo**: from the App settings → *Install App* → select `vitus-labs/ui-system` (or your fork).
+4. **Add credentials to the repo**:
+   - Settings → Secrets and variables → Actions → **Variables** tab → *New repository variable*
+     - Name: `RELEASE_APP_ID`
+     - Value: the App's numeric ID (top of App settings page)
+   - Settings → Secrets and variables → Actions → **Secrets** tab → *New repository secret*
+     - Name: `RELEASE_APP_PRIVATE_KEY`
+     - Value: the entire contents of the `.pem` file (including the `-----BEGIN…END-----` lines)
+
+`release.yml`'s `Mint GitHub App token` step will detect `RELEASE_APP_ID` and use the App from then on. Pushes from the App's token DO trigger downstream workflows.
+
+#### Option B — Fine-grained PAT (faster but expires)
+
+Best for: getting unblocked in 2 minutes; accept rotating the token every 90 days.
 
 1. **Create the PAT**: github.com/settings/personal-access-tokens → *Generate new token (Fine-grained)*
    - Resource owner: `vitus-labs`
@@ -129,7 +155,7 @@ To make Version PRs self-trigger CI, create a fine-grained Personal Access Token
    - Name: `RELEASE_PAT`
    - Value: (paste the token)
 
-`release.yml` falls back to the default `GITHUB_TOKEN` when `RELEASE_PAT` is unset, so this is genuinely optional — without it, releases still work, you just close+reopen the Version PR once to kick CI.
+If neither is configured, `release.yml` falls back to `GITHUB_TOKEN` and logs a loud warning. Releases still work, you just close+reopen the Version PR once to kick CI — exactly what the App / PAT exist to avoid.
 
 ### Prerelease channel
 


### PR DESCRIPTION
## Why every release needed manual close+reopen

\`changesets/action\` pushes the Version PR commit using \`GITHUB_TOKEN\`. GitHub silently suppresses workflow runs for any event triggered by \`GITHUB_TOKEN\` (recursion-prevention). So the bot's push fires \`pull_request.synchronize\` on the Version PR, but **no workflow runs**. The PR lands with empty CI checks → maintainer has to close+reopen (which fires \`pull_request.reopened\` from a human actor) to kick CI.

Verified: \`gh api repos/.../actions/secrets\` returns \`total_count: 0\` — no \`RELEASE_PAT\` configured, so the workflow's existing PAT fallback was inactive. The historical fix (PR #211 wired up \`RELEASE_PAT\`) needed a secret that was never set.

## What this PR does

\`release.yml\` now resolves auth in priority order:

1. **GitHub App** (preferred, this PR adds it) — mints a short-lived token via \`actions/create-github-app-token@v2.2.2\` when \`vars.RELEASE_APP_ID\` is set (paired with \`secrets.RELEASE_APP_PRIVATE_KEY\`).
2. **\`RELEASE_PAT\`** — existing PAT fallback.
3. **\`GITHUB_TOKEN\`** — last-resort fallback, now emits a loud \`::warning\` annotation pointing at the setup docs, so the empty-checks footgun stops being silent.

The resolved token feeds both \`actions/checkout\` and \`changesets/action\`. Pushes from App / PAT tokens DO trigger downstream CI; only \`GITHUB_TOKEN\` is suppressed.

## Why App over PAT

| | App | PAT |
|---|---|---|
| Setup time | ~10 min | ~2 min |
| Expiration | none | 90 days default |
| Identity | machine, audit-log clean | personal account |
| Industry pattern | Vercel, Stripe, Next.js | older approach |

PAT is still wired up — pick whichever you can set up faster.

## Setup (one-time, choose A or B)

**A — GitHub App (recommended).** Create a GitHub App with Contents+Pull requests+Workflows write permissions, install on this repo, then add:
- Variable: \`RELEASE_APP_ID\` = the App's numeric ID
- Secret: \`RELEASE_APP_PRIVATE_KEY\` = full \`.pem\` contents

**B — Fine-grained PAT (faster).** Create a fine-grained PAT scoped to this repo with Contents+Pull requests+Workflows write, then add:
- Secret: \`RELEASE_PAT\`

Full step-by-step in \`CONTRIBUTING.md\` → *Setup: make Version PRs self-trigger CI*.

## After merge

The very next release will:
- Mint the App token (or PAT, or fall through to \`GITHUB_TOKEN\` with the new loud warning).
- Push the Version PR commit using that identity.
- CI checks fire automatically on the Version PR. No close+reopen.

If no secrets are configured yet, the workflow degrades to today's behavior plus a clearer warning — nothing breaks.

## Test plan

- [x] YAML structurally valid (15 steps in stable job)
- [x] Action SHA pinned to v2.2.2 (matches repo's ratchet policy)
- [x] No changeset needed (no \`packages/\` changes — verified by \`changeset-check.yml\` rules)
- [ ] After merge + secret setup, next \`chore: version packages\` PR has CI checks firing without manual intervention

🤖 Generated with [Claude Code](https://claude.com/claude-code)