### PR TITLE
test(core): pin exact 'state change crashes' repro for isEqual cycle

### DIFF
--- a/packages/core/src/__tests__/useStableValue.test.tsx
+++ b/packages/core/src/__tests__/useStableValue.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react'
+import { act, render } from '@testing-library/react'
 import { type ReactNode, useState } from 'react'
 import useStableValue from '~/useStableValue'
 
@@ -105,5 +105,49 @@ describe('useStableValue — React integration with cyclic data', () => {
     expect(() =>
       render(<Probe value={parent} onStable={() => undefined} />),
     ).not.toThrow()
+  })
+
+  // Exact-symptom regression: "page loads fine, crashes on state change".
+  // First render: ref.current === value (Object.is short-circuits → no
+  // isEqual descent). State change → second render with a referentially-
+  // fresh cyclic prop → ref.current !== value → isEqual descends → without
+  // cycle detection, infinite recursion → stack overflow.
+  // Pre-fix: this test crashed. Post-fix: passes.
+  it('survives a state-change re-render with cyclic props (the reported failure)', () => {
+    const makeCyclic = (): Record<string, unknown> => {
+      // Mimics a real $rocketstyle/$rocketstate-shaped prop: nested
+      // object with a back-reference somewhere in the graph.
+      const $rocketstate: Record<string, unknown> = { mode: 'default' }
+      const props: Record<string, unknown> = {
+        title: 'Header',
+        $rocketstate,
+      }
+      // The actual cycle: rocketstyle/attrs sometimes ends up with props
+      // that reference back to their own state container.
+      $rocketstate.owner = props
+      return props
+    }
+
+    let trigger: (() => void) | undefined
+    let renderCount = 0
+
+    const Header = () => {
+      const [showMore, setShowMore] = useState(false)
+      renderCount++
+      const props = makeCyclic()
+      // The actual broken path: hoc wraps props in useStableValue every render.
+      useStableValue({ ...props, showMore })
+      if (!trigger) trigger = () => setShowMore(true)
+      return null
+    }
+
+    expect(() => render(<Header />)).not.toThrow()
+    expect(renderCount).toBe(1)
+
+    // Trigger the state change that historically crashed. Wrap in act() so
+    // React flushes the update synchronously and our renderCount assertion
+    // sees the post-update value.
+    expect(() => act(() => trigger?.())).not.toThrow()
+    expect(renderCount).toBeGreaterThan(1)
   })
 })


### PR DESCRIPTION
Follow-up to #285. That PR fixed the cycle-detection crash; this PR pins the **exact symptom site** from the bug report so any future regression is caught immediately.

## The reported failure mode

> On first render the ref.current is the same value (Object.is short-circuits → returns true). On the SECOND render (after setShowMore), ref.current !== newProps, so it descends into isObjectEqual → hits the cycle → ∞.

The existing tests cover the underlying cycle-detection contract. This test covers the **observable React-app symptom**: page loads fine, crashes on the first state update.

## What the test does

1. Renders a component whose props include a cyclic graph (\`$rocketstate.owner = props\` — mimics the real rocketstyle/attrs shape).
2. First render: \`ref.current === value\` (initial \`useRef(value)\` makes them ref-equal). \`Object.is\` short-circuits in \`isEqual\`. No descent. Survives even pre-fix.
3. Triggers a \`setState\` wrapped in \`act()\` so React flushes synchronously.
4. Second render: \`ref.current\` (old) !== \`value\` (freshly built). \`isEqual\` must descend → hits the cycle.

**Pre-#285**: this crashes with \`RangeError: Maximum call stack size exceeded\`.
**Post-#285**: passes — cycle detector breaks the recursion.

## Why a separate PR

#285 was already merged before I caught that the existing tests covered the cycle math but not the exact \"first render fine, state change crashes\" path that consumers actually report. Splitting this out keeps that PR focused and lets this one ship as pure test coverage with no behavior change.

## Test plan

- [x] 203/203 core tests pass (1 new)
- [x] lint clean
- [x] No package changeset needed — pure test file under \`packages/core/src/__tests__/\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)