### PR TITLE
docs: center README logo header + fix vertical alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 <!-- LOGO:BEGIN -->
-<p align="left">
+<div align="center">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="./.github/assets/vitus-labs-lockup-dark.svg">
     <img alt="vitus·labs" src="./.github/assets/vitus-labs-lockup-light.svg" height="80">
   </picture>
-</p>
+</div>
 <!-- LOGO:END -->
 
 # UI System

--- a/packages/attrs/README.md
+++ b/packages/attrs/README.md
@@ -1,17 +1,23 @@
 <!-- LOGO:BEGIN -->
-<p align="left">
+<div align="center">
+<table align="center" border="0" cellpadding="0" cellspacing="0"><tr>
+<td valign="middle">
   <a href="https://github.com/vitus-labs/ui-system">
     <picture>
       <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/vitus-labs/ui-system/main/.github/assets/vitus-labs-mark-dark.svg">
-      <img alt="vitus·labs" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/.github/assets/vitus-labs-mark-light.svg" width="48" height="48">
+      <img alt="vitus·labs" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/.github/assets/vitus-labs-mark-light.svg" width="56" height="56">
     </picture>
   </a>
-  &nbsp;&nbsp;&nbsp;
+</td>
+<td width="20">&nbsp;</td>
+<td valign="middle">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/vitus-labs/ui-system/main/packages/attrs/assets/logo-dark.svg">
-    <img alt="@vitus-labs/attrs" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/packages/attrs/assets/logo-light.svg" width="96" height="96">
+    <img alt="@vitus-labs/attrs" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/packages/attrs/assets/logo-light.svg" width="72" height="72">
   </picture>
-</p>
+</td>
+</tr></table>
+</div>
 <!-- LOGO:END -->
 
 # @vitus-labs/attrs

--- a/packages/connector-emotion/README.md
+++ b/packages/connector-emotion/README.md
@@ -1,17 +1,23 @@
 <!-- LOGO:BEGIN -->
-<p align="left">
+<div align="center">
+<table align="center" border="0" cellpadding="0" cellspacing="0"><tr>
+<td valign="middle">
   <a href="https://github.com/vitus-labs/ui-system">
     <picture>
       <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/vitus-labs/ui-system/main/.github/assets/vitus-labs-mark-dark.svg">
-      <img alt="vitus·labs" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/.github/assets/vitus-labs-mark-light.svg" width="48" height="48">
+      <img alt="vitus·labs" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/.github/assets/vitus-labs-mark-light.svg" width="56" height="56">
     </picture>
   </a>
-  &nbsp;&nbsp;&nbsp;
+</td>
+<td width="20">&nbsp;</td>
+<td valign="middle">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/vitus-labs/ui-system/main/packages/connector-emotion/assets/logo-dark.svg">
-    <img alt="@vitus-labs/connector-emotion" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/packages/connector-emotion/assets/logo-light.svg" width="96" height="96">
+    <img alt="@vitus-labs/connector-emotion" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/packages/connector-emotion/assets/logo-light.svg" width="72" height="72">
   </picture>
-</p>
+</td>
+</tr></table>
+</div>
 <!-- LOGO:END -->
 
 # @vitus-labs/connector-emotion

--- a/packages/connector-native/README.md
+++ b/packages/connector-native/README.md
@@ -1,17 +1,23 @@
 <!-- LOGO:BEGIN -->
-<p align="left">
+<div align="center">
+<table align="center" border="0" cellpadding="0" cellspacing="0"><tr>
+<td valign="middle">
   <a href="https://github.com/vitus-labs/ui-system">
     <picture>
       <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/vitus-labs/ui-system/main/.github/assets/vitus-labs-mark-dark.svg">
-      <img alt="vitus·labs" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/.github/assets/vitus-labs-mark-light.svg" width="48" height="48">
+      <img alt="vitus·labs" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/.github/assets/vitus-labs-mark-light.svg" width="56" height="56">
     </picture>
   </a>
-  &nbsp;&nbsp;&nbsp;
+</td>
+<td width="20">&nbsp;</td>
+<td valign="middle">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/vitus-labs/ui-system/main/packages/connector-native/assets/logo-dark.svg">
-    <img alt="@vitus-labs/connector-native" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/packages/connector-native/assets/logo-light.svg" width="96" height="96">
+    <img alt="@vitus-labs/connector-native" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/packages/connector-native/assets/logo-light.svg" width="72" height="72">
   </picture>
-</p>
+</td>
+</tr></table>
+</div>
 <!-- LOGO:END -->
 
 # @vitus-labs/connector-native

--- a/packages/connector-styled-components/README.md
+++ b/packages/connector-styled-components/README.md
@@ -1,17 +1,23 @@
 <!-- LOGO:BEGIN -->
-<p align="left">
+<div align="center">
+<table align="center" border="0" cellpadding="0" cellspacing="0"><tr>
+<td valign="middle">
   <a href="https://github.com/vitus-labs/ui-system">
     <picture>
       <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/vitus-labs/ui-system/main/.github/assets/vitus-labs-mark-dark.svg">
-      <img alt="vitus·labs" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/.github/assets/vitus-labs-mark-light.svg" width="48" height="48">
+      <img alt="vitus·labs" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/.github/assets/vitus-labs-mark-light.svg" width="56" height="56">
     </picture>
   </a>
-  &nbsp;&nbsp;&nbsp;
+</td>
+<td width="20">&nbsp;</td>
+<td valign="middle">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/vitus-labs/ui-system/main/packages/connector-styled-components/assets/logo-dark.svg">
-    <img alt="@vitus-labs/connector-styled-components" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/packages/connector-styled-components/assets/logo-light.svg" width="96" height="96">
+    <img alt="@vitus-labs/connector-styled-components" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/packages/connector-styled-components/assets/logo-light.svg" width="72" height="72">
   </picture>
-</p>
+</td>
+</tr></table>
+</div>
 <!-- LOGO:END -->
 
 # @vitus-labs/connector-styled-components

--- a/packages/connector-styler/README.md
+++ b/packages/connector-styler/README.md
@@ -1,17 +1,23 @@
 <!-- LOGO:BEGIN -->
-<p align="left">
+<div align="center">
+<table align="center" border="0" cellpadding="0" cellspacing="0"><tr>
+<td valign="middle">
   <a href="https://github.com/vitus-labs/ui-system">
     <picture>
       <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/vitus-labs/ui-system/main/.github/assets/vitus-labs-mark-dark.svg">
-      <img alt="vitus·labs" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/.github/assets/vitus-labs-mark-light.svg" width="48" height="48">
+      <img alt="vitus·labs" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/.github/assets/vitus-labs-mark-light.svg" width="56" height="56">
     </picture>
   </a>
-  &nbsp;&nbsp;&nbsp;
+</td>
+<td width="20">&nbsp;</td>
+<td valign="middle">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/vitus-labs/ui-system/main/packages/connector-styler/assets/logo-dark.svg">
-    <img alt="@vitus-labs/connector-styler" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/packages/connector-styler/assets/logo-light.svg" width="96" height="96">
+    <img alt="@vitus-labs/connector-styler" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/packages/connector-styler/assets/logo-light.svg" width="72" height="72">
   </picture>
-</p>
+</td>
+</tr></table>
+</div>
 <!-- LOGO:END -->
 
 # @vitus-labs/connector-styler

--- a/packages/coolgrid/README.md
+++ b/packages/coolgrid/README.md
@@ -1,17 +1,23 @@
 <!-- LOGO:BEGIN -->
-<p align="left">
+<div align="center">
+<table align="center" border="0" cellpadding="0" cellspacing="0"><tr>
+<td valign="middle">
   <a href="https://github.com/vitus-labs/ui-system">
     <picture>
       <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/vitus-labs/ui-system/main/.github/assets/vitus-labs-mark-dark.svg">
-      <img alt="vitus·labs" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/.github/assets/vitus-labs-mark-light.svg" width="48" height="48">
+      <img alt="vitus·labs" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/.github/assets/vitus-labs-mark-light.svg" width="56" height="56">
     </picture>
   </a>
-  &nbsp;&nbsp;&nbsp;
+</td>
+<td width="20">&nbsp;</td>
+<td valign="middle">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/vitus-labs/ui-system/main/packages/coolgrid/assets/logo-dark.svg">
-    <img alt="@vitus-labs/coolgrid" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/packages/coolgrid/assets/logo-light.svg" width="96" height="96">
+    <img alt="@vitus-labs/coolgrid" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/packages/coolgrid/assets/logo-light.svg" width="72" height="72">
   </picture>
-</p>
+</td>
+</tr></table>
+</div>
 <!-- LOGO:END -->
 
 # @vitus-labs/coolgrid

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,17 +1,23 @@
 <!-- LOGO:BEGIN -->
-<p align="left">
+<div align="center">
+<table align="center" border="0" cellpadding="0" cellspacing="0"><tr>
+<td valign="middle">
   <a href="https://github.com/vitus-labs/ui-system">
     <picture>
       <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/vitus-labs/ui-system/main/.github/assets/vitus-labs-mark-dark.svg">
-      <img alt="vitus·labs" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/.github/assets/vitus-labs-mark-light.svg" width="48" height="48">
+      <img alt="vitus·labs" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/.github/assets/vitus-labs-mark-light.svg" width="56" height="56">
     </picture>
   </a>
-  &nbsp;&nbsp;&nbsp;
+</td>
+<td width="20">&nbsp;</td>
+<td valign="middle">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/vitus-labs/ui-system/main/packages/core/assets/logo-dark.svg">
-    <img alt="@vitus-labs/core" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/packages/core/assets/logo-light.svg" width="96" height="96">
+    <img alt="@vitus-labs/core" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/packages/core/assets/logo-light.svg" width="72" height="72">
   </picture>
-</p>
+</td>
+</tr></table>
+</div>
 <!-- LOGO:END -->
 
 # @vitus-labs/core

--- a/packages/elements/README.md
+++ b/packages/elements/README.md
@@ -1,17 +1,23 @@
 <!-- LOGO:BEGIN -->
-<p align="left">
+<div align="center">
+<table align="center" border="0" cellpadding="0" cellspacing="0"><tr>
+<td valign="middle">
   <a href="https://github.com/vitus-labs/ui-system">
     <picture>
       <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/vitus-labs/ui-system/main/.github/assets/vitus-labs-mark-dark.svg">
-      <img alt="vitus·labs" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/.github/assets/vitus-labs-mark-light.svg" width="48" height="48">
+      <img alt="vitus·labs" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/.github/assets/vitus-labs-mark-light.svg" width="56" height="56">
     </picture>
   </a>
-  &nbsp;&nbsp;&nbsp;
+</td>
+<td width="20">&nbsp;</td>
+<td valign="middle">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/vitus-labs/ui-system/main/packages/elements/assets/logo-dark.svg">
-    <img alt="@vitus-labs/elements" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/packages/elements/assets/logo-light.svg" width="96" height="96">
+    <img alt="@vitus-labs/elements" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/packages/elements/assets/logo-light.svg" width="72" height="72">
   </picture>
-</p>
+</td>
+</tr></table>
+</div>
 <!-- LOGO:END -->
 
 # @vitus-labs/elements

--- a/packages/hooks/README.md
+++ b/packages/hooks/README.md
@@ -1,17 +1,23 @@
 <!-- LOGO:BEGIN -->
-<p align="left">
+<div align="center">
+<table align="center" border="0" cellpadding="0" cellspacing="0"><tr>
+<td valign="middle">
   <a href="https://github.com/vitus-labs/ui-system">
     <picture>
       <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/vitus-labs/ui-system/main/.github/assets/vitus-labs-mark-dark.svg">
-      <img alt="vitus·labs" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/.github/assets/vitus-labs-mark-light.svg" width="48" height="48">
+      <img alt="vitus·labs" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/.github/assets/vitus-labs-mark-light.svg" width="56" height="56">
     </picture>
   </a>
-  &nbsp;&nbsp;&nbsp;
+</td>
+<td width="20">&nbsp;</td>
+<td valign="middle">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/vitus-labs/ui-system/main/packages/hooks/assets/logo-dark.svg">
-    <img alt="@vitus-labs/hooks" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/packages/hooks/assets/logo-light.svg" width="96" height="96">
+    <img alt="@vitus-labs/hooks" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/packages/hooks/assets/logo-light.svg" width="72" height="72">
   </picture>
-</p>
+</td>
+</tr></table>
+</div>
 <!-- LOGO:END -->
 
 # @vitus-labs/hooks

--- a/packages/kinetic-presets/README.md
+++ b/packages/kinetic-presets/README.md
@@ -1,17 +1,23 @@
 <!-- LOGO:BEGIN -->
-<p align="left">
+<div align="center">
+<table align="center" border="0" cellpadding="0" cellspacing="0"><tr>
+<td valign="middle">
   <a href="https://github.com/vitus-labs/ui-system">
     <picture>
       <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/vitus-labs/ui-system/main/.github/assets/vitus-labs-mark-dark.svg">
-      <img alt="vitus·labs" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/.github/assets/vitus-labs-mark-light.svg" width="48" height="48">
+      <img alt="vitus·labs" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/.github/assets/vitus-labs-mark-light.svg" width="56" height="56">
     </picture>
   </a>
-  &nbsp;&nbsp;&nbsp;
+</td>
+<td width="20">&nbsp;</td>
+<td valign="middle">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/vitus-labs/ui-system/main/packages/kinetic-presets/assets/logo-dark.svg">
-    <img alt="@vitus-labs/kinetic-presets" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/packages/kinetic-presets/assets/logo-light.svg" width="96" height="96">
+    <img alt="@vitus-labs/kinetic-presets" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/packages/kinetic-presets/assets/logo-light.svg" width="72" height="72">
   </picture>
-</p>
+</td>
+</tr></table>
+</div>
 <!-- LOGO:END -->
 
 # @vitus-labs/kinetic-presets

--- a/packages/kinetic/README.md
+++ b/packages/kinetic/README.md
@@ -1,17 +1,23 @@
 <!-- LOGO:BEGIN -->
-<p align="left">
+<div align="center">
+<table align="center" border="0" cellpadding="0" cellspacing="0"><tr>
+<td valign="middle">
   <a href="https://github.com/vitus-labs/ui-system">
     <picture>
       <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/vitus-labs/ui-system/main/.github/assets/vitus-labs-mark-dark.svg">
-      <img alt="vitus·labs" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/.github/assets/vitus-labs-mark-light.svg" width="48" height="48">
+      <img alt="vitus·labs" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/.github/assets/vitus-labs-mark-light.svg" width="56" height="56">
     </picture>
   </a>
-  &nbsp;&nbsp;&nbsp;
+</td>
+<td width="20">&nbsp;</td>
+<td valign="middle">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/vitus-labs/ui-system/main/packages/kinetic/assets/logo-dark.svg">
-    <img alt="@vitus-labs/kinetic" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/packages/kinetic/assets/logo-light.svg" width="96" height="96">
+    <img alt="@vitus-labs/kinetic" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/packages/kinetic/assets/logo-light.svg" width="72" height="72">
   </picture>
-</p>
+</td>
+</tr></table>
+</div>
 <!-- LOGO:END -->
 
 # @vitus-labs/kinetic

--- a/packages/rocketstories/README.md
+++ b/packages/rocketstories/README.md
@@ -1,17 +1,23 @@
 <!-- LOGO:BEGIN -->
-<p align="left">
+<div align="center">
+<table align="center" border="0" cellpadding="0" cellspacing="0"><tr>
+<td valign="middle">
   <a href="https://github.com/vitus-labs/ui-system">
     <picture>
       <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/vitus-labs/ui-system/main/.github/assets/vitus-labs-mark-dark.svg">
-      <img alt="vitus·labs" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/.github/assets/vitus-labs-mark-light.svg" width="48" height="48">
+      <img alt="vitus·labs" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/.github/assets/vitus-labs-mark-light.svg" width="56" height="56">
     </picture>
   </a>
-  &nbsp;&nbsp;&nbsp;
+</td>
+<td width="20">&nbsp;</td>
+<td valign="middle">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/vitus-labs/ui-system/main/packages/rocketstories/assets/logo-dark.svg">
-    <img alt="@vitus-labs/rocketstories" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/packages/rocketstories/assets/logo-light.svg" width="96" height="96">
+    <img alt="@vitus-labs/rocketstories" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/packages/rocketstories/assets/logo-light.svg" width="72" height="72">
   </picture>
-</p>
+</td>
+</tr></table>
+</div>
 <!-- LOGO:END -->
 
 # @vitus-labs/rocketstories

--- a/packages/rocketstyle/README.md
+++ b/packages/rocketstyle/README.md
@@ -1,17 +1,23 @@
 <!-- LOGO:BEGIN -->
-<p align="left">
+<div align="center">
+<table align="center" border="0" cellpadding="0" cellspacing="0"><tr>
+<td valign="middle">
   <a href="https://github.com/vitus-labs/ui-system">
     <picture>
       <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/vitus-labs/ui-system/main/.github/assets/vitus-labs-mark-dark.svg">
-      <img alt="vitus·labs" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/.github/assets/vitus-labs-mark-light.svg" width="48" height="48">
+      <img alt="vitus·labs" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/.github/assets/vitus-labs-mark-light.svg" width="56" height="56">
     </picture>
   </a>
-  &nbsp;&nbsp;&nbsp;
+</td>
+<td width="20">&nbsp;</td>
+<td valign="middle">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/vitus-labs/ui-system/main/packages/rocketstyle/assets/logo-dark.svg">
-    <img alt="@vitus-labs/rocketstyle" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/packages/rocketstyle/assets/logo-light.svg" width="96" height="96">
+    <img alt="@vitus-labs/rocketstyle" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/packages/rocketstyle/assets/logo-light.svg" width="72" height="72">
   </picture>
-</p>
+</td>
+</tr></table>
+</div>
 <!-- LOGO:END -->
 
 # @vitus-labs/rocketstyle

--- a/packages/styler/README.md
+++ b/packages/styler/README.md
@@ -1,17 +1,23 @@
 <!-- LOGO:BEGIN -->
-<p align="left">
+<div align="center">
+<table align="center" border="0" cellpadding="0" cellspacing="0"><tr>
+<td valign="middle">
   <a href="https://github.com/vitus-labs/ui-system">
     <picture>
       <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/vitus-labs/ui-system/main/.github/assets/vitus-labs-mark-dark.svg">
-      <img alt="vitus·labs" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/.github/assets/vitus-labs-mark-light.svg" width="48" height="48">
+      <img alt="vitus·labs" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/.github/assets/vitus-labs-mark-light.svg" width="56" height="56">
     </picture>
   </a>
-  &nbsp;&nbsp;&nbsp;
+</td>
+<td width="20">&nbsp;</td>
+<td valign="middle">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/vitus-labs/ui-system/main/packages/styler/assets/logo-dark.svg">
-    <img alt="@vitus-labs/styler" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/packages/styler/assets/logo-light.svg" width="96" height="96">
+    <img alt="@vitus-labs/styler" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/packages/styler/assets/logo-light.svg" width="72" height="72">
   </picture>
-</p>
+</td>
+</tr></table>
+</div>
 <!-- LOGO:END -->
 
 # @vitus-labs/styler

--- a/packages/unistyle/README.md
+++ b/packages/unistyle/README.md
@@ -1,17 +1,23 @@
 <!-- LOGO:BEGIN -->
-<p align="left">
+<div align="center">
+<table align="center" border="0" cellpadding="0" cellspacing="0"><tr>
+<td valign="middle">
   <a href="https://github.com/vitus-labs/ui-system">
     <picture>
       <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/vitus-labs/ui-system/main/.github/assets/vitus-labs-mark-dark.svg">
-      <img alt="vitus·labs" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/.github/assets/vitus-labs-mark-light.svg" width="48" height="48">
+      <img alt="vitus·labs" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/.github/assets/vitus-labs-mark-light.svg" width="56" height="56">
     </picture>
   </a>
-  &nbsp;&nbsp;&nbsp;
+</td>
+<td width="20">&nbsp;</td>
+<td valign="middle">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/vitus-labs/ui-system/main/packages/unistyle/assets/logo-dark.svg">
-    <img alt="@vitus-labs/unistyle" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/packages/unistyle/assets/logo-light.svg" width="96" height="96">
+    <img alt="@vitus-labs/unistyle" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/packages/unistyle/assets/logo-light.svg" width="72" height="72">
   </picture>
-</p>
+</td>
+</tr></table>
+</div>
 <!-- LOGO:END -->
 
 # @vitus-labs/unistyle

--- a/scripts/generate-package-logos.mjs
+++ b/scripts/generate-package-logos.mjs
@@ -141,7 +141,8 @@ const buildMark = (name, mode) => {
   const fg = fgFor(mode)
   const ac = accentFor(META[name].accent, mode)
   const body = glyphs[name](fg, ac)
-  return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" width="200" height="200" role="img" aria-label="${name === 'ui-system' ? 'vitus·labs' : '@vitus-labs/' + name}">${body}</svg>\n`
+  const label = name === 'ui-system' ? 'vitus·labs' : `@vitus-labs/${name}`
+  return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" width="200" height="200" role="img" aria-label="${label}">${body}</svg>\n`
 }
 
 // Lockup: umbrella mark + "vitus·labs" wordmark (Geist Mono).
@@ -165,30 +166,41 @@ const HEADER_END = '<!-- LOGO:END -->'
 // README always points at the latest committed art.
 const RAW = 'https://raw.githubusercontent.com/vitus-labs/ui-system/main'
 
+// `<div align="center">` + `<table align="center">` gives reliable
+// horizontal centering on both github.com and npmjs.com renderers.
+// `valign="middle"` on the cells guarantees vertical centering across the
+// two different-sized marks. `<picture>` + `prefers-color-scheme` swaps
+// the SVG variant based on the viewer's theme — readable in both modes.
 const pkgHeader = (pkg) => `${HEADER_BEGIN}
-<p align="left">
+<div align="center">
+<table align="center" border="0" cellpadding="0" cellspacing="0"><tr>
+<td valign="middle">
   <a href="https://github.com/vitus-labs/ui-system">
     <picture>
       <source media="(prefers-color-scheme: dark)" srcset="${RAW}/.github/assets/vitus-labs-mark-dark.svg">
-      <img alt="vitus·labs" src="${RAW}/.github/assets/vitus-labs-mark-light.svg" width="48" height="48">
+      <img alt="vitus·labs" src="${RAW}/.github/assets/vitus-labs-mark-light.svg" width="56" height="56">
     </picture>
   </a>
-  &nbsp;&nbsp;&nbsp;
+</td>
+<td width="20">&nbsp;</td>
+<td valign="middle">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="${RAW}/packages/${pkg}/assets/logo-dark.svg">
-    <img alt="@vitus-labs/${pkg}" src="${RAW}/packages/${pkg}/assets/logo-light.svg" width="96" height="96">
+    <img alt="@vitus-labs/${pkg}" src="${RAW}/packages/${pkg}/assets/logo-light.svg" width="72" height="72">
   </picture>
-</p>
+</td>
+</tr></table>
+</div>
 ${HEADER_END}
 `
 
 const rootHeader = () => `${HEADER_BEGIN}
-<p align="left">
+<div align="center">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="./.github/assets/vitus-labs-lockup-dark.svg">
     <img alt="vitus·labs" src="./.github/assets/vitus-labs-lockup-light.svg" height="80">
   </picture>
-</p>
+</div>
 ${HEADER_END}
 `
 


### PR DESCRIPTION
Follow-up to #293. The merged version left the header left-aligned and used a `<p>` tag with default baseline alignment, which made the differently-sized marks look vertically offset (visible on dark theme screenshots). This PR fixes both issues.

## What changed

- **Centered the header** via `<div align=\"center\">` (GitHub-canonical, also honored by npmjs.com).
- **Wrapped the two-mark block in a borderless `<table>` with `valign=\"middle\"`** on each cell — the standard GFM trick for image-row alignment across different image sizes.
- **Resized the package mark 96px → 72px** so the ratio with the 56px umbrella mark feels balanced (was a 2:1 size step, now ~1.3:1).
- **Theme switching unchanged** — `<picture>` + `prefers-color-scheme` already picks `logo-dark.svg` (light foreground) on dark theme and `logo-light.svg` (dark foreground) on light theme. Readable in both modes.

## Why a new PR

#293 was already squash-merged with the original layout before I pushed the alignment fix to the source branch. So this is a clean follow-up off current main, scoped to just the alignment + centering changes.

## Regeneration

Run `bun run logos` to regenerate every SVG + README header from the source script. Idempotent — re-running produces no diff if the script is unchanged.

## Test plan

- [x] `bun run lint` — clean
- [x] All 16 READMEs updated by the script
- [x] Spot-checked the rendered markup on a sample README (styler) — table wraps both marks, both cells use `valign=\"middle\"`, outer `<div align=\"center\">` centers horizontally
- [ ] After merge: confirm github.com renders the centered + vertically aligned header
- [ ] After next release: confirm npmjs.com package pages also render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)