### PR TITLE
fix(release): single umbrella GitHub Release, not 15 per-package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,6 +116,14 @@ jobs:
           publish: bun run release
           title: 'chore: version packages'
           commit: 'chore: version packages'
+          # Disable the built-in per-package GitHub Releases — the
+          # "Create umbrella GitHub Release" step below ships a single
+          # `vX.Y.Z` release for the fixed-group suite instead. Without
+          # this, the action ALSO creates 15 per-package releases (it
+          # defaults to true when `publish` is set), cluttering the
+          # releases page and re-triggering the per-package iteration that
+          # was observed hanging mid-run on the 2.2.0 release.
+          createGithubReleases: false
         env:
           # Token resolved in the `Resolve release token` step above.
           # App / PAT pushes trigger downstream CI on the Version PR;


### PR DESCRIPTION
The 2.7.2 release created **16 GitHub Releases**: the intended single umbrella `v2.7.2` **plus 15 redundant per-package releases** (`@vitus-labs/core@2.7.2`, `@vitus-labs/styler@2.7.2`, …).

## Cause

`changesets/action` defaults `createGithubReleases: true` whenever `publish` is set. The workflow added a custom "Create umbrella GitHub Release" step but never disabled the built-in — so **both** ran. The umbrella step's own comment says it was meant to *replace* the per-package iteration ("observed hanging mid-run on the 2.2.0 release after npm publish had already succeeded"), but the built-in was left enabled, so that iteration still happens.

## Fix

One line: `createGithubReleases: false` on the changesets/action step. Now only the single `vX.Y.Z` umbrella release is created for the fixed-group suite — matching the documented intent and removing the hang risk.

Verified: YAML parses, `createGithubReleases: false` set, umbrella step still present, `publish` unchanged.

## Follow-up (not in this PR)

The 15 stale per-package releases already created for 2.7.2 are cosmetic. They can be bulk-deleted with:
```bash
for p in attrs connector-emotion connector-native connector-styled-components \
         connector-styler coolgrid core elements hooks kinetic kinetic-presets \
         rocketstories rocketstyle styler unistyle; do
  gh release delete "@vitus-labs/$p@2.7.2" --yes --cleanup-tag=false 2>/dev/null
done
```
(Left out of this PR since deleting releases is irreversible — your call.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)