### PR TITLE
perf(styler): cache SSR <style> element per resolved CSS — +9% ssr-dynamic

### DIFF
--- a/.changeset/perf-styler-ssr-style-cache.md
+++ b/.changeset/perf-styler-ssr-style-cache.md
@@ -1,0 +1,5 @@
+---
+'@vitus-labs/styler': patch
+---
+
+Faster SSR: cache the `<style precedence>` element per resolved CSS. The dynamic render path no longer re-allocates an identical `<style>` ReactElement on every render of the same component — it reuses the immutable element via a WeakMap keyed on the `sheet.prepare()` result. ~9% faster on `ssr-dynamic` and ~5% on `ssr-themed`; static and client paths unchanged.

--- a/.size-limit.json
+++ b/.size-limit.json
@@ -80,7 +80,7 @@
   {
     "name": "@vitus-labs/styler",
     "path": "packages/styler/lib/index.js",
-    "limit": "12.5 KB",
+    "limit": "13 KB",
     "gzip": true
   },
   {

--- a/packages/styler/src/styled.ts
+++ b/packages/styler/src/styled.ts
@@ -231,6 +231,19 @@ const createStyledComponent = (
   // stable per-component, so paying typeof per render was waste.
   const tagIsDOM = typeof tag === 'string'
 
+  // SSR: cache the `<style precedence>` ReactElement keyed by the object
+  // `sheet.prepare()` returns. prepare() returns the SAME `{className, rules}`
+  // reference for a repeated cssText (its own cache), so the WeakMap hits
+  // whenever the resolved CSS repeats — every render in `ssr-themed` (constant
+  // theme → one cssText), all-but-2 in `ssr-dynamic`. React elements are
+  // immutable and `<style precedence>` dedupes by href, so sharing the
+  // reference across renders is safe — same trick as the static path's
+  // `cachedStyleEl`. Saves one jsx('style') + its props-object allocation
+  // per render on hit.
+  const ssrStyleElCache: WeakMap<object, ReactElement> | null = IS_SERVER
+    ? new WeakMap()
+    : null
+
   // DYNAMIC PATH — two function bodies, chosen by IS_SERVER at module load.
   // The server variant drops `useRef` LRU + `useInsertionEffect` (no DOM to
   // inject into; React's server renderer no-ops the effect anyway), saving
@@ -243,7 +256,8 @@ const createStyledComponent = (
   // unconditionally; the choice between bodies happens at module load.
 
   const DynamicStyled: ComponentType<any> = IS_SERVER
-    ? ({ ref, ...rawProps }: Record<string, any>) => {
+    ? // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: hot-path SSR render — styleEl cache + prepare + buildProps inlined for perf
+      ({ ref, ...rawProps }: Record<string, any>) => {
         const theme = useTheme()
         if (theme !== EMPTY_THEME && rawProps.theme === undefined)
           rawProps.theme = theme
@@ -259,11 +273,19 @@ const createStyledComponent = (
           // dedupes <style precedence> emissions automatically.
           const prepared = sheet.prepare(cssText, boost)
           className = prepared.className
-          styleEl = jsx('style', {
-            href: prepared.className,
-            precedence: 'medium',
-            children: prepared.rules,
-          })
+          // biome-ignore lint/style/noNonNullAssertion: ssrStyleElCache is non-null whenever this SSR body runs (IS_SERVER)
+          const cache = ssrStyleElCache!
+          const cachedEl = cache.get(prepared)
+          if (cachedEl !== undefined) {
+            styleEl = cachedEl
+          } else {
+            styleEl = jsx('style', {
+              href: prepared.className,
+              precedence: 'medium',
+              children: prepared.rules,
+            })
+            cache.set(prepared, styleEl)
+          }
         }
 
         const finalTag = rawProps.as || tag


### PR DESCRIPTION
Round 5 of styler perf. The SSR dynamic render path allocated a fresh `jsx('style', {...})` element **every render**, even though for a given resolved cssText the `<style precedence>` element is identical (same href, same rules). The common SSR case — rendering the same component tree hundreds of times per request — re-allocated it needlessly.

## The fix

`sheet.prepare()` already returns the **same `{className, rules}` object reference** for a repeated cssText (its own cache). So this keys a `WeakMap` on that object and reuses the immutable `<style>` ReactElement — auto-GC, zero string hashing. React elements are immutable and `<style precedence>` dedupes by `href`, so sharing the reference across renders is safe — the static path already does exactly this (`cachedStyleEl`).

```diff
  const prepared = sheet.prepare(cssText, boost)
  className = prepared.className
- styleEl = jsx('style', { href: prepared.className, precedence: 'medium', children: prepared.rules })
+ const cachedEl = cache.get(prepared)
+ if (cachedEl !== undefined) styleEl = cachedEl
+ else { styleEl = jsx('style', {...}); cache.set(prepared, styleEl) }
```

## Local numbers (mean of 3 runs, ±2% local variance)

| Scenario | baseline | this PR | Δ |
|---|---|---|---|
| **ssr-dynamic** | 440.2 | **481.3** | **+9.3%** |
| **ssr-themed** | 364.2 | **384.3** | **+5.5%** |
| ssr-static | 714.8 | 713.1 | flat (path untouched) |
| csr-mount/update/many | — | within noise | client body byte-identical |

The win lands exactly on the two scenarios that hit the SSR dynamic path with repeated cssText. The cache is `IS_SERVER`-gated, so the static path and the entire client render body are untouched — **the CI same-runner bench is the arbiter** for the real deltas (local CSR numbers are untrustworthy).

## Size

Bumped styler budget 12.5 → 13 KB. The WeakMap + branch added ~80 B, landing *exactly* at the old 12.5 KB limit (0 margin). Comment-trimming to reclaim is off-limits — the repo learned that comment-only changes perturb the V8 JIT and regress CSR. 500 B headroom now.

## Test plan

- [x] 2827/2827 tests pass (incl. SSR hydration roundtrip + precedence tests — output must be identical)
- [x] lint clean
- [x] size within budget (12.5/13 KB)
- [ ] **CI same-runner bench** — the definitive verdict; confirm ssr-dynamic/themed gain holds and no CSR regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)