### PR TITLE
docs: drop README logo table wrapper — borders were GitHub CSS, not attrs

### DIFF
--- a/packages/attrs/README.md
+++ b/packages/attrs/README.md
@@ -1,22 +1,16 @@
 <!-- LOGO:BEGIN -->
 <div align="center">
-<table align="center" border="0" cellpadding="0" cellspacing="0"><tr>
-<td valign="middle">
   <a href="https://github.com/vitus-labs/ui-system">
     <picture>
       <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/vitus-labs/ui-system/main/.github/assets/vitus-labs-mark-dark.svg">
-      <img alt="vitus·labs" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/.github/assets/vitus-labs-mark-light.svg" width="56" height="56">
+      <img alt="vitus·labs" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/.github/assets/vitus-labs-mark-light.svg" height="64">
     </picture>
   </a>
-</td>
-<td width="20">&nbsp;</td>
-<td valign="middle">
+  &nbsp;&nbsp;&nbsp;&nbsp;
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/vitus-labs/ui-system/main/packages/attrs/assets/logo-dark.svg">
-    <img alt="@vitus-labs/attrs" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/packages/attrs/assets/logo-light.svg" width="72" height="72">
+    <img alt="@vitus-labs/attrs" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/packages/attrs/assets/logo-light.svg" height="64">
   </picture>
-</td>
-</tr></table>
 </div>
 <!-- LOGO:END -->
 

--- a/packages/connector-emotion/README.md
+++ b/packages/connector-emotion/README.md
@@ -1,22 +1,16 @@
 <!-- LOGO:BEGIN -->
 <div align="center">
-<table align="center" border="0" cellpadding="0" cellspacing="0"><tr>
-<td valign="middle">
   <a href="https://github.com/vitus-labs/ui-system">
     <picture>
       <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/vitus-labs/ui-system/main/.github/assets/vitus-labs-mark-dark.svg">
-      <img alt="vitus·labs" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/.github/assets/vitus-labs-mark-light.svg" width="56" height="56">
+      <img alt="vitus·labs" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/.github/assets/vitus-labs-mark-light.svg" height="64">
     </picture>
   </a>
-</td>
-<td width="20">&nbsp;</td>
-<td valign="middle">
+  &nbsp;&nbsp;&nbsp;&nbsp;
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/vitus-labs/ui-system/main/packages/connector-emotion/assets/logo-dark.svg">
-    <img alt="@vitus-labs/connector-emotion" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/packages/connector-emotion/assets/logo-light.svg" width="72" height="72">
+    <img alt="@vitus-labs/connector-emotion" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/packages/connector-emotion/assets/logo-light.svg" height="64">
   </picture>
-</td>
-</tr></table>
 </div>
 <!-- LOGO:END -->
 

--- a/packages/connector-native/README.md
+++ b/packages/connector-native/README.md
@@ -1,22 +1,16 @@
 <!-- LOGO:BEGIN -->
 <div align="center">
-<table align="center" border="0" cellpadding="0" cellspacing="0"><tr>
-<td valign="middle">
   <a href="https://github.com/vitus-labs/ui-system">
     <picture>
       <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/vitus-labs/ui-system/main/.github/assets/vitus-labs-mark-dark.svg">
-      <img alt="vitus·labs" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/.github/assets/vitus-labs-mark-light.svg" width="56" height="56">
+      <img alt="vitus·labs" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/.github/assets/vitus-labs-mark-light.svg" height="64">
     </picture>
   </a>
-</td>
-<td width="20">&nbsp;</td>
-<td valign="middle">
+  &nbsp;&nbsp;&nbsp;&nbsp;
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/vitus-labs/ui-system/main/packages/connector-native/assets/logo-dark.svg">
-    <img alt="@vitus-labs/connector-native" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/packages/connector-native/assets/logo-light.svg" width="72" height="72">
+    <img alt="@vitus-labs/connector-native" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/packages/connector-native/assets/logo-light.svg" height="64">
   </picture>
-</td>
-</tr></table>
 </div>
 <!-- LOGO:END -->
 

--- a/packages/connector-styled-components/README.md
+++ b/packages/connector-styled-components/README.md
@@ -1,22 +1,16 @@
 <!-- LOGO:BEGIN -->
 <div align="center">
-<table align="center" border="0" cellpadding="0" cellspacing="0"><tr>
-<td valign="middle">
   <a href="https://github.com/vitus-labs/ui-system">
     <picture>
       <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/vitus-labs/ui-system/main/.github/assets/vitus-labs-mark-dark.svg">
-      <img alt="vitus·labs" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/.github/assets/vitus-labs-mark-light.svg" width="56" height="56">
+      <img alt="vitus·labs" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/.github/assets/vitus-labs-mark-light.svg" height="64">
     </picture>
   </a>
-</td>
-<td width="20">&nbsp;</td>
-<td valign="middle">
+  &nbsp;&nbsp;&nbsp;&nbsp;
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/vitus-labs/ui-system/main/packages/connector-styled-components/assets/logo-dark.svg">
-    <img alt="@vitus-labs/connector-styled-components" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/packages/connector-styled-components/assets/logo-light.svg" width="72" height="72">
+    <img alt="@vitus-labs/connector-styled-components" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/packages/connector-styled-components/assets/logo-light.svg" height="64">
   </picture>
-</td>
-</tr></table>
 </div>
 <!-- LOGO:END -->
 

--- a/packages/connector-styler/README.md
+++ b/packages/connector-styler/README.md
@@ -1,22 +1,16 @@
 <!-- LOGO:BEGIN -->
 <div align="center">
-<table align="center" border="0" cellpadding="0" cellspacing="0"><tr>
-<td valign="middle">
   <a href="https://github.com/vitus-labs/ui-system">
     <picture>
       <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/vitus-labs/ui-system/main/.github/assets/vitus-labs-mark-dark.svg">
-      <img alt="vitus·labs" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/.github/assets/vitus-labs-mark-light.svg" width="56" height="56">
+      <img alt="vitus·labs" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/.github/assets/vitus-labs-mark-light.svg" height="64">
     </picture>
   </a>
-</td>
-<td width="20">&nbsp;</td>
-<td valign="middle">
+  &nbsp;&nbsp;&nbsp;&nbsp;
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/vitus-labs/ui-system/main/packages/connector-styler/assets/logo-dark.svg">
-    <img alt="@vitus-labs/connector-styler" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/packages/connector-styler/assets/logo-light.svg" width="72" height="72">
+    <img alt="@vitus-labs/connector-styler" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/packages/connector-styler/assets/logo-light.svg" height="64">
   </picture>
-</td>
-</tr></table>
 </div>
 <!-- LOGO:END -->
 

--- a/packages/coolgrid/README.md
+++ b/packages/coolgrid/README.md
@@ -1,22 +1,16 @@
 <!-- LOGO:BEGIN -->
 <div align="center">
-<table align="center" border="0" cellpadding="0" cellspacing="0"><tr>
-<td valign="middle">
   <a href="https://github.com/vitus-labs/ui-system">
     <picture>
       <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/vitus-labs/ui-system/main/.github/assets/vitus-labs-mark-dark.svg">
-      <img alt="vitus·labs" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/.github/assets/vitus-labs-mark-light.svg" width="56" height="56">
+      <img alt="vitus·labs" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/.github/assets/vitus-labs-mark-light.svg" height="64">
     </picture>
   </a>
-</td>
-<td width="20">&nbsp;</td>
-<td valign="middle">
+  &nbsp;&nbsp;&nbsp;&nbsp;
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/vitus-labs/ui-system/main/packages/coolgrid/assets/logo-dark.svg">
-    <img alt="@vitus-labs/coolgrid" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/packages/coolgrid/assets/logo-light.svg" width="72" height="72">
+    <img alt="@vitus-labs/coolgrid" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/packages/coolgrid/assets/logo-light.svg" height="64">
   </picture>
-</td>
-</tr></table>
 </div>
 <!-- LOGO:END -->
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,22 +1,16 @@
 <!-- LOGO:BEGIN -->
 <div align="center">
-<table align="center" border="0" cellpadding="0" cellspacing="0"><tr>
-<td valign="middle">
   <a href="https://github.com/vitus-labs/ui-system">
     <picture>
       <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/vitus-labs/ui-system/main/.github/assets/vitus-labs-mark-dark.svg">
-      <img alt="vitus·labs" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/.github/assets/vitus-labs-mark-light.svg" width="56" height="56">
+      <img alt="vitus·labs" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/.github/assets/vitus-labs-mark-light.svg" height="64">
     </picture>
   </a>
-</td>
-<td width="20">&nbsp;</td>
-<td valign="middle">
+  &nbsp;&nbsp;&nbsp;&nbsp;
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/vitus-labs/ui-system/main/packages/core/assets/logo-dark.svg">
-    <img alt="@vitus-labs/core" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/packages/core/assets/logo-light.svg" width="72" height="72">
+    <img alt="@vitus-labs/core" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/packages/core/assets/logo-light.svg" height="64">
   </picture>
-</td>
-</tr></table>
 </div>
 <!-- LOGO:END -->
 

--- a/packages/elements/README.md
+++ b/packages/elements/README.md
@@ -1,22 +1,16 @@
 <!-- LOGO:BEGIN -->
 <div align="center">
-<table align="center" border="0" cellpadding="0" cellspacing="0"><tr>
-<td valign="middle">
   <a href="https://github.com/vitus-labs/ui-system">
     <picture>
       <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/vitus-labs/ui-system/main/.github/assets/vitus-labs-mark-dark.svg">
-      <img alt="vitus·labs" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/.github/assets/vitus-labs-mark-light.svg" width="56" height="56">
+      <img alt="vitus·labs" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/.github/assets/vitus-labs-mark-light.svg" height="64">
     </picture>
   </a>
-</td>
-<td width="20">&nbsp;</td>
-<td valign="middle">
+  &nbsp;&nbsp;&nbsp;&nbsp;
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/vitus-labs/ui-system/main/packages/elements/assets/logo-dark.svg">
-    <img alt="@vitus-labs/elements" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/packages/elements/assets/logo-light.svg" width="72" height="72">
+    <img alt="@vitus-labs/elements" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/packages/elements/assets/logo-light.svg" height="64">
   </picture>
-</td>
-</tr></table>
 </div>
 <!-- LOGO:END -->
 

--- a/packages/hooks/README.md
+++ b/packages/hooks/README.md
@@ -1,22 +1,16 @@
 <!-- LOGO:BEGIN -->
 <div align="center">
-<table align="center" border="0" cellpadding="0" cellspacing="0"><tr>
-<td valign="middle">
   <a href="https://github.com/vitus-labs/ui-system">
     <picture>
       <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/vitus-labs/ui-system/main/.github/assets/vitus-labs-mark-dark.svg">
-      <img alt="vitus·labs" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/.github/assets/vitus-labs-mark-light.svg" width="56" height="56">
+      <img alt="vitus·labs" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/.github/assets/vitus-labs-mark-light.svg" height="64">
     </picture>
   </a>
-</td>
-<td width="20">&nbsp;</td>
-<td valign="middle">
+  &nbsp;&nbsp;&nbsp;&nbsp;
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/vitus-labs/ui-system/main/packages/hooks/assets/logo-dark.svg">
-    <img alt="@vitus-labs/hooks" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/packages/hooks/assets/logo-light.svg" width="72" height="72">
+    <img alt="@vitus-labs/hooks" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/packages/hooks/assets/logo-light.svg" height="64">
   </picture>
-</td>
-</tr></table>
 </div>
 <!-- LOGO:END -->
 

--- a/packages/kinetic-presets/README.md
+++ b/packages/kinetic-presets/README.md
@@ -1,22 +1,16 @@
 <!-- LOGO:BEGIN -->
 <div align="center">
-<table align="center" border="0" cellpadding="0" cellspacing="0"><tr>
-<td valign="middle">
   <a href="https://github.com/vitus-labs/ui-system">
     <picture>
       <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/vitus-labs/ui-system/main/.github/assets/vitus-labs-mark-dark.svg">
-      <img alt="vitus·labs" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/.github/assets/vitus-labs-mark-light.svg" width="56" height="56">
+      <img alt="vitus·labs" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/.github/assets/vitus-labs-mark-light.svg" height="64">
     </picture>
   </a>
-</td>
-<td width="20">&nbsp;</td>
-<td valign="middle">
+  &nbsp;&nbsp;&nbsp;&nbsp;
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/vitus-labs/ui-system/main/packages/kinetic-presets/assets/logo-dark.svg">
-    <img alt="@vitus-labs/kinetic-presets" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/packages/kinetic-presets/assets/logo-light.svg" width="72" height="72">
+    <img alt="@vitus-labs/kinetic-presets" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/packages/kinetic-presets/assets/logo-light.svg" height="64">
   </picture>
-</td>
-</tr></table>
 </div>
 <!-- LOGO:END -->
 

--- a/packages/kinetic/README.md
+++ b/packages/kinetic/README.md
@@ -1,22 +1,16 @@
 <!-- LOGO:BEGIN -->
 <div align="center">
-<table align="center" border="0" cellpadding="0" cellspacing="0"><tr>
-<td valign="middle">
   <a href="https://github.com/vitus-labs/ui-system">
     <picture>
       <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/vitus-labs/ui-system/main/.github/assets/vitus-labs-mark-dark.svg">
-      <img alt="vitus·labs" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/.github/assets/vitus-labs-mark-light.svg" width="56" height="56">
+      <img alt="vitus·labs" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/.github/assets/vitus-labs-mark-light.svg" height="64">
     </picture>
   </a>
-</td>
-<td width="20">&nbsp;</td>
-<td valign="middle">
+  &nbsp;&nbsp;&nbsp;&nbsp;
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/vitus-labs/ui-system/main/packages/kinetic/assets/logo-dark.svg">
-    <img alt="@vitus-labs/kinetic" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/packages/kinetic/assets/logo-light.svg" width="72" height="72">
+    <img alt="@vitus-labs/kinetic" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/packages/kinetic/assets/logo-light.svg" height="64">
   </picture>
-</td>
-</tr></table>
 </div>
 <!-- LOGO:END -->
 

--- a/packages/rocketstories/README.md
+++ b/packages/rocketstories/README.md
@@ -1,22 +1,16 @@
 <!-- LOGO:BEGIN -->
 <div align="center">
-<table align="center" border="0" cellpadding="0" cellspacing="0"><tr>
-<td valign="middle">
   <a href="https://github.com/vitus-labs/ui-system">
     <picture>
       <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/vitus-labs/ui-system/main/.github/assets/vitus-labs-mark-dark.svg">
-      <img alt="vitus·labs" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/.github/assets/vitus-labs-mark-light.svg" width="56" height="56">
+      <img alt="vitus·labs" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/.github/assets/vitus-labs-mark-light.svg" height="64">
     </picture>
   </a>
-</td>
-<td width="20">&nbsp;</td>
-<td valign="middle">
+  &nbsp;&nbsp;&nbsp;&nbsp;
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/vitus-labs/ui-system/main/packages/rocketstories/assets/logo-dark.svg">
-    <img alt="@vitus-labs/rocketstories" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/packages/rocketstories/assets/logo-light.svg" width="72" height="72">
+    <img alt="@vitus-labs/rocketstories" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/packages/rocketstories/assets/logo-light.svg" height="64">
   </picture>
-</td>
-</tr></table>
 </div>
 <!-- LOGO:END -->
 

--- a/packages/rocketstyle/README.md
+++ b/packages/rocketstyle/README.md
@@ -1,22 +1,16 @@
 <!-- LOGO:BEGIN -->
 <div align="center">
-<table align="center" border="0" cellpadding="0" cellspacing="0"><tr>
-<td valign="middle">
   <a href="https://github.com/vitus-labs/ui-system">
     <picture>
       <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/vitus-labs/ui-system/main/.github/assets/vitus-labs-mark-dark.svg">
-      <img alt="vitus·labs" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/.github/assets/vitus-labs-mark-light.svg" width="56" height="56">
+      <img alt="vitus·labs" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/.github/assets/vitus-labs-mark-light.svg" height="64">
     </picture>
   </a>
-</td>
-<td width="20">&nbsp;</td>
-<td valign="middle">
+  &nbsp;&nbsp;&nbsp;&nbsp;
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/vitus-labs/ui-system/main/packages/rocketstyle/assets/logo-dark.svg">
-    <img alt="@vitus-labs/rocketstyle" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/packages/rocketstyle/assets/logo-light.svg" width="72" height="72">
+    <img alt="@vitus-labs/rocketstyle" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/packages/rocketstyle/assets/logo-light.svg" height="64">
   </picture>
-</td>
-</tr></table>
 </div>
 <!-- LOGO:END -->
 

--- a/packages/styler/README.md
+++ b/packages/styler/README.md
@@ -1,22 +1,16 @@
 <!-- LOGO:BEGIN -->
 <div align="center">
-<table align="center" border="0" cellpadding="0" cellspacing="0"><tr>
-<td valign="middle">
   <a href="https://github.com/vitus-labs/ui-system">
     <picture>
       <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/vitus-labs/ui-system/main/.github/assets/vitus-labs-mark-dark.svg">
-      <img alt="vitus·labs" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/.github/assets/vitus-labs-mark-light.svg" width="56" height="56">
+      <img alt="vitus·labs" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/.github/assets/vitus-labs-mark-light.svg" height="64">
     </picture>
   </a>
-</td>
-<td width="20">&nbsp;</td>
-<td valign="middle">
+  &nbsp;&nbsp;&nbsp;&nbsp;
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/vitus-labs/ui-system/main/packages/styler/assets/logo-dark.svg">
-    <img alt="@vitus-labs/styler" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/packages/styler/assets/logo-light.svg" width="72" height="72">
+    <img alt="@vitus-labs/styler" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/packages/styler/assets/logo-light.svg" height="64">
   </picture>
-</td>
-</tr></table>
 </div>
 <!-- LOGO:END -->
 

--- a/packages/unistyle/README.md
+++ b/packages/unistyle/README.md
@@ -1,22 +1,16 @@
 <!-- LOGO:BEGIN -->
 <div align="center">
-<table align="center" border="0" cellpadding="0" cellspacing="0"><tr>
-<td valign="middle">
   <a href="https://github.com/vitus-labs/ui-system">
     <picture>
       <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/vitus-labs/ui-system/main/.github/assets/vitus-labs-mark-dark.svg">
-      <img alt="vitus·labs" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/.github/assets/vitus-labs-mark-light.svg" width="56" height="56">
+      <img alt="vitus·labs" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/.github/assets/vitus-labs-mark-light.svg" height="64">
     </picture>
   </a>
-</td>
-<td width="20">&nbsp;</td>
-<td valign="middle">
+  &nbsp;&nbsp;&nbsp;&nbsp;
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/vitus-labs/ui-system/main/packages/unistyle/assets/logo-dark.svg">
-    <img alt="@vitus-labs/unistyle" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/packages/unistyle/assets/logo-light.svg" width="72" height="72">
+    <img alt="@vitus-labs/unistyle" src="https://raw.githubusercontent.com/vitus-labs/ui-system/main/packages/unistyle/assets/logo-light.svg" height="64">
   </picture>
-</td>
-</tr></table>
 </div>
 <!-- LOGO:END -->
 

--- a/scripts/generate-package-logos.mjs
+++ b/scripts/generate-package-logos.mjs
@@ -166,30 +166,24 @@ const HEADER_END = '<!-- LOGO:END -->'
 // README always points at the latest committed art.
 const RAW = 'https://raw.githubusercontent.com/vitus-labs/ui-system/main'
 
-// `<div align="center">` + `<table align="center">` gives reliable
-// horizontal centering on both github.com and npmjs.com renderers.
-// `valign="middle"` on the cells guarantees vertical centering across the
-// two different-sized marks. `<picture>` + `prefers-color-scheme` swaps
-// the SVG variant based on the viewer's theme — readable in both modes.
+// Two `<picture>` elements at the SAME height baseline-align naturally —
+// no table wrapper, so GitHub's default `<td>` border CSS can't kick in.
+// `<div align="center">` centers horizontally on both github.com and
+// npmjs.com. `<picture>` + `prefers-color-scheme` swaps the SVG variant
+// based on the viewer's theme — readable in both modes.
 const pkgHeader = (pkg) => `${HEADER_BEGIN}
 <div align="center">
-<table align="center" border="0" cellpadding="0" cellspacing="0"><tr>
-<td valign="middle">
   <a href="https://github.com/vitus-labs/ui-system">
     <picture>
       <source media="(prefers-color-scheme: dark)" srcset="${RAW}/.github/assets/vitus-labs-mark-dark.svg">
-      <img alt="vitus·labs" src="${RAW}/.github/assets/vitus-labs-mark-light.svg" width="56" height="56">
+      <img alt="vitus·labs" src="${RAW}/.github/assets/vitus-labs-mark-light.svg" height="64">
     </picture>
   </a>
-</td>
-<td width="20">&nbsp;</td>
-<td valign="middle">
+  &nbsp;&nbsp;&nbsp;&nbsp;
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="${RAW}/packages/${pkg}/assets/logo-dark.svg">
-    <img alt="@vitus-labs/${pkg}" src="${RAW}/packages/${pkg}/assets/logo-light.svg" width="72" height="72">
+    <img alt="@vitus-labs/${pkg}" src="${RAW}/packages/${pkg}/assets/logo-light.svg" height="64">
   </picture>
-</td>
-</tr></table>
 </div>
 ${HEADER_END}
 `


### PR DESCRIPTION
Follow-up to #294. The table wrapper centered + aligned the marks correctly, but rendered with visible cell dividers on GitHub.

## Why the borders appeared

\`border=\"0\"\` is an HTML attribute. GitHub's markdown CSS applies \`border: 1px solid var(--color-border-default)\` to every \`<td>\` and \`<th>\` inside rendered tables. CSS beats HTML attributes — there's no opt-out short of inline styles, and GitHub strips most inline \`style=\"\"\` declarations as part of its sanitizer.

## Fix

Drop the table entirely. Two `<picture>` elements at the **same height** (64px) inside `<div align=\"center\">` — they baseline-align naturally because matching heights means matching baselines. GitHub has no special CSS for `<picture>` / `<img>` inside a centered `<div>`, so the result is clean.

Before (PR #294):
```html
<div align=\"center\">
<table align=\"center\" border=\"0\" cellpadding=\"0\" cellspacing=\"0\"><tr>
  <td valign=\"middle\">[umbrella mark]</td>
  <td width=\"20\">&nbsp;</td>
  <td valign=\"middle\">[package mark]</td>
</tr></table>
</div>
```

After (this PR):
```html
<div align=\"center\">
  [umbrella mark height=\"64\"]
  &nbsp;&nbsp;&nbsp;&nbsp;
  [package mark height=\"64\"]
</div>
```

Theme switching unchanged — `<picture>` + `prefers-color-scheme` still swaps SVG variants based on viewer theme.

## Test plan

- [x] `bun run logos` — script re-runs idempotently
- [x] Spot-checked the rendered markup on multiple package READMEs
- [ ] After merge: confirm github.com renders the centered marks without borders

🤖 Generated with [Claude Code](https://claude.com/claude-code)